### PR TITLE
4.3 - Fixed variable name

### DIFF
--- a/.changelog
+++ b/.changelog
@@ -4,6 +4,7 @@
 # - Fixed error in Bat section of Upgrade Guide (bsc#1234567)
 # For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)#Changelog_section_.28.25changelog.29
 
+- Corrected the reactivation key varaible name (bsc#1253158)
 - Improved CLM procedure in Adminstration Guide (bsc#1230876)
 - Added commands to server migration procedures in Installation and
   Upgrade Guide (bsc#1214569)

--- a/modules/client-configuration/pages/contact-methods-migrate-traditional.adoc
+++ b/modules/client-configuration/pages/contact-methods-migrate-traditional.adoc
@@ -66,14 +66,14 @@ cd /srv/www/htdocs/pub/bootstrap/
 +
 
 ----
-cat bootstrap-migrate-to-salt.sh | ssh root@EXAMPLE.COM REACTIVATION-KEY=REACT_KEY /bin/bash
+cat bootstrap-migrate-to-salt.sh | ssh root@EXAMPLE.COM REACTIVATION_KEY=REACT_KEY /bin/bash
 ----
 
 . Alternatively, on the client, run the command:
 +
 
 ----
-curl -Sks https://server_hostname/pub/bootstrap/bootstrap-migrate-to-salt.sh | REACTIVATION-KEY=REACT_KEY /bin/bash
+curl -Sks https://server_hostname/pub/bootstrap/bootstrap-migrate-to-salt.sh | REACTIVATION_KEY=REACT_KEY /bin/bash
 ----
 +
 


### PR DESCRIPTION
# Description

From the bug description: 

_In the two commands we give for running the new bootstrap script, we currently show REACTIVATION-KEY (with a dash) when the correct variable name is REACTIVATION_KEY (with an underscore). 
When using REACTIVATION-KEY, the commands fail to run altogether as the dash character is not allowed in shell variable names. This leads the shell to try to interpret it as a command. 
It is not immediately obvious from the error produced that the variable name is to blame. Many customers might feel they need to open a support case when the documented commands do not work for them._


# Target branches
- 4.3


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1221950