### PR TITLE
update

### DIFF
--- a/modules/administration/pages/backup-restore.adoc
+++ b/modules/administration/pages/backup-restore.adoc
@@ -82,7 +82,6 @@ This will change [option]``archive_command`` in [path]``/var/lib/pgsql/data/post
 ----
 archive_command = '/bin/true'
 ----
---
 
 ____
 
@@ -303,6 +302,8 @@ If for some reason it is needed to skip restoring a volume present in the backup
 === Recommended steps after restoring a backup
 
 .Procedure: Recommended steps after {productname} restore
+[role=procedure]
+____
 
 . Re-synchronize your {productname} repositories using either the {productname} {webui}, or with the [command]``mgr-sync`` tool at the command prompt in the container.
   You can choose to re-register your product, or skip the registration and SSL certificate generation sections.


### PR DESCRIPTION
I introduced a regression yesterday. Unfortunately, GitHub Copilot AI (approved by SUSE) inserted an extra -- in my file, which broke the example blocks and caused half of the Administration Guide content to disappear. Thankfully, it was easy to trace — the issue occurred in the exact file I modified yesterday.

- master

