### PR TITLE
Improved step in the procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Improved instruction in the procedure for checking synchronization
+  progress (bsc#1233494)
 - Fixed the admonition in Client Configuration Guide (bsc#1233496)
 - Added notes about how to run `mgradm` on security-enforced hosts (bsc#1243704)
 - Reorganised files for better visibility of differences between AutoYaST 

--- a/modules/client-configuration/pages/snippets/check_sync_cli.adoc
+++ b/modules/client-configuration/pages/snippets/check_sync_cli.adoc
@@ -11,7 +11,7 @@ mgrctl exec -ti -- ls /var/log/rhn/reposync/
 
 +
 
-. At the command prompt on the {productname} container host, as root, check the synchronization of a channel log file:
+. After logging in to the container, at the command prompt on the {productname} container host, as root, check the synchronization of a channel log file:
 
 +
 


### PR DESCRIPTION
# Description

From the bug report: 

"Point 1 says 'At the command prompt in the SUSE Manager Server...'
With containers, it might not be clear for everybody that this means logging into the container. I suggest to make this more clear."


# Target branches

- master
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4158

# Links
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1233494