### PR TITLE
Third-party SSL certificates for migrating 4.3 to 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Addressed the issue about using third-party SLS certificates 
+  during migration (bsc#1253382)
 - Fixed typo for command options in Reference Guide (bsc#1253174)
 - Added additional step for client deletion in Client Configuration
   Guide (bsc#1253249)

--- a/l10n-weblate/installation-and-upgrade.cfg
+++ b/l10n-weblate/installation-and-upgrade.cfg
@@ -62,5 +62,6 @@
 [type: asciidoc] modules/installation-and-upgrade/partials/snippet-ssl-requirements.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-ssl-requirements.adoc
 [type: asciidoc] modules/installation-and-upgrade/partials/snippet-start-proxy.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-start-proxy.adoc
 [type: asciidoc] modules/installation-and-upgrade/partials/snippet-step-deploy-podman-certs.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-step-deploy-podman-certs.adoc
+[type: asciidoc] modules/installation-and-upgrade/partials/snippet-third-party-ssl-certificates.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-third-party-ssl-certificates.adoc
 [type: asciidoc] modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc
 [type: asciidoc] modules/installation-and-upgrade/partials/snippet-warn-images-sl-micro.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-warn-images-sl-micro.adoc

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
@@ -78,6 +78,17 @@ endif::[]
 During a migration the server SSL certificate and CA chain are copied from the source server, meaning that only the database certificates are required
 
 
+=== Using third-party SSL certificates
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-third-party-ssl-certificates.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-third-party-ssl-certificates.adoc[leveloffset=+1]
+endif::[]
+
+
 == Migration
 
 ===  Prepare {productname} {productnumber} server host

--- a/modules/installation-and-upgrade/partials/snippet-third-party-ssl-certificates.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-third-party-ssl-certificates.adoc
@@ -1,0 +1,14 @@
+[WARNING]
+====
+When using third-party SSL certificates, you must include the appropriate SSL database flags in the command [comamnd]``mgradm migrate podman`` to avoid configuration failures. 
+====
+
+Refer to [comamnd]``mgradm migrate podman --help`` for details on these flags:
+
+* [literal]`` --ssl-db-ca-intermediate strings``: Intermediate CA certificate path for the database if different from the server one
+
+* [literal]``--ssl-db-ca-root string``: Root CA certificate path for the database if different from the server one
+
+* [literal]``--ssl-db-cert string``: Database certificate path
+
+* [literal]``--ssl-db-key string``: Database key path


### PR DESCRIPTION
# Description

Highlighted the requirement for third-party SSL certificates when migrating 4.3 to 5.1

# Target branches

- master
- 5.1


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1253350
