### PR TITLE
Fix link in Relevant Patches

### DIFF
--- a/modules/reference/pages/patches/patch-list-relevant.adoc
+++ b/modules/reference/pages/patches/patch-list-relevant.adoc
@@ -7,7 +7,7 @@ The menu:Patches[Patch List > Relevant] section displays a list of all patches r
 
 Each patch in the list shows a patch type, an advisory number, a short description, the number of clients in your network affected, and the date the patch was last updated.
 Click the advisory number to see more information about the patch.
-For more information about the menu:Patches[Patch List > Patch Details] section, see xref:reference:patches/patch-details.adoc
+For more information about the menu:Patches[Patch List > Patch Details] section, see xref:reference:patches/patch-details.adoc[]
 
 
 [[patch-status]]


### PR DESCRIPTION
# Description

Fixes link in Relevant Patches by fixing a typo


# Target branches

Backport targets (edit as needed):

- master
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4584
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4583
- 4.3 https://github.com/uyuni-project/uyuni-docs/pull/4582
