### PR TITLE
Added missing step for RH clients

### DIFF
--- a/modules/client-configuration/pages/clients-rh-cdn.adoc
+++ b/modules/client-configuration/pages/clients-rh-cdn.adoc
@@ -78,6 +78,12 @@ subscription-manager register
 ----
 +
 Enter your {redhat} Portal username and password when prompted.
+. Run command:
++
+----
+subscription-manager activate
+----
++
 . Copy your entitlement certificate and key from the client system, to a location that the {productname} Server can access:
 +
 ----


### PR DESCRIPTION
# Description

Procedure was inaccurate without the additional step.

# Target branches

Which documentation version does this PR apply to?

- [x] Master (Default)
- [x] Manager-4.2
- [x] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes https://github.com/SUSE/spacewalk/issues/15814