### PR TITLE
backport 4.2: docker build host OS warning (#1557)

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -5,6 +5,8 @@
 # For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Changelog_section_.28.25changelog.29
 
 - Add the details about using Salt Bundle as optional with 4.2
+- In Administration Guide, Create Build Host section (docker), added warning
+  about OS verstion requirement.
 - In Administration Guide, documented that monitoring tools are available in
   SUSE Linux Enterprise 12 and 15 and openSUSE Leap 15, but Grafana is not
   available on Proxy (bsc#1191143)

--- a/modules/administration/pages/image-management.adoc
+++ b/modules/administration/pages/image-management.adoc
@@ -59,8 +59,23 @@ To build images with {productname}, you need to create and configure a build hos
 Container build hosts are Salt clients running {sle} 12 or later.
 This section guides you through the initial configuration for a build host.
 
-From the {productname} {webui}, perform these steps to configure a build host:
 
+
+[IMPORTANT]
+====
+The operating system on the build host must match the operating system on the targeted image.
+
+For example, build {sles}{nbsp}15 based images on a build host running {sles}{nbsp}15 (SP2 or later) OS version.
+Build {sles}{nbsp}12 based images on a build host running {sles}{nbsp}12 SP4 or {sles}{nbsp}12 SP3 OS version.
+
+Cross-architecture builds are unsupported.
+////
+2022-05-12, ke: at least for now, according to feedback, this is unsupported:
+For example, you must build Raspberry Pi {sles}{nbsp}15 SP3 images on a Raspberry Pi (aarch64 architecture) build host running {sles}{nbsp}15 SP3.
+////
+====
+
+From the {productname} {webui}, perform these steps to configure a build host:
 
 . Select a Salt client to be designated as a build host from the menu:Systems[Overview] page.
 . From the [guimenu]``System Details`` page of the selected client assign the containers modules.


### PR DESCRIPTION
# Description

* docker build host OS warning
https://github.com/SUSE/spacewalk/issues/17620
Co-authored-by: Dominik Gedon <dev@gedon.org>
* at least for now, ARM is unsupported
* cross-arch is unsupported.

# Target branches

Which documentation version does this PR apply to?

- [ ] Master (Default)
- [x] Manager-4.2
- [ ] Manager-4.1
- [ ] Manager-4.0

# Links

Fixes #<insert issue or PR link, if any>
