### PR TITLE
Added missing configuration step to snippet for generating proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added missing step for generating proxy configuration (bsc#1249425)
 - Fixed typo for command options in Reference Guide (bsc#1253174)
 - Added additional step for client deletion in Client Configuration
   Guide (bsc#1253249)

--- a/modules/installation-and-upgrade/partials/snippet-generate_proxy_config.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-generate_proxy_config.adoc
@@ -111,6 +111,17 @@ _____
 
 . SSH into your Server container host.
 
+. Copy the CA certificate and private key into the server container:
+
++
+
+----
+mgrctl cp /root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT server:/root/ssl-build/
+mgrctl cp /root/ssl-build/RHN-ORG-PRIVATE-SSL-KEY server:/root/ssl-build/
+----
+
++
+
 . Execute the following commands, replacing the Server and Proxy FQDN:
 
 +


### PR DESCRIPTION
# Description

Added step for copying the RHN-ORG-TRUSTED-SSL-CERT and RHN-ORG-PRIVATE-SSL-KEY to container before generating the proxy configuration via CLI.


# Target branches

- master
- 5.1
- 5.0

# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/28396