### PR TITLE
Add a note that migrate command only covers migration from 4.3 to 5.0 (#3902)

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-migration-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-migration-mlm.adoc
@@ -15,15 +15,18 @@ endif::[]
 
 * To migrate a {productname} 4.3 Server to a container, you require a new machine with {sl-micro} {microversion} or {sles} {bci-mlm} and [literal]``mgradm`` installed.
 
-// FIXME?
-* An in-place migration from {productname} 4.3 to {productnumber} is unsupported.
-  The underlying operating system has been changed from {sles} 15 SP4 to {sl-micro} or {sles} {bci-mlm}.
+* An in-place migration from {productname} 4.3 to {productnumber} is not supported, regardless of whether the chosen host operating system is {sl-micro} {microversion} or {sles} {bci-mlm}.
 
 * Before migrating from {productname} 4.3 to {productnumber}, any existing traditional clients including the traditional proxies must be migrated to {salt}.
 For more information about migrating traditional {productname} 4.3 clients to {salt} clients, see https://documentation.suse.com/suma/4.3/en/suse-manager/client-configuration/contact-methods-migrate-traditional.html.
 
 * Traditional contact protocol is no longer supported in {productname} 5.0 and later.
 
+[IMPORTANT]
+====
+This guide only covers the migration from {productname} 4.3 to {productnumber}.
+Migrating an existing {productname} {productnumber} instance to the same version while switching the host operating system from {sl-micro} {microversion} to {sles} {bci-mlm}, or vice versa, is not handled by the [command]``mgradm migrate`` command.
+====
 
 === Hostnames
 


### PR DESCRIPTION
* Update modules/installation-and-upgrade/pages/container-deployment/suma/server-migration-suma.adoc
Co-authored-by: Karl Eichwalder <ke@suse.de>
