### PR TITLE
5.1 - Removed implicit references to traditional clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Removed random leftover references to traditional clients
+  (bsc#1247305)
 - Fixed broken link in Administration Guide (bsc#1247322)
 - Added instructions for third-party channels to Adminstration
   Guide (bsc#1246422)

--- a/modules/administration/pages/actions.adoc
+++ b/modules/administration/pages/actions.adoc
@@ -9,15 +9,15 @@ You can manage actions on your clients in a number of different ways:
 * You can apply recurring actions to individual clients, to all clients in a system group, or to an entire organization.
 * You can set actions to be performed in a particular order by creating action chains.
   ** Action chains can be created and edited ahead of time, and scheduled to run at a time that suits you.
-* You can also perform remote commands on one or more of your Salt clients.
-  ** Remote commands allows you to issue commands to individual Salt clients, or to all clients that match a search term.
+* You can also perform remote commands on one or more of your clients.
+  ** Remote commands allows you to issue commands to individual clients, or to all clients that match a search term.
 
 
 [[recurring_actions]]
 == Recurring Actions
 
 
-You can apply recurring actions on individual Salt clients, to a system group, or to all clients in an organization.
+You can apply recurring actions on individual clients, to a system group, or to all clients in an organization.
 
 Currently, {productname} supports the following action types as recurring actions:
 
@@ -138,11 +138,7 @@ You can see scheduled actions from action chains by navigating to menu:Schedule[
 
 == Remote Commands
 
-You can configure clients to run commands remotely.
-This allows you to issue scripts or individual commands to a client, without having access to the client directly.
-
-This feature is automatically enabled on Salt clients, and you do not need to perform any further configuration.
-You can use this procedure to enable it manually, instead.
+Use this procedure to run a remote command via {salt}.
 
 Before you begin, ensure your client is subscribed to the appropriate tools child channel for its installed operating system.
 For more information about subscribing to software channels, see xref:client-configuration:channels.adoc[].

--- a/modules/administration/pages/maintenance-windows.adoc
+++ b/modules/administration/pages/maintenance-windows.adoc
@@ -30,7 +30,7 @@ Some examples of restricted actions are:
 * Package installation
 * Client upgrade
 * Product migration
-* Highstate application (for Salt clients)
+* Highstate application
 
 Unrestricted actions are minor actions that are considered safe and are unlikely to cause problems on the client.
 Some examples of unrestricted actions are:
@@ -135,7 +135,7 @@ The restricted actions are:
 * Rebooting a client
 * Rolling back transactions
 * Configuration management changing tasks
-* Applying a highstate (for Salt clients)
+* Applying a highstate
 * Autoinstallation and reinstallation
 * Remote commands
 * Product migrations
@@ -143,8 +143,8 @@ The restricted actions are:
 
 [NOTE]
 ====
-For Salt clients, it is possible to run remote commands directly at any time by navigating to menu:Salt[Remote Commands].
-This applies whether or not the Salt client is in a maintenance window.
+It is possible to run remote commands directly at any time by navigating to menu:Salt[Remote Commands].
+This applies whether or not the client is in a maintenance window.
 For more information about remote commands, see xref:administration:actions.adoc[].
 ====
 


### PR DESCRIPTION
# Description

Leftover implicit references to traditional clients have remained in places. This PR removes them.

# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4249
- 5.1
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4252


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/27955