### PR TITLE
5.0 - Extra steps for cloned clients

### DIFF
--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -41,9 +41,18 @@ This procedure does not manipulate the original client, which remains registered
 
 
 .Procedure: Resolving Duplicate Machine IDs in Cloned Salt Clients
+[role=procedure]
+_____
+
+. *Initial System Configuration*
+
 
 . On the cloned machine, change the hostname and IP addresses.
     Make sure [path]``/etc/hosts`` contains the changes you made and the correct host entries.
+
+
+. *Resolving Duplicate Machine IDs*
+
 . For distributions that support systemd: If your machines have the same machine ID, as root, delete the files on each duplicated client and re-create it:
 +
 ----
@@ -70,6 +79,10 @@ rm /var/lib/dbus/machine-id
 rm /var/lib/zypp/AnonymousUniqueId
 dbus-uuidgen --ensure
 ----
+
+
+. *Reconfiguring {salt} Clients*
+
 . If your clients still have the same Salt client ID, delete the [path]``minion_id`` file on each client (FQDN is used when it is regenerated on client restart).
   For Salt Minion clients:
 +
@@ -103,3 +116,5 @@ service venv-salt-minion restart
 ----
 . Re-register the clients.
   Each client now has a different [path]``/etc/machine-id`` and should be correctly displayed on the [guimenu]``System Overview`` page.
+
+_____

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -98,7 +98,7 @@ Not performing these steps will result in a mix of old and new kernel entries af
 ====
 
 +
-. After changing the machine ID and before liberating:
+. After changing the machine ID and before liberating, run:
 
 +
 ----

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -53,7 +53,9 @@ _____
 
 . *Resolving Duplicate Machine IDs*
 
-. For distributions that support systemd: If your machines have the same machine ID, as root, delete the files on each duplicated client and re-create it:
+. _For distributions that support systemd:_
+   If your machines have the same machine ID, as root, delete the files on each duplicated client and re-create it:
+
 +
 ----
 rm /etc/machine-id
@@ -72,14 +74,39 @@ If names do not match, [command]``journalctl`` could not retrieve any log and [c
 mv /var/log/journal/* /var/log/journal/$(cat /etc/machine-id)
 ----
 
-. For distributions that do not support systemd: As root, generate a machine ID from dbus:
+. _For distributions that do not support systemd:_ 
+   As root, generate a machine ID from dbus:
+
 +
+
 ----
 rm /var/lib/dbus/machine-id
 rm /var/lib/zypp/AnonymousUniqueId
 dbus-uuidgen --ensure
 ----
 
+. *Fixing Kernel Entries on {rhel}*
+
+. If you are cloning a {rhel} 8.x server that will later be liberated to {sll}, you must perform extra steps to fix the kernel configuration files. 
+
++
+
+[IMPORTANT]
+====
+{rhel} uses the machine ID to generate kernel entries in [path]``/boot/loader/entries``. 
+Not performing these steps will result in a mix of old and new kernel entries after the liberation, as {sll} kernels will create new entries instead of replacing the old ones.
+====
+
++
+. After changing the machine ID and before liberating, as root run:
+
++
+----
+sudo rm -rf /boot/loader/entries/
+sudo  for ver in $(rpm -q kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n'); do echo "Reinstalling kernel $ver..."; sudo kernel-install add $ver /lib/modules/$ver; done
+ 
+sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+----
 
 . *Reconfiguring {salt} Clients*
 
@@ -91,24 +118,31 @@ dbus-uuidgen --ensure
 rm /etc/salt/minion_id
 rm -rf /etc/salt/pki
 ----
+
 +
 
 For Salt Bundle clients:
+
 +
 
 ----
 rm /etc/venv-salt-minion/minion_id
 rm -rf /etc/venv-salt-minion/pki
 ----
+
 . Delete accepted keys from the onboarding page and the system profile from {productname}, and restart the client with.
   For Salt Minion clients:
+
 +
+
 ----
 service salt-minion restart
 ----
+
 +
 
 For Salt Bundle clients: 
+
 +
 
 ----

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -85,7 +85,7 @@ rm /var/lib/zypp/AnonymousUniqueId
 dbus-uuidgen --ensure
 ----
 
-. *Fixing Kernel Entries on {rhel} 8.10
+. *Fixing Kernel Entries on {rhel} 8.10*
 
 . If you are cloning a {rhel} 8.10 server that will later be liberated to {sll}, you must perform extra steps to fix the kernel configuration files. 
 

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -98,7 +98,7 @@ Not performing these steps will result in a mix of old and new kernel entries af
 ====
 
 +
-. After changing the machine ID and before liberating, as root run:
+. After changing the machine ID and before liberating:
 
 +
 ----

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -85,9 +85,9 @@ rm /var/lib/zypp/AnonymousUniqueId
 dbus-uuidgen --ensure
 ----
 
-. *Fixing Kernel Entries on {rhel}*
+. *Fixing Kernel Entries on {rhel} 8.10
 
-. If you are cloning a {rhel} 8.x server that will later be liberated to {sll}, you must perform extra steps to fix the kernel configuration files. 
+. If you are cloning a {rhel} 8.10 server that will later be liberated to {sll}, you must perform extra steps to fix the kernel configuration files. 
 
 +
 

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -104,7 +104,6 @@ Not performing these steps will result in a mix of old and new kernel entries af
 ----
 sudo rm -rf /boot/loader/entries/
 sudo  for ver in $(rpm -q kernel --qf '%{VERSION}-%{RELEASE}.%{ARCH}\n'); do echo "Reinstalling kernel $ver..."; sudo kernel-install add $ver /lib/modules/$ver; done
- 
 sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
 ----
 

--- a/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
+++ b/modules/administration/pages/troubleshooting/tshoot-registerclones.adoc
@@ -42,7 +42,7 @@ This procedure does not manipulate the original client, which remains registered
 
 .Procedure: Resolving Duplicate Machine IDs in Cloned Salt Clients
 [role=procedure]
-_____
+____
 
 . *Initial System Configuration*
 
@@ -150,4 +150,4 @@ service venv-salt-minion restart
 . Re-register the clients.
   Each client now has a different [path]``/etc/machine-id`` and should be correctly displayed on the [guimenu]``System Overview`` page.
 
-_____
+____


### PR DESCRIPTION
# Description

Additional steps were missing from the procedure for troubleshooting registered cloned clients. 

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4338
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4337
- 5.0


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28495 / bug https://bugzilla.suse.com/show_bug.cgi?id=1250427