### PR TITLE
Added missing options to command example.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added missing options to command example in Installation and 
+  Upgrade Guide (bsc#1252908)
 - Added non-SUSE URLs to requirements in installation and Upgrade
   Guide (bsc#1252665)
 - Fixed typo for command options in Reference Guide (bsc#1253174)

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/server-air-gapped-deployment-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/server-air-gapped-deployment-suma.adoc
@@ -142,7 +142,17 @@ podman load -i ptf-images.tar
 
 +
 
-. Install the PTF using `mgradm support ptf podman` as would be done on a connected machine.
-  Because the images are already loaded they will not be pulled.
+. Install the PTF as it would be done on a connected machine, using command:
+
++
+
+[shell, source]
+----
+mgradm support ptf podman [--test|--ptf] NUMBER --user SCC_ACCOUNT
+----
+
++
+
+Because the images are already loaded they will not be pulled.
 
 ____


### PR DESCRIPTION
# Description

podman was missing option in order to  run correctly.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4530
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4534
- 5.0 


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28794