### PR TITLE
5.0 - Fixed typo for command options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed typo for command options in Reference Guide (bsc#1253174)
 - Added additional step for client deletion in Client Configuration
   Guide (bsc#1253249)
 - Clarified server config option for spacemd in Refrence Guide

--- a/modules/reference/pages/spacecmd/proxy_container.adoc
+++ b/modules/reference/pages/spacecmd/proxy_container.adoc
@@ -25,7 +25,7 @@ parameters:
 options:
   -o, --output Path where to create the generated configuration. Default: 'config.zip'
   -p, --ssh-port SSH port the proxy listens one. Default: 22
-  --ca-crt path to the certificate of the CA to use to generate a new proxy certificate.
+  --ca-cert path to the certificate of the CA to use to generate a new proxy certificate.
            Using /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT by default.
   --ca-key path to the private key of the CA to use to generate a new proxy certificate.
            Using /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY by default.


### PR DESCRIPTION
# Description

Fixed typo for command options

# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4524
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4525
- 5.0


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28883

