### PR TITLE
Added details for the admonition related to SLE 16 products

### DIFF
--- a/modules/client-configuration/pages/clients-sle.adoc
+++ b/modules/client-configuration/pages/clients-sle.adoc
@@ -258,12 +258,14 @@ Use the same GPG key for both {sles}{nbsp}15 and {sles}{nbsp}12 clients.
 The correct key is called ``sle12-gpg-pubkey-39db7c82.key``.
 ====
 
+////
+2025-12-15: Removing until we get the correct name of the key
 [NOTE]
 ====
 {sles}{nbsp}16 clients use a different GPG key.
 The correct key is called ``XXXXXXXXXX``.
 ====
-
+////
 
 endif::[]
 


### PR DESCRIPTION
# Description

[**The PR**](https://github.com/uyuni-project/uyuni-docs/pull/4566) adding SLE 16 / openSUSE  Leap 16.0 to the documentation has an admonition (placeholder) with the information that needs to be clarified.

The PR has been merged, and this one removed the admonition until it's confirmed if we need it and what information should be shown. 