### PR TITLE
Product name change preparations - Use parameter wherever possible (part 7)

### DIFF
--- a/modules/administration/pages/monitoring.adoc
+++ b/modules/administration/pages/monitoring.adoc
@@ -575,7 +575,7 @@ For more information about configuring all available options, see xref:specializ
 By default, {productname} does not provide any certificates for securing monitoring configuration.
 For providing security, you can generate or import custom certificates, self-signed or signed by a third party certificate authority (CA).
 
-This section demonstrates how to generate client/server certificates for Prometheus and Node exporter minions self-signed with SUSE Manager CA.
+This section demonstrates how to generate client/server certificates for Prometheus and Node exporter minions self-signed with {productname} CA.
 
 .Procedure: Creating server/client TLS certificate
 

--- a/modules/quickstart/pages/legacy-installation/quickstart-install-uyuni-proxy.adoc
+++ b/modules/quickstart/pages/legacy-installation/quickstart-install-uyuni-proxy.adoc
@@ -211,7 +211,7 @@ Use this option if you want to reuse a SSH key that was used for SSH-Push Salt c
 Create and Populate Configuration Channel rhn_proxy_config_1000010001?::
 Accept default ``Y``.
 
-SUSE Manager Username::
+{productname} Username::
 Use same user name and password as on the {productname} server.
 
 If parts are missing, such as CA key and public certificate, the script prints commands that you must execute to integrate the needed files.


### PR DESCRIPTION
# Description

As part of the preparations for the product name change from SUSE Manager to SUSE Multi-Linux Manager, the use of parameter {productname} has been extended to all the instances in the documentation where we still had plain text instead.

This is Part 7 of the effort: any other plain text references to the prouct, instead of the parameter.
 
Some minor regular clean-up and normalization is done along the way too.


# Target branches

Parametarization will be implemented for both master and manager-5.0 branches, but the product name change will only happen for 5.1 branch (i.e. master) 

- master 
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/3529

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/25782