### PR TITLE
backport42 - Fixed broken links in the installation guide.

### DIFF
--- a/modules/installation/pages/general-requirements.adoc
+++ b/modules/installation/pages/general-requirements.adoc
@@ -42,12 +42,14 @@ Create an account with {scc} before installation of {sles} and {productname}.
 
 Depending on your organization's setup, you might also need to activate your subscription, using the btn:[Activate Subscriptions] menu.
 
+For more information about using SCC, see https://scc.suse.com/docs/help.
+
 
 
 [[install.media]]
-== Obtain the Unified Installer
+== Unified Installer
 
-{susemgr} Server and Proxy can be installed with the {sle} Unified Installer.
+{susemgr} Server and Proxy are installed with the {sle} Unified Installer.
 
 //REMARK What about Uyuni?
 ifeval::[{suma-content} == true]
@@ -56,7 +58,7 @@ You do not require a separate code for SLES{nbsp}{sles-version} {sp-version}.
 endif::[]
 
 If not already done, download the {sle} Unified Installer from https://download.suse.com/index.jsp.
-Direct link to {sle} {sles-version} {sp-version}, required to install SUSE Manager: https://download.suse.com/index.jsp?product_id=&search=Search&families=22609&version=68287.
+
 For a later version or a different architecture, such as {ibmz}, select the respective item.
 With the Unified Installer you can install many SLE-based base products such as SLES, SLES for SAP Applications, or {susemgr}.
 

--- a/modules/installation/pages/install-proxy-unified.adoc
+++ b/modules/installation/pages/install-proxy-unified.adoc
@@ -3,7 +3,7 @@
 
 {susemgr} Proxy is a {suse} product within the {sle} product family.
 This section describes how to install {susemgr} Proxy from {sle} installation media.
-It assumes you have already registered the {susemgr} Proxy product with the {scc} and have a registration code.
+It assumes you already have valid organization credentials with {scc} and have obtained a registration code for your {susemgr} Proxy.
 
 For information on registering with {scc}, retrieving your organization credentials from {scc}, or obtaining installation media, see xref:general-requirements.adoc[].
 


### PR DESCRIPTION
# Description

Overdue backporting to 4.2 branch of the changes already implemented in master branch.
- Removed instruction for obtaining UI, 
- Removed obsolete download link.
- Extended note with recommendation to always use UI, except when SUMA image is not available (cloud only).

# Target branches

Which documentation version does this PR apply to?

- [x] Master (Default)  https://github.com/uyuni-project/uyuni-docs/pull/931
- [x] Manager-4.2
- [ ] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes https://github.com/SUSE/spacewalk/issues/15977
