### PR TITLE
backport 5.1: information on how you can use pre-installed images to migrate from 4.3 (#4260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added information on using pre-installed images to migrate from 4.3
+  to 5.1 (bsc#1247786)
 - Added support data upload feature to Administration Guide
 - Fixed issues in Image Building chapter in the Administration Guide
   (bsc#1245987)

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
@@ -79,6 +79,13 @@ Running [command]``mgradm install`` and then [command]``mgradm migrate``  is not
 In the following steps, we are only preparing the host system, not installing the actual {productname} {productnumber} Server.
 ====
 
+You can use VM images on the {sl-micro} {microversion} as a migration target.
+In such a scenario, you can prepare the host system as described in xref:installation-and-upgrade:container-deployment/mlm/server-deployment-vm-mlm.adoc[] or xref:installation-and-upgrade:container-deployment/mlm/server-deployment-vmdk-mlm.adoc[].
+But at the end as the last step, instead of [command]``mgradm install`` you must execute the command [command]``mgradm migrate``.
+
+
+
+
 [[prepare-micro-host]]
 include::../../../snippet-prepare-micro-host.adoc[leveloffset=+2]
 

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
@@ -176,10 +176,13 @@ transactional-update
 
 . This step is optional.
   However, if custom persistent storage is required for your infrastructure, use the [command]``mgr-storage-server`` tool.
-** For more information, see [command]``mgr-storage-server --help``.
-This tool simplifies creating the container storage and database volumes.
 
-** Use the command in the following manner:
++
+
+For more information, see [command]``mgr-storage-server --help``.
+This tool simplifies creating the container storage and database volumes.
+Use the command in the following manner:
+
 +
 
 ----
@@ -188,9 +191,11 @@ mgr-storage-server <storage-disk-device> [<database-disk-device>]
 +
 For example:
 +
+
 ----
 mgr-storage-server /dev/nvme1n1 /dev/nvme2n1
 ----
+
 +
 [NOTE]
 ====
@@ -203,4 +208,3 @@ For more information, see
 ====
 
 include::../snippet-step-deploy-podman-certs.adoc[]
-

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
@@ -131,21 +131,27 @@ transactional-update
 
 . This step is optional.
   However, if custom persistent storage is required for your infrastructure, use the [command]``mgr-storage-server`` tool.
-** For more information, see [command]``mgr-storage-server --help``.
-This tool simplifies creating the container storage and database volumes.
 
-** Use the command in the following manner:
++
+
+For more information, see [command]``mgr-storage-server --help``.
+This tool simplifies creating the container storage and database volumes.
+Use the command in the following manner:
+
 +
 
 ----
 mgr-storage-server <storage-disk-device> [<database-disk-device>]
 ----
+
 +
 For example:
 +
+
 ----
 mgr-storage-server /dev/nvme1n1 /dev/nvme2n1
 ----
+
 +
 [NOTE]
 ====
@@ -158,4 +164,3 @@ For more information, see
 ====
 
 include::../snippet-step-deploy-podman-certs.adoc[]
-

--- a/modules/installation-and-upgrade/pages/container-deployment/snippet-step-deploy-podman-certs.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/snippet-step-deploy-podman-certs.adoc
@@ -1,5 +1,17 @@
-. Execute one of the following commands, depending on the SSL certificate variant (self-signed or third-party).
+. Deploy {productname}.
+
++
+
+[NOTE]
+====
+If you use VM images as a migration target, here as the last step, execute the command [command]``mgradm migrate`` instead of [command]``mgradm install``.
+====
+
++
+
+Execute one of the following commands, depending on the SSL certificate variant (self-signed or third-party).
   Replace `<FQDN>` with your fully qualified domain name of the {productname} Server:
+
 +
 
 --


### PR DESCRIPTION
* https://bugzilla.suse.com/show_bug.cgi?id=1247786
* https://github.com/SUSE/spacewalk/issues/28044

* add note about using VM images as migration target from 4.3 plus drive-by edit

* explicitly say that images are supported on {sl-micro} {microversion} only
* Warn with admonition in advance. Move note.
