### PR TITLE
5.1 - Added procedures for disabling HSTS

### DIFF
--- a/modules/administration/pages/ssl-certs-hsts.adoc
+++ b/modules/administration/pages/ssl-certs-hsts.adoc
@@ -6,8 +6,7 @@
 HTTP Strict Transport Security (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security[HSTS]) is a policy mechanism that helps to protect websites against man-in-the-middle attacks such as protocol downgrade attacks and cookie hijacking.
 
 On {productname}, HSTS is enabled by default.
-If you neede to disable it on the server, follow this procedure:
-
+If you need to disable it on the server, follow this procedure:
 
 
 .Procedure: Disabling HSTS on the server
@@ -35,7 +34,7 @@ mgrctl exec -- systemctl restart apache2
 
 _____
 
-If you needed to disable it on the proxy, follow this procedure:
+If you need to disable it on the proxy, follow this procedure:
 
 .Procedure: Disabling HSTS on the proxy
 [role=procedure]


### PR DESCRIPTION
# Description

Changed file to reflect that HSTS is enabled by default, and added procedures for explicit disabling of HSTS.
(Backport of Karl's remaining PR.)


# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4189
- 5.1 


# Links
- This PR tracks issue: https://github.com/SUSE/spacewalk/issues/27857