### PR TITLE
Backport 4.2: Ccg autoinst secureboot #18937 keichwa (#1760)

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -4,6 +4,8 @@
 # - Fixed error in Bat section of Upgrade Guide (bsc#1234567)
 # For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Changelog_section_.28.25changelog.29
 
+- Documented how pxeboot works with Secure Boot enabled in Client
+  Configuration Guide.
 - Added SLE Micro 5.2 and 5.3 as available as a technology preview in Client
   Configuration Guide, and the IBM Z architecture for 5.1, 5.2, and 5.3
 - Documented mandatory channels in the Disconnected Setup chapter of the

--- a/modules/client-configuration/pages/autoinst-pxeboot.adoc
+++ b/modules/client-configuration/pages/autoinst-pxeboot.adoc
@@ -83,6 +83,12 @@ Alternatively, if your DHCP server is registered at {productname}, you can confi
 . Click btn:[Save Formula] to save your configuration.
 . Apply the highstate.
 
+
+[NOTE]
+====
+If you use Secure Boot, type [path]``grub/shim.efi instead of [path]``grub/grub.efi`` in the [guimenu]``Filename EFI`` field.
+====
+
 This sets up a global PXE server for all the hosts, you can also have per-host settings.
 For more information about the DHCPd formula, see xref:salt:formula-dhcpd.adoc[DHCPd Formula].
 


### PR DESCRIPTION
# Description

* add note about secure boot and shim.efi
* https://github.com/SUSE/spacewalk/issues/18937
https://github.com/uyuni-project/uyuni/issues/5851

Short summary of why you created this PR

# Target branches

Which documentation version does this PR apply to?

- [ ] Master (Default)
- [ ] Manager-4.3
- [x] Manager-4.2

# Links

Fixes #<insert issue or PR link, if any>
