### PR TITLE
backport41 port 443: tftpsync (#1215)

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -6,6 +6,12 @@
 
   * Fixed unpublished patches note in the server update chapter of the
     Upgrade Guide
+- Documented low on disc space warnings in the Managing Disk Space chapter in
+  Administration Guide
+- In the ports section of the Installation Guide, mention "tftpsync"
+  explicitly for port 443 (bsc#1190665)
+- In server upgrade procedure in the Upgrade Guide add 'zypper ref' step
+  to refresh repositories reliably.
 - Update 'effective_cache_size' section of the Salt Guide
   (bsc#1191274)
 - Documented new filter in the Content Lifecycle Management chapter of

--- a/modules/installation/pages/ports.adoc
+++ b/modules/installation/pages/ports.adoc
@@ -22,13 +22,13 @@ Opening these ports allows external network traffic to access the {productname} 
 [cols="1,1,1,1", options="header"]
 .External Port Requirements for {productname} Server
 |===
-| Port number | Protocol | Used By | Notes
+| Port number | Protocol | Used By | Notes
 | 22          |          |         | Required for ssh-push and ssh-push-tunnel contact methods.
-| 67          | TCP/UDP  | DHCP    | Required only if clients are requesting IP addresses from the server.
+| 67          | TCP/UDP  | DHCP    | Required only if clients are requesting IP addresses from the server.
 | 69          | TCP/UDP  | TFTP    | Required if server is used as a PXE server for automated client installation.
 | 80          | TCP      | HTTP    | Required temporarily for some bootstrap repositories and automated installations.
 Port 80 is not used to serve the {webui}.
-| 443         | TCP      | HTTPS   | {webui}, client, and proxy requests.
+| 443         | TCP      | HTTPS   | {webui}, client, and server and proxy (``tftpsync``) requests.
 | 4505        |  TCP     | salt    | Required to accept communication requests from clients.
 The client initiates the connection, and it stays open to receive commands from the Salt master.
 | 4506        | TCP      | salt    | Required to accept communication requests from clients.
@@ -105,7 +105,7 @@ Opening these ports allows external network traffic to access the {productname} 
 Clients connected to the proxy initiate check in on the server and hop through to clients.
 | 67          | TCP/UDP  | DHCP    | Required only if clients are requesting IP addresses from the server.
 | 69          | TCP/UDP  | TFTP    | Required if the server is used as a PXE server for automated client installation.
-| 443         | TCP      | HTTPS   | {webui}, client, and proxy requests.
+| 443         | TCP      | HTTPS   | {webui}, client, and server and proxy (``tftpsync``) requests.
 | 4505        | TCP      | salt    | Required to accept communication requests from clients.
 The client initiates the connection, and it stays open to receive commands from the Salt master.
 | 4506        | TCP      | salt    | Required to accept communication requests from clients.


### PR DESCRIPTION
* port 443: mention tftfsync
https://bugzilla.suse.com/show_bug.cgi?id=1190665
https://github.com/SUSE/spacewalk/issues/15915

# Description

Short summary of why you created this PR

# Target branches

Which documentation version does this PR apply to?

- [ ] Master (Default)
- [ ] Manager-4.2
- [x] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes #<insert issue or PR link, if any>
