### PR TITLE
backport 5.1: Documented building and deploying certificate on Image Build Host (#4281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Documented building and deploying certificate on Image Build
+  Host (bsc#1248447)
 - Replaced salt-minion with venv-salt-minion package in Image
   Management chapter in Administration Guide (bsc#1248448)
 - Added information on using pre-installed images to migrate from 4.3

--- a/modules/administration/pages/ssl-certs-imported.adoc
+++ b/modules/administration/pages/ssl-certs-imported.adoc
@@ -107,7 +107,6 @@ podman secret create --replace uyuni-cert $path_to_server_certificate
 podman secret create --replace uyuni-key $path_to_server_key
 podman secret create --replace uyuni-db-cert $path_to_database_certificate
 podman secret create --replace uyuni-db-key $path_to_database_key
-mgradm restart
 ----
 
 .Procedure: Restarting the Server
@@ -137,6 +136,21 @@ endif::[]
 
 If the Root CA was changed, it needs to get deployed to all the clients connected to {productname}.
 
+[NOTE]
+====
+If the CA certificate was updated, a RPM file with Kiwi certificate needs to be repackaged.
+
+On the {productname} Server container host, execute following command:
+
+[source,shell]
+----
+mgrctl exec mgr-package-rpm-certificate-osimage
+----
+
+Then apply highstate on the Image Build hosts to deploy the new certificates for Kiwi to use.
+====
+
+
 
 .Procedure: Deploying the Root CA on Clients
 
@@ -145,3 +159,6 @@ If the Root CA was changed, it needs to get deployed to all the clients connecte
 . Navigate to menu:Systems[System Set Manager > Overview].
 . In the [guimenu]``States`` field, click btn:[Apply] to apply the system states.
 . In the [guimenu]``Highstate`` page, click btn:[Apply Highstate] to propagate the changes to the clients.
+
+
+


### PR DESCRIPTION

* https://bugzilla.suse.com/show_bug.cgi?id=1248447
* https://github.com/SUSE/spacewalk/issues/28165

Co-authored-by: Ondřej Holeček <oholecek@suse.com>

* drive-by edit: remove duplicated command
