### PR TITLE
Fixed typo for command options

### DIFF
--- a/modules/reference/pages/spacecmd/proxy_container.adoc
+++ b/modules/reference/pages/spacecmd/proxy_container.adoc
@@ -25,7 +25,7 @@ parameters:
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.zip'
   -p, --ssh-port SSH port the proxy listens one. Default: 22
-  --ca-crt path to the certificate of the CA to use to generate a new proxy certificate.
+  --ca-cert path to the certificate of the CA to use to generate a new proxy certificate.
            Using /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT by default.
   --ca-key path to the private key of the CA to use to generate a new proxy certificate.
            Using /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY by default.


### PR DESCRIPTION
# Description

Fixed typo for command options

# Target branches
- master [Changelog](https://github.com/uyuni-project/uyuni-docs/pull/4526) 
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4525
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4527



# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28883

