### PR TITLE
4.3 - Added info about requesting access to PTFs 

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -4,6 +4,7 @@
 # - Fixed error in Bat section of Upgrade Guide (bsc#1234567)
 # For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Changelog_section_.28.25changelog.29
 
+- Added information about requesting access to PTFs  (bsc#1213308)
 - Added lang support for new shared header to html outputs
 - Added shared header styles for documentation.suse.com 
 - Removed Ubuntu 20.04 from the list supported clients in Client

--- a/modules/administration/pages/ptfs.adoc
+++ b/modules/administration/pages/ptfs.adoc
@@ -31,6 +31,11 @@ Other versions or Operating Systems do not have this feature yet and the pages a
 ====
 
 
+[IMPORTANT]
+====
+Access to PTF channels via {productname} needs to be requested from L3 support.
+====
+
 .Procedure: Enable and Synchronize PTF repositories using the command line
 
 . On the console enter [command]``mgr-sync refresh``.


### PR DESCRIPTION
# Description

The access to PTF-channels via SUMA needs to be requested.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4331
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4330
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4329
- 4.3 


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1213308.