### PR TITLE
Fixing the mixup in the rollback PR

### DIFF
--- a/modules/specialized-guides/pages/large-deployments/tuning.adoc
+++ b/modules/specialized-guides/pages/large-deployments/tuning.adoc
@@ -126,8 +126,8 @@ This section contains information about the available parameters.
                          Proxies, {webui}, and XMLRPC API clients each consume one.
                          Requests exceeding the parameter will be queued and might result in timeouts.
 | Tune when            | xref:user-count[User count] and proxy count increase significantly and this line appears in [path]``/var/log/apache2/error_log``: [systemitem]``[...] [mpm_prefork:error] [pid ...] AH00161: server reached MaxRequestWorkers setting, consider raising the MaxRequestWorkers setting``.
-| Value default        | 200
-| Value recommendation | 200-500
+| Value default        | 150
+| Value recommendation | 150-500
 | Location             | [path]``/etc/apache2/server-tuning.conf``, in the `prefork.c` section
 | Example              | `MaxClients = 200`
 | After changing       | Immediately change xref:server-limit[`ServerLimit`] and check xref:max-threads[`maxThreads`] for possible adjustment.
@@ -248,8 +248,8 @@ This section contains information about the available parameters.
 |===
 | Description          | The maximum number of minions concurrently executing a scheduled action.
 | Tune when            | xref:client-count[Client count] reaches several thousands and actions are not executed quickly enough.
-| Value default        | 150
-| Value recommendation | 100-500
+| Value default        | 200
+| Value recommendation | 200-500
 | Location             | [path]``/etc/rhn/rhn.conf``
 | Example              | `java.salt_batch_size = 300`
 | After changing       | Check xref:memory-usage[memory usage].


### PR DESCRIPTION
# Description

Timeline of the issue:
1. Initially, PR https://github.com/uyuni-project/uyuni-docs/pull/2197 was merged prematurely and did not need to go to 4.3.6 before the actual code was merged as well.
2. When this was discovered, a rollback PR was created: https://github.com/uyuni-project/uyuni-docs/pull/2216 - and merged
3. Closer inspection showed that the change in the rollback PR was not made **at the right place** (i.e. the correct lines, even though the values were correct ).
4. This PR resets the values in the file  `large-deployments/tuning.adoc` to the initial content (i.e. same values as in 4.3.5)

# Target branches

Which documentation version does this PR apply to?

- [x] Master (Default)
- [ ] Manager-4.3
- [ ] Manager-4.2



# Links

Fixes #<insert issue or PR link, if any>
