### PR TITLE
Added documentation for task schedule errata-advisory-map-sync-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Added documentation for task schedule errata-advisory-map-sync-default
+  (bsc#1243808)
 - Added note about AutoYaST profiles not having passwords
 - Raised recommended proxy RAM value to 8 GB (bsc#1244552)
 - Improved Hub documentation: peripheral list page, hierarchy of the Hub

--- a/modules/administration/pages/task-schedules.adoc
+++ b/modules/administration/pages/task-schedules.adoc
@@ -65,8 +65,8 @@ Sends daily report e-mails to relevant addresses.
 For more information about configuring notifications for specific users, see xref:reference:users/user-details.adoc[].
 
 menu:errata-advisory-map-sync-default[]::
-Updates internal SUSE patch vendor advisory database tables.
-If available, the original advisory provided by SUSE is shown in the section Vendor Advisory of each patch detail.
+Updates internal {suse} patch vendor advisory database tables.
+If available, the original advisory provided by {suse} is shown in the section Vendor Advisory of each patch detail.
 
 menu:errata-cache-default[]::
 Updates internal patch cache database tables, which are used to look up packages that need updates for each server.


### PR DESCRIPTION
# Description
Added documentation for task schedule errata-advisory-map-sync-default

# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3, SUMA MU X.Y.Z, or SUMA development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master
- 5.0
- 4.3

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/27375
- Related development PR https://github.com/uyuni-project/uyuni/pull/10488
