### PR TITLE
Add info to pass the env variables to the bootstrap script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Added info about passing env variables to bootstrap script
+- Added info about passing env variables to bootstrap script in Client
+  Configuration Guide
 - Fixed Api doc is not linked in the reference guide (bsc#1243243)
 - Documented root SSH login configuration with password in Troubleshooting
   section in Administration Guide (bsc#1243569)

--- a/modules/client-configuration/pages/registration-bootstrap.adoc
+++ b/modules/client-configuration/pages/registration-bootstrap.adoc
@@ -66,7 +66,7 @@ The [command]``mgr-bootstrap`` command offers several other options, including t
 [NOTE]
 ====
 
-If user wish to create a bootstrap script to register against the Proxy, they can do so using the following command from the Server container:
+If users wish to create a bootstrap script to register against the Proxy, they can do so using the following command from the Server container:
 
 ----
 mgr-boostrap --hostname $proxyfqdn


### PR DESCRIPTION
# Description

This PR add info for the user about passing the env varianbles to bootstrap script.

# Target branches

* Which product version this PR applies to (Uyuni, 5.0, 5.1).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master
- 5.0


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/27470
- Related development PR #<insert PR link, if any>
