### PR TITLE
5.1 - Added links to man pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added links to man pages for createrepo_c and reprepro to
+  Administration Guide (bsc#1237181)
 - Added missing options to command example in Installation and 
   Upgrade Guide (bsc#1252908)
 - Added non-SUSE URLs to requirements in installation and Upgrade

--- a/modules/administration/pages/custom-channels.adoc
+++ b/modules/administration/pages/custom-channels.adoc
@@ -79,7 +79,10 @@ You can only add a repository to the {productname} with the {webui} if it is a v
 Check in advance that needed repository metadata are available.
 Tools such as [command]``createrepo`` and [command]``reprepro`` are useful in this regard.
 [command]``mgrpush`` can help with pushing a single RPM into a channel without creating a repository.
-For more information, see the  man pages for [literal]``createrepo_c`` and [literal]``reprepro``.
+
+* For more information on [literal]``createrepo_c`` see [link]``https://manpages.opensuse.org/Leap-15.6/createrepo_c/``
+
+* For more information on [literal]``reprepro`` see [link]``https://manpages.opensuse.org/Leap-15.6/reprepro/``
 
 
 .Procedure: Adding a software repository


### PR DESCRIPTION
# Description

These man pages are not available on SLE Micro, so the customer could use them. The section has been changed to add links to man pages on openSUSE.



# Target branches
- master https://github.com/uyuni-project/uyuni-docs/pull/4547
- 5.1
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4540


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/26470