### PR TITLE
Explain how to generate SSL DB cert for 5.0 peripheral server migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Explained how to generate the DB certificate for the upgrade of a 5.0 peripheral server (bsc#1248282)
 - Explained how to generate the proxy certificates on a peripheral server (bsc#1249425)
 - Fixed the issue with importing SSL certificates in Administration Guide 
   (bsc#1253382)

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc
@@ -21,6 +21,27 @@ endif::[]
 
 During a migration the server SSL certificate and CA chain are copied from the source server, meaning that only the database certificates are required
 
+[NOTE]
+====
+{productname} 5.0 peripheral servers are always using third-party SSL certificates.
+If the hub server has generated the certificates for the peripheral server, it needs to generate the certificate for the peripheral database too.
+
+On the hub server, run the following command for each of the peripheral server to migrate.
+
+[source,shell]
+----
+mgrctl exec -ti -- rhn-ssl-tool --gen-server --dir="/root/ssl-build" --set-country="COUNTRY" \
+  --set-state="STATE" --set-city="CITY" --set-org="ORGANIZATION" \
+  --set-org-unit="ORGANIZATION UNIT" --set-email="name@example.com" \
+  --set-hostname=<hostname>-reportdb --set-cname="example.com" --set-cname=db --set-cname=reportdb
+----
+
+The files to use will be inside the server container and need to be copied to the new peripheral server host:
+
+. [litteral]``/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT`` as the root CA,
+. [litteral]``/root/ssl-build/<hostname>-reportdb/server.crt`` as the db certificate and
+. [litteral]``/root/ssl-build/<hostname>-reportdb/server.key`` as the db certificate's key.
+====
 
 
 == Client tools rebranding


### PR DESCRIPTION
# Description

Generating the DB certificate for a 5.0 peripheral server migration is not obvious, document it.

# Target branches


Backport targets (edit as needed):

- master
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4561


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28139
