### PR TITLE
fix for 2021.08 url

### DIFF
--- a/branding/supplemental-ui/uyuni/uyuni-webui/partials/header-content.hbs
+++ b/branding/supplemental-ui/uyuni/uyuni-webui/partials/header-content.hbs
@@ -2,7 +2,7 @@
     <nav class="navbar">
         <div class="navbar-brand">
             <div class="navbar-item">
-                <a class=" navbar-logo" href="https://www.uyuni-project.org/uyuni-docs/uyuni/index.html"><img
+                <a class=" navbar-logo" href="https://www.uyuni-project.org/uyuni-docs/index.html"><img
                         class="logo" src="{{uiRootPath}}/img/uyuni_logo.png"/></a>
                 <!-- <a href="https://opensource.suse.com/doc-susemanager/index.html">Uyuni Project</a>
         <span class="separator">//</span>


### PR DESCRIPTION
# Description

Corrects the logo url path after translation directory changes.

# Target branches

Which documentation version does this PR apply to?

- [ ] Master (Default)
- [ ] Manager-4.2
- [ ] Manager-4.1
- [ ] Manager-4.0
- [x] uyuni-2021.08 

# Links

Fixes #<insert issue or PR link, if any>
