### PR TITLE
backport 4.3: Add note about autoyast profiles not having passwords (#4071)

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -4,6 +4,7 @@
 # - Fixed error in Bat section of Upgrade Guide (bsc#1234567)
 # For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Changelog_section_.28.25changelog.29
 
+- Added note about autoyast profiles not having passwords
 - Added details about the behavior of the rescheduled failed action
   (bsc#1244065)
 - Updated Network Requirement section to add settings for server

--- a/modules/client-configuration/pages/autoinst-profiles.adoc
+++ b/modules/client-configuration/pages/autoinst-profiles.adoc
@@ -113,6 +113,11 @@ Each of these profiles requires you to set some variables before you use it.
 Check the [path]``README`` file included with the script to determine which variables you need.
 For more information about using variables in {ay} scripts, see xref:client-configuration:autoinst-profiles#variables[Variables].
 
+[IMPORTANT]
+====
+Provided {ay} templates do not set any user password. Consider setting up root and other user accounts and passwords or other means of authentication. For more information about user accounts in the {ay} profiles, see https://doc.opensuse.org/projects/autoyast/#Configuration-Security-users-and-groups.
+====
+
 These are the most important sections in the {ay} installation file for installing with {productname}:
 
 * ``<add-on>`` allows to add child channels to the installation


### PR DESCRIPTION
* Add note about autoyast profiles not having passwords
* Update modules/client-configuration/pages/autoinst-profiles.adoc
