### PR TITLE
51 - Add a note on upgrade with third-party SSL certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add a note for the upgrade with third-party SSL certificates
 - Improved the warning about partial backups in Administration Guide
   (bsc#1250551)
 - Removed reference to hub peripheral registration using mgradm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add a note for the upgrade with third-party SSL certificates
+- Added note for the upgrade with third-party SSL certificates to Installation and Upgrade Guide
 - Improved the warning about partial backups in Administration Guide
   (bsc#1250551)
 - Removed reference to hub peripheral registration using mgradm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Added note for the upgrade with third-party SSL certificates to Installation and Upgrade Guide
+- Added note for the upgrade with third-party SSL certificates to 
+  Installation and Upgrade Guide
 - Improved the warning about partial backups in Administration Guide
   (bsc#1250551)
 - Removed reference to hub peripheral registration using mgradm

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -96,15 +96,15 @@ This command will bring the status of the container up-to-date and restart the s
 
 
 .Upgrading with third-party SSL certificate
-[NOTE]
+[IMPORTANT]
 ====
-If you are using third-party certificates, the database container needs to have an SSL certificate with the following Subject Alternate Names:
+If you are using third-party certificates, the database container needs to have an SSL certificate with the following Subject Alternate Names (SANs):
 
 * [literal]``db``
 * [literal]``reportdb``
 * the externally facing fully qualified domain name
 
-The same certificate can be use for both the main container and the database one, but it needs to have those SANs too.
+The same certificate can be used for both the main container and the database one, but it needs to have those SANs too.
 
 In order to pass the new certificates to the upgrade command, use the [command]``--ssl-db-ca-root``, [command]``--ssl-db-cert`` and [command]``--ssl-db-key`` parameters.
 ====

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -95,6 +95,19 @@ mgradm upgrade podman
 This command will bring the status of the container up-to-date and restart the server.
 
 
+.Upgrading with third-party SSL certificate
+[NOTE]
+====
+If you are using third-party certificates, the database container needs to have an SSL certificate with the following Subject Alternate Names:
+
+* [literal]``db``
+* [literal]``reportdb``
+* the externally facing fully qualified domain name
+
+The same certificate can be use for both the main container and the database one, but it needs to have those SANs too.
+
+In order to pass the new certificates to the upgrade command, use the [command]``--ssl-db-ca-root``, [command]``--ssl-db-cert`` and [command]``--ssl-db-key`` parameters.
+====
 
 .Upgrading to specific version
 [NOTE]


### PR DESCRIPTION
# Description

Not having a note on how to upgrade with third-party certificates lead to confusion and painful debugging for users.

See https://github.com/uyuni-project/uyuni/issues/10561

# Target branches

Backport targets :

- master https://github.com/uyuni-project/uyuni-docs/pull/4348
- 5.1

# Links
- This PR tracks issue https://github.com/uyuni-project/uyuni/issues/10561
