### PR TITLE
Add Raspberry Pi OS 13 (Uyuni Only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Document Raspberry Pi OS 13 (Uyuni only)
 - Added instructions for migrating Server and Proxy from 5.1 to 5.2 product
   version to Installation and Upgrade Guide
 - Added instructions for migrating Server and Proxy from 5.0 to 5.2 product

--- a/modules/client-configuration/pages/clients-raspberrypios.adoc
+++ b/modules/client-configuration/pages/clients-raspberrypios.adoc
@@ -83,7 +83,7 @@ ifeval::[{uyuni-content} == true]
 
 [[raspberrypios-channels-uyuni-cli]]
 [cols="1,1,1", options="header"]
-.Raspberry Pi OS Channels - CLI
+.Raspberry Pi 12 OS Channels - CLI
 |===
 
 | Channel description
@@ -149,6 +149,92 @@ ifeval::[{uyuni-content} == true]
 | RPI Channel
 | -
 | raspberrypios-12-armhf-rpi-uyuni
+
+|===
+
+[cols="1,1,1", options="header"]
+.Raspberry Pi 13 OS Channels - CLI
+|===
+
+| Channel description
+| {arm64}
+| {armhf}
+
+| Main Channel
+| raspberrypios-13-pool-arm64-uyuni
+| raspberrypios-13-pool-armhf-uyuni
+
+| Main Updates Channel
+| raspberrypios-13-arm64-main-updates-uyuni
+| -
+
+| Main Security Channel
+| raspberrypios-13-arm64-main-security-uyuni
+| -
+
+| Main Backports Channel
+| raspberrypios-13-arm64-main-backports-uyuni
+| -
+
+| Contrib Channel
+| raspberrypios-13-arm64-contrib-uyuni
+| raspberrypios-13-armhf-contrib-uyuni
+
+| Contrib Updates Channel
+| raspberrypios-13-arm64-contrib-updates-uyuni
+| -
+
+| Contrib Security Channel
+| raspberrypios-13-arm64-contrib-security-uyuni
+| -
+
+| Contrib Backports Channel
+| raspberrypios-13-arm64-contrib-backports-uyuni
+| -
+
+| Non-free Channel
+| raspberrypios-13-arm64-non-free-uyuni
+| raspberrypios-13-armhf-non-free-uyuni
+
+| Non-free Updates Channel
+| raspberrypios-13-arm64-non-free-updates-uyuni
+| -
+
+| Non-free Security Channel
+| raspberrypios-13-arm64-non-free-security-uyuni
+| -
+
+| Non-free Backports Channel
+| raspberrypios-13-arm64-non-free-backports-uyuni
+| -
+
+| Non-free-firmeware Channel
+| raspberrypios-13-arm64-non-free-firmware-uyuni
+| -
+
+| Non-free-firmeware Updates Channel
+| raspberrypios-13-arm64-non-free-firmware-updates-uyuni
+| -
+
+| Non-free-firmeware Security Channel
+| raspberrypios-13-arm64-non-free-firmware-security-uyuni
+| -
+
+| Non-free-firmeware Backports Channel
+| raspberrypios-13-arm64-non-free-firmware-backports-uyun
+| -
+
+| Raspberry Channel
+| raspberrypios-13-arm64-raspberry-uyuni
+| raspberrypios-13-armhf-raspberry-uyuni
+
+| RPI Channel
+| -
+| raspberrypios-13-armhf-rpi-uyuni
+
+| Client Channel
+| raspberrypios-13-arm64-uyuni-client
+| raspberrypios-13-armhf-uyuni-client
 
 |===
 endif::[]

--- a/modules/client-configuration/pages/supported-features-raspberrypios.adoc
+++ b/modules/client-configuration/pages/supported-features-raspberrypios.adoc
@@ -25,7 +25,7 @@ The icons in this table indicate:
 * {cross} the feature is not available
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
-
+ifeval::[{mlm-content} == true]
 [cols="1,1", options="header"]
 .Supported Features on {raspberrypios} Operating Systems
 |===
@@ -160,6 +160,187 @@ The icons in this table indicate:
 | N/A
 
 |===
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+[cols="1,1,1", options="header"]
+.Supported Features on {raspberrypios} Operating Systems
+|===
+
+| Feature
+| {raspberrypios}{nbsp}12
+| {raspberrypios}{nbsp}13
+
+| Client
+| {check}
+| {check}
+
+| System packages
+| {raspberrypios} Community
+| {raspberrypios} Community
+
+| Registration
+| {check}
+| {check}
+
+| Install packages
+| {check}
+| {check}
+
+| Apply patches
+| {question}
+| {question}
+
+| Remote commands
+| {check}
+| {check}
+
+| System package states
+| {check}
+| {check}
+
+| System custom states
+| {check}
+| {check}
+
+| Group custom states
+| {check}
+| {check}
+
+| Organization custom states
+| {check}
+| {check}
+
+| System set manager (SSM)
+| {check}
+| {check}
+
+| Product migration
+| N/A
+| N/A
+
+| Basic Virtual Guest Management {star}
+| {check}
+| {check}
+
+| Advanced Virtual Guest Management {star}
+| {check}
+| {check}
+
+| Virtual Guest Installation (Kickstart), as Host OS
+| {cross}
+| {cross}
+
+| Virtual Guest Installation (image template), as Host OS
+| {check}
+| {check}
+
+| System deployment (PXE/Kickstart)
+| {cross}
+| {cross}
+
+| System redeployment (Kickstart)
+| {cross}
+| {cross}
+
+| Contact methods
+| {check} ZeroMQ, Salt-SSH
+| {check} ZeroMQ, Salt-SSH
+
+| Works with {productname} Proxy
+| {check}
+| {check}
+
+| Action chains
+| {check}
+| {check}
+
+| Staging (pre-download of packages)
+| {check}
+| {check}
+
+| Duplicate package reporting
+| {check}
+| {check}
+
+| CVE auditing
+| {question}
+| {question}
+
+| SCAP auditing
+| {question}
+| {question}
+
+| Package verification
+| {cross}
+| {cross}
+
+| Package locking
+| {check}
+| {check}
+
+| System locking
+| {cross}
+| {cross}
+
+| Maintenance Windows
+| {check}
+| {check}
+
+| System snapshot
+| {cross}
+| {cross}
+
+| Configuration file management
+| {check}
+| {check}
+
+| Package profiles
+| {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
+
+| Power management
+| {check}
+| {check}
+
+| Monitoring server
+| {cross}
+| {cross}
+
+| Monitoring clients
+| {check}
+| {check}
+
+| Docker buildhost
+| {question}
+| {question}
+
+| Build Docker image with OS
+| {check}
+| {check}
+
+| Kiwi buildhost
+| {cross}
+| {cross}
+
+| Build Kiwi image with OS
+| {cross}
+| {cross}
+
+| Recurring Actions
+| {check}
+| {check}
+
+| AppStreams
+| N/A
+| N/A
+
+| Yomi
+| N/A
+| N/A
+
+|===
+endif::[]
 
 {star} Virtual Guest Management:
 

--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -274,7 +274,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {raspberrypios} 12
+| {raspberrypios} 12, 13
 | {cross}
 | {cross}
 | {cross}


### PR DESCRIPTION
# IMPORTANT

**REWIEW, BUT DO NOT MERGE THIS UNTIL THE DEVELOPMENT PR IS MERGED**

Whoever is merging the development PR will ping you.

# Description

Add Raspberry Pi OS 13 (Uyuni Only)

IMPORTANT: Raspberry Pi OS 13 will not be part of neither SUSE Multi-Linux Manager 5.2 ATM. Only Raspberry Pi OS 12 will stay ATM.

Renders:
- Uyuni and SUSE Multi-Linux Manager 5.2: https://w3.suse.de/~jgonzalez/hackweek25/raspberrypios13/

# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.

Uyuni only

* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.

No

* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Nothing

Backport targets (edit as needed):

- master (This PR)
- 5.1 (not needed)
- 5.0 (not needed)
- 4.3 (not needed)


# Links
- Related development PR https://github.com/uyuni-project/uyuni/pull/11279
- https://github.com/SUSE/spacewalk/issues/28674
- https://github.com/SUSE/spacewalk/issues/29116
