### PR TITLE
5.0 - Installation instruction change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Changed the installation instructions to use product instead of packages 
+  (bsc#1249041)
 - Clarified the instructions that needs to run in container 
   (bsc#1252680)
 - Improved CLM procedure in Administration Guide (bsc#1230876)

--- a/modules/installation-and-upgrade/partials/container-deployment/prepare-sles-host.adoc
+++ b/modules/installation-and-upgrade/partials/container-deployment/prepare-sles-host.adoc
@@ -58,6 +58,8 @@ You will be required to enter the {productname} Extension registration code belo
 
 . Update the System (optional, if the system was not set to download updates during install):
 
++
+
 [source,shell]
 ----
 zypper up
@@ -65,23 +67,43 @@ zypper up
 
 . Reboot.
 
-. Log in as root and install [package]``podman`` and product related packages:
+. Log in as root and install the product package.
 
-* For the server, also [package]``mgradm`` and [package]``mgradm-bash-completion`` (if not already automatically installed):
++
 
-[source,shell]
-----
-zypper install podman mgradm mgradm-bash-completion
-----
+* On the server:
 
-* For the proxy, also [package]``mgrpxy`` and [package]``mgrpxy-bash-completion`` (if not already automatically installed):
++
 
 [source,shell]
 ----
-zypper install podman mgrpxy mgrpxy-bash-completion
+zypper in podman
+zypper in -t product SUSE-Manager-Server
 ----
+
+* On the proxies:
+
++
+
+[source,shell]
+----
+zypper in podman
+zypper in -t product SUSE-Multi-Manager-Proxy
+----
+
++
+
+[IMPORTANT]
+====
+Make sure that package [package]``podman`` is installed.
+Additionally,  on the server [package]``mgradm`` and [package]``mgradm-bash-completion`` or on the proxies, [package]``mgrpxy`` and [package]``mgrpxy-bash-completion`` also need to be installed.
+====
+
++
 
 . Start the Podman service by rebooting the system, or running a command:
+
++
 
 [source, shell]
 ----


### PR DESCRIPTION
# Description

Changed the installation instructions to use product instead of packages.

# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4497
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4502
- 5.0


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/28415