### PR TITLE
5.1 - Remove reference to HUB peripheral registration using mgradm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed reference to hub peripheral registration using mgradm
 - Documented System Hardware as a new Report in Administration Guide
 - Added lang support for new shared header to html outputs
 - Shared header added to theme for documentation.suse.com

--- a/modules/specialized-guides/pages/large-deployments/hub-install.adoc
+++ b/modules/specialized-guides/pages/large-deployments/hub-install.adoc
@@ -170,15 +170,6 @@ rhn-ssl-tool --gen-server --dir="/root/ssl-build" --set-country="COUNTRY" \
 mgradm install podman --ssl-ca-root RHN-ORG-TRUSTED-SSL-CERT --ssl-server-cert server.crt --ssl-server-key server.key --ssl-db-ca-root RHN-ORG-TRUSTED-SSL-CERT --ssl-db-server-cert server.crt --ssl-db-server-key server.key
 ----
 
-* Finally, on every peripheral server host, register the peripheral server to the hub server:
-+
-
-// CHECKIT: did we specify the credential during the hub server deployment?
-+
-----
-mgradm hub register --api-password <hub password> --api-server <hub fqdn> --api-user <hub admin>
-----
-
 _____
 
 


### PR DESCRIPTION
# Some hints

Remove reference register peripheral server to HUB using mgradm since it can lead to an inconsistent state when used with hub online synchronization.
See issue: https://github.com/SUSE/spacewalk/issues/28474


# Description

Remove reference register peripheral server to HUB using mgradm since it can lead to an inconsistent state when used with hub online synchronization.


# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4333
- 5.1


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28474
