### PR TITLE
5.0 - Added missing step for client deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added additional step for client deletion in Client Configuration
+  Guide (bsc#1253249)
 - Clarified server config option for spacemd in Refrence Guide
   (bsc#1253197)
 - Changed the installation instructions to use product instead of 

--- a/modules/client-configuration/pages/delete-clients.adoc
+++ b/modules/client-configuration/pages/delete-clients.adoc
@@ -20,11 +20,17 @@ If you need to remove a client from your {productname} Server, you can:
 == Delete a Client with the {webui}
 
 .Procedure: Deleting a Client
+[role=procedure]
+____
 . In the {productname} {webui}, navigate to menu:Systems[System List] and select the client to delete.
+
 . Click btn:[Delete System].
+
 . Check the details and click btn:[Delete Profile] to confirm.
+
 . For Salt clients, {productname} attempts to clean up additional configuration.
   If the client cannot be contacted, you are given the option to cancel the deletion, or delete the client without cleaning up the configuration files.
+____
 
 You can also delete multiple clients using the System Set Manager.
 For more information about the System Set Manager, see xref:client-configuration:system-set-manager.adoc[].
@@ -40,12 +46,17 @@ It does not uninstall the package.
 == Delete a Client on the Command Line (with API Call)
 
 .Procedure: Deleting a Client from the Server
+[role=procedure]
+____
 . Delete the client with the FQDN (Fully Qualified Domain Name):
+
 +
+
 ----
 spacecmd system_delete FQDN
 ----
-+
+____
+
 [command]``spacecmd system_delete`` also deletes the {salt} key.
 
 [command]``system_delete`` offers the following options:
@@ -94,6 +105,8 @@ Instead of [command]``zypper`` use equivalent packager commands such as [command
 ====
 
 .Procedure: Deleting SLES 12 and 15 Clients
+[role=procedure]
+____
 . Stop the salt-minion service:
 
 +
@@ -114,7 +127,9 @@ rm -f /etc/zypp/repos.d/susemanager\:channels.repo
 rm -r /etc/sysconfig/rhn/
 rm -r /etc/salt/
 ----
+
 +
+
 . Remove Client Packages:
 
 +
@@ -124,8 +139,12 @@ rm -r /etc/salt/
 zypper rm salt salt-minion python*-salt sle-manager-tools-release
 ----
 
+____
+
 
 .Procedure: Salt Bundle Client - Manual Registration Cleanup
+[role=procedure]
+____
 . To unregister, run:
 
 +
@@ -138,5 +157,17 @@ rm -f /etc/zypp/repos.d/susemanager\:bootstrap.repo
 rm -f /etc/zypp/repos.d/susemanager\:channels.repo
 rm -r /etc/venv-salt-minion/*
 ----
+
++
+
+. Remove client machine ID:
+
++
+
+----
+rm /etc/sysconfig/rhn/systemid
+----
+
+____
 
 For information about the {salt} bundle, see xref:client-configuration:contact-methods-saltbundle.adoc[].


### PR DESCRIPTION
# Description

Step for removing client ID was missing from the instructions.

# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4511
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4513
- 5.0


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1253249