### PR TITLE
backport 5.1: Fix upgrade procedure for server and proxy (#4202) (#4212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed upgrade procedure for server and proxy in Installation and
+  Upgrade Guide (bsc#1247084)
 - Added revision date to metadata for tracking document changes
 - Removed duplicated paragraphs from Hub documentation in Large
   Deployments Guide

--- a/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
@@ -2,10 +2,10 @@
 :revdate: 2025-05-05
 :page-revdate: {revdate}
 
-Before running the upgrade command, it is recommended to to update the host operating system.
+Before running the upgrade command, it is required to update the host operating system.
 Updating the host operating system will also result in the update of the {productname} tooling such as the [literal]``mgrpxy`` tool.
 
-.Procedure: Upgrading {productname} Proxy
+.Procedure: Upgrading Proxy
 
 . Refresh software repositories with [command]``zypper``:
 

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -2,10 +2,10 @@
 :revdate: 2025-07-29
 :page-revdate: {revdate}
 
-Before running the upgrade command, it is recommended to to update the host operating system.
+Before running the upgrade command, it is required to update the host operating system.
 Updating the host operating system will also result in the update of the {productname} tooling such as the [literal]``mgradm`` tool.
 
-.Procedure: Upgrading {productname} Server
+.Procedure: Upgrading Server
 
 . Refresh software repositories with [command]``zypper``:
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1247084
https://github.com/SUSE/spacewalk/issues/27928
