### PR TITLE
5.1 - Add info about passing intermediate certificates

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/snippet-generate_proxy_config.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/snippet-generate_proxy_config.adoc
@@ -121,6 +121,7 @@ mgrctl exec -ti 'spacecmd proxy_container_config -- -p 8022 pxy.example.com srv.
 ----
 
 +
+
 . If your setup uses an intermediate CA, copy it as well and include it in the command with the `-i` option (can be provided multiple times if needed) :
 
 +


### PR DESCRIPTION
# Description

Add info about passing intermediate certificates


# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4363
- 5.1
- 5.0https://github.com/uyuni-project/uyuni-docs/pull/4366



# Links
- This PR tracks issue https://bugzilla.suse.com/show_bug.cgi?id=1250575 and https://bugzilla.suse.com/show_bug.cgi?id=1250649
- Related development PR #<insert PR link, if any>
