### PR TITLE
channel label for redhat8 products

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -6,6 +6,7 @@
 
 - In the SLS State for Keeping Clients Updated of the Cookbook, add support
   for Ubuntu/Debian/RHEL7 flags for reboot required
+- Fix base channel label for Red Hat 8 products in the Client Configuration Guide
 - In the Client Configuration Guide, move the information about required
   Python to the section about the Web UI registration procedure.
 - Warn about building ARM images on aarch64 architecture in the Administration

--- a/modules/client-configuration/pages/clients-rh-cdn.adoc
+++ b/modules/client-configuration/pages/clients-rh-cdn.adoc
@@ -269,7 +269,7 @@ The channels you need for this procedure are:
 | res7-suse-manager-tools-x86_64
 
 | {redhat} 8
-| rhel-x86_64-server-8
+| rhel8-pool-x86_64
 | -
 | res8-suse-manager-tools-x86_64
 

--- a/modules/client-configuration/pages/clients-rh-rhui.adoc
+++ b/modules/client-configuration/pages/clients-rh-rhui.adoc
@@ -255,7 +255,7 @@ The channels you need for this procedure are:
 | res7-suse-manager-tools-x86_64
 
 | {redhat} 8
-| rhel-x86_64-server-8
+| rhel8-pool-x86_64
 | -
 | res8-suse-manager-tools-x86_64
 

--- a/modules/client-configuration/pages/clients-sleses.adoc
+++ b/modules/client-configuration/pages/clients-sleses.adoc
@@ -136,7 +136,7 @@ The channels you need for this procedure are:
 | res7-suse-manager-tools-x86_64
 
 | {es} 8
-| rhel-x86_64-server-8
+| rhel8-pool-x86_64
 | -
 | res8-suse-manager-tools-x86_64
 


### PR DESCRIPTION
# Description

https://github.com/uyuni-project/uyuni-docs/pull/1265
fix channel label for redhat8 products.

# Target branches

Which documentation version does this PR apply to?

- [ ] Master (Default)
- [x] Manager-4.2
- [ ] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes #<insert issue or PR link, if any>
