### PR TITLE
5.1 - Add instructions to clean container images after upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added instructions to clean unused container images after upgrad
+  (bsc#1253022)
 - Clarified the instructions that needs to run in containeri
   (bsc#1252680)
 - Improved CLM procedure in Adminstration Guide (bsc#1230876)

--- a/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
@@ -6,7 +6,8 @@ Before running the upgrade command, it is required to update the host operating 
 Updating the host operating system will also result in the update of the {productname} tooling such as the [literal]``mgrpxy`` tool.
 
 .Procedure: Upgrading Proxy
-
+[role=procedure]
+____
 . Refresh software repositories with [command]``zypper``:
 
 +
@@ -101,6 +102,23 @@ Or, those running on a Kubernetes cluster can update using:
 ----
 mgrpxy upgrade kubernetes
 ----
+
++
+
+. On podman, clean up the unused container images to free disk space:
+
++
+
+[source,shell]
+----
+podman image prune -a
+----
+
+____
+
+On Kubernetes the image cleanup is handled automatically, or it depends on the Kubernetes distribution.
+
+
 
 [NOTE]
 ====

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -6,6 +6,8 @@ Before running the upgrade command, it is required to update the host operating 
 Updating the host operating system will also result in the update of the {productname} tooling such as the [literal]``mgradm`` tool.
 
 .Procedure: Upgrading Server
+[role=procedure]
+____
 
 . Refresh software repositories with [command]``zypper``:
 
@@ -93,6 +95,17 @@ mgradm upgrade podman
 +
 
 This command will bring the status of the container up-to-date and restart the server.
+
++
+. Clean up the unused container images to free disk space:
+
++
+[source,shell]
+----
+podman image prune -a
+----
+
+____
 
 
 .Upgrading with third-party SSL certificate


### PR DESCRIPTION
# Description

Add instructions to clean container images after upgrade.

# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4483
- 5.1
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4486


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28848
- Related development PR #<insert PR link, if any>
