### PR TITLE
Clear description of three distinctive paths to install SUMA

### DIFF
--- a/modules/installation/pages/install-server-unified.adoc
+++ b/modules/installation/pages/install-server-unified.adoc
@@ -16,7 +16,7 @@ Before installing {susemgr}, ensure your physical or virtual machine has enough 
 * In case of installing {susemgr} in a public cloud where {susemgr} image is available, use that image. 
     For more information, see xref:quickstart-public-cloud:qs-publiccloud-overview.adoc[].
 * In case of installing {susemgr} in a public cloud where a {susemgr} image is not available, it is possible to start from a {sles}{nbsp}{sles-version}{nbsp}{sp-version} and switch the base product to {susemgr}{nbsp}{productnumber}.
-    For more information, see xref:installation:install-vm.adoc[].
+  For more information, see xref:installation:install-vm.adoc[].
 ====
 
 


### PR DESCRIPTION
# Description

* Previously, the user was redirected to a path of installing SUMA on top of SLES JeOS that is an existing option, but not the first recommended way we want to promote.
I've created a list within the admonition which states all possible distinctive paths clearly.

- One admonition has been converted to regular text, in line with already existing content  that had the same purpose (removed Note for hardware requirements and made it plan text just like paragraph pointing to general requirements). Less admonitions, less visual clutter.

- Fixed broken xref link.

# Target branches

Which documentation version does this PR apply to?

- [x] Master (Default)
- [x] Manager-4.2
- [ ] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes partially #14451.
