### PR TITLE
4.3 - Removed non-existent icon reference, old comments, etc.

### DIFF
--- a/modules/reference/pages/configuration/config-channels.adoc
+++ b/modules/reference/pages/configuration/config-channels.adoc
@@ -77,10 +77,12 @@ To import files from other configuration channels, including any locally managed
 Then click btn:[Import Configuration Files].
 +
 
-NOTE: A sandbox icon (image:spacewalk-icon-sandbox.svg[]) indicates that the listed file is currently located in a local sandbox.
+[NOTE]
+==== 
+A sandbox icon (image:spacewalk-icon-sandbox.svg[]) indicates that the listed file is currently located in a local sandbox.
 Files in a system's sandbox are considered experimental and could be unstable.
 Use caution when selecting them for a central configuration channel.
-+
+====
 
 
 Create File:::

--- a/modules/reference/pages/configuration/config-overview.adoc
+++ b/modules/reference/pages/configuration/config-overview.adoc
@@ -48,23 +48,11 @@ Filename	Configuration Channel	Modified
 +
 Click the name of a file to see its [guimenu]``Details`` page.
 Click the channel name to see its [guimenu]``Channel Details`` page.
-+
-////
-File types that can appear here:
-* image:spacewalk-icon-software-channels.svg[Spacewalk Icon Software Channels,scaledwidth=1.6em] -- Centrally managed configuration file provided by a global configuration channel.
-* image:fa-desktop.svg[FA Desktop,scaledwidth=1.6em] -- [Management] Locally managed configuration file, maybe overriding a centrally managed file.
-* image:spacewalk-icon-sandbox.svg[Spacewalk Icon Sandbox,scaledwidth=1.6em] -- [Management] Sandbox configuration file.
-////
 
 Recently Scheduled Configuration File Deployments::
 Each scheduled action is listed along with the status of the action.
 Any scheduled configuration task, from enabling configuration management on a system to deploying a specific configuration file, is displayed.
 Here you can quickly assess if all tasks have been successfully carried out or fix any problems.
-+
-////
-System	Files to be Deployed	Scheduled By	Scheduled For	Status
-d104.suse.de 	1 file 	admin 	5/28/20 7:47:00 AM CEST 	Queued
-////
 +
 // FIXME: add missing status variants
 +


### PR DESCRIPTION
As part of documentation cleanup for better maintenance, images are identified as candidates for removal when their content and purpose are already well described in the corresponding procedures. Random clean-ups that get discovered along the way are done too.

- master https://github.com/uyuni-project/uyuni-docs/pull/3615
- manager-5.0 https://github.com/uyuni-project/uyuni-docs/pull/3622
- manager-4.3