### PR TITLE
5.1 - Improve the warning about partial backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Improved the warning about partial backups in Administration Guide
+  (bsc#1250551)
 - Removed reference to hub peripheral registration using mgradm
 - Documented System Hardware as a new Report in Administration Guide
 - Added lang support for new shared header to html outputs

--- a/modules/administration/pages/backup-restore.adoc
+++ b/modules/administration/pages/backup-restore.adoc
@@ -167,7 +167,8 @@ Particularly when database backup is skipped, backup is created without stopping
 
 [WARNING]
 ====
-Partial backup cannot guarantee backup/restore consistency.
+Partial backups are only considering a part of the data, and do not take potential dependencies with other parts which may not have been backed up in consideration. 
+Therefore they cannot guarantee backup/restore consistency.
 ====
 
 .Procedure: Creating Partial Backup by Skipping Database Backup


### PR DESCRIPTION
# Description

Improve the warning about partial backups.


# Target branches

* Which product version this PR applies to (Uyuni, 5.1).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? yes to 5.1
Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4336
- 5.1



# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28460
- Related development PR #<insert PR link, if any>
