### PR TITLE
Fix broken URL for VMware vSphere documentation

### DIFF
--- a/modules/client-configuration/pages/vhm-vmware.adoc
+++ b/modules/client-configuration/pages/vhm-vmware.adoc
@@ -24,7 +24,7 @@ If you want to exclude any objects or resources, mark them with [parameter]``no-
 
 When you are adding new hosts to {productname}, you need to consider if the roles and permissions that have been assigned to users and objects need to be inventoried by {productname}.
 
-For more on users, roles, and permissions, see the VMware vSphere documentation: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere.html
+For more information on users, roles, and permissions, see the VMware vSphere documentation: https://techdocs.broadcom.com/us/en/vmware-cis/vsphere.html
 
 
 .Procedure: Creating a VMware VHM


### PR DESCRIPTION
# Description

This PR fixes a broken URL for the referenced VMware vSphere documentation.

# Target branches

- master
- 5.1
- 5.0
- 4.3

# Links
- https://github.com/SUSE/spacewalk/issues/28003