### PR TITLE
Document Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   version to Installation and Upgrade Guide
 - Added instructions for migrating Server and Proxy from 5.0 to 5.2 product
   version to Installation and Upgrade Guide
+- Document Debian 13
 - Reformatted storage-scripts table to use plain paragraphs instead of bullet 
   lists to fix po4a extraction issue causing missing bullets in CJK translations
 - Removed Ubuntu 20.04 for SUSE Multi-Linux Manager from the list of

--- a/modules/client-configuration/pages/clients-debian.adoc
+++ b/modules/client-configuration/pages/clients-debian.adoc
@@ -13,7 +13,7 @@ ifeval::[{mlm-content} == true]
 [IMPORTANT]
 ====
 * {debian} repository URLs are available from {scclongform}.
-* Packages and metadata are provided by Debian, not by {suse}.
+* Packages and metadata are provided by {debian}, not by {suse}.
 * For supported products, see the release notes and the support table at xref:client-configuration:supported-features-debian.adoc[].
 ====
 endif::[]
@@ -49,11 +49,12 @@ The products you need for this procedure are:
 
 [[debian-channels-wizard]]
 [cols="1,1", options="header"]
-.Debian Products - WebUI
+.{debian} Products - WebUI
 |===
 
 | OS Version  | Product Name
-| {debian} 12 | Debian 12
+| {debian} 12 | {debian} 12
+| {debian} 13 | {debian} 13
 |===
 
 ifndef::backend-pdf[]
@@ -69,11 +70,12 @@ The channels you need for this procedure are:
 
 [[debian-channels-cli]]
 [cols="1,1", options="header"]
-.Debian Channels - CLI
+.{debian} Channels - CLI
 |===
 
 | OS Version  | Product Name
 | {debian} 12 | debian-12-pool-amd64
+| {debian} 13 | debian-13-pool-amd64
 |===
 
 ifndef::backend-pdf[]
@@ -93,7 +95,7 @@ The channels you need for this procedure are:
 
 [[debian-channels-cli]]
 [cols="1,1,1,1,1", options="header"]
-.Debian Channels - CLI
+.{debian} 12 Channels - CLI
 |===
 
 | OS Version
@@ -107,6 +109,31 @@ The channels you need for this procedure are:
 | debian-12-amd64-uyuni-client
 | debian-12-amd64-main-updates-uyuni
 | debian-12-amd64-main-security-uyuni
+
+|===
+
+[cols="1,1", options="header"]
+.{debian} 13 Channels - CLI
+|===
+
+| Channel description         | Channel name
+| Main                        | debian-13-pool-amd64-uyuni
+| Main Updates                | debian-13-amd64-main-updates-uyuni
+| Main Security               | debian-13-amd64-main-security-uyuni
+| Main Backports              | debian-13-amd64-main-backports-uyuni
+| Contrib                     | debian-13-amd64-contrib-uyuni
+| Contrib Updates             | debian-13-amd64-contrib-updates-uyuni
+| Contrib Security            | debian-13-amd64-contrib-security-uyuni
+| Contrib Backports           | debian-13-amd64-contrib-backports-uyuni
+| Non-Free                    | debian-13-amd64-non-free-uyuni
+| Non-Free Updates            | debian-13-amd64-non-free-updates-uyuni
+| Non-Free Security           | debian-13-amd64-non-free-security-uyuni
+| Non-Free Backports          | debian-13-amd64-non-free-backports-uyuni
+| Non-Free-Firmware           | debian-13-amd64-non-free-firmware-uyuni
+| Non-Free-Firmware Updates   | debian-13-amd64-non-free-firmware-updates-uyuni
+| Non-Free-Firmware Security  | debian-13-amd64-non-free-firmware-security-uyuni
+| Non-Free-Firmware Backports | debian-13-amd64-non-free-firmware-backports-uyuni
+| Client Tools                | debian-13-amd64-uyuni-client
 
 |===
 

--- a/modules/client-configuration/pages/supported-features-debian.adoc
+++ b/modules/client-configuration/pages/supported-features-debian.adoc
@@ -18,137 +18,180 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1", options="header"]
+[cols="1,1,1", options="header"]
 .Supported Features on {debian} Operating Systems
 |===
 
 | Feature
 | {debian}{nbsp}12
+| {debian}{nbsp}13
 
 | Client
+| {check}
 | {check}
 
 | System packages
 | {debian} Community
+| {debian} Community
 
 | Registration
+| {check}
 | {check}
 
 | Install packages
 | {check}
+| {check}
 
 | Apply patches
+| {question}
 | {question}
 
 | Remote commands
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 
 | System custom states
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 
 | Organization custom states
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 
 | Product migration
 | N/A
+| N/A
 
 | Basic Virtual Guest Management {star}
+| {check}
 | {check}
 
 | Advanced Virtual Guest Management {star}
 | {check}
+| {check}
 
 | Virtual Guest Installation (Kickstart), as Host OS
+| {check}
 | {check}
 
 | Virtual Guest Installation (image template), as Host OS
 | {check}
+| {check}
 
 | System deployment (PXE/Kickstart)
+| {check}
 | {check}
 
 | System redeployment (Kickstart)
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 
 | Staging (pre-download of packages)
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 
 | CVE auditing
 | {question}
+| {question}
 
 | SCAP auditing
+| {question}
 | {question}
 
 | Package verification
 | {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 
 | System locking
 | {cross}
+| {cross}
 
 | Maintenance Windows
+| {check}
 | {check}
 
 | System snapshot
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 
 | Monitoring server
 | {cross}
+| {cross}
 
 | Monitoring clients
+| {check}
 | {check}
 
 | Docker buildhost
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {salt}
 | {salt}
 
 | Kiwi buildhost
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 
 | Recurring Actions
 | {check}
+| {check}
 
 | AppStreams
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 
 |===

--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -108,7 +108,7 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {check}
 
-| {debian} 12 (*)
+| {debian} 12, 13 (*)
 | {check}
 | {cross}
 | {cross}
@@ -246,7 +246,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {debian} 12 (*)
+| {debian} 12, 13 (*)
 | {check}
 | {cross}
 | {cross}
@@ -274,7 +274,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {raspberrypios} 12
+| {raspberrypios} 12, 13
 | {cross}
 | {cross}
 | {cross}


### PR DESCRIPTION
# IMPORTANT

**REWIEW, BUT DO NOT MERGE THIS UNTIL THE DEVELOPMENT PR IS MERGED. SAME FOR THE PR FOT THE BACKPORT TO 5.1**

Whoever is merging the development PR will ping you. In particular Orion should ping you when https://github.com/SUSE/spacewalk/issues/29112 is ready

# Description

Document Debian 13

Renders:
- Uyuni and SUSE Multi-Linux Manager 5.2: https://w3.suse.de/~jgonzalez/hackweek25/debian13/

# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version): Uyuni, 5.2. @admd to confirm if needs backport to 5.1
* Does this PR need to be backported? @admd to confirm if needs backport to 5.1
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master (this PR)
- 5.1: You will need to handle it (@KucharczykL: see https://github.com/uyuni-project/uyuni-docs/pull/4866)

Not for 5.0 or 5.3

# Links
- https://github.com/SUSE/spacewalk/issues/29116
- https://github.com/uyuni-project/uyuni/pull/11279
