### PR TITLE
Backport42 - Added missing command.

### DIFF
--- a/modules/client-configuration/pages/clients-rh-cdn.adoc
+++ b/modules/client-configuration/pages/clients-rh-cdn.adoc
@@ -78,6 +78,12 @@ subscription-manager register
 ----
 +
 Enter your {redhat} Portal username and password when prompted.
+. Run command:
++
+----
+subscription-manager activate
+----
++
 . Copy your entitlement certificate and key from the client system, to a location that the {productname} Server can access:
 +
 ----


### PR DESCRIPTION
# Description

Existing procedure was incomplete without the additional step.

# Target branches

Which documentation version does this PR apply to?

- [x] Master (Default) https://github.com/uyuni-project/uyuni-docs/pull/1235
- [x] Manager-4.2
- [x] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes https://github.com/SUSE/spacewalk/issues/15814