### PR TITLE
backport 5.0.5: Fix upgrade procedure for server and proxy (#4202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed upgrade procedure for server and proxy in Installation and
+  Upgrade Guide (bsc#1247084)
 - Fixed the hostname rename page for containers (bsc#1229825)
 - Added containers file and linked it to navigation list in
   Installation and Upgrade Guide

--- a/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
@@ -1,8 +1,8 @@
 = Proxy Upgrade
 
-Before running the upgrade command, it is recommended to upgrade the [literal]``mgrpxy`` tool first.
+Before running the upgrade command, it is required to upgrade the [literal]``mgrpxy`` tool first.
 
-.Procedure
+.Procedure: Upgrading Proxy
 . Refresh software repositories with [command]``zypper``:
 +
 ----

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -1,6 +1,6 @@
 = Server Upgrade
 
-Before running the upgrade command, it is recommended to upgrade the [literal]``mgradm`` tool first.
+Before running the upgrade command, it is required to upgrade the [literal]``mgradm`` tool first.
 
 .Procedure: Upgrading Server
 . Refresh software repositories with [command]``zypper``:


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1247084
https://github.com/SUSE/spacewalk/issues/27928
