### PR TITLE
Added the correct name for SLE16 GPG key

### DIFF
--- a/modules/client-configuration/pages/clients-sle.adoc
+++ b/modules/client-configuration/pages/clients-sle.adoc
@@ -254,14 +254,11 @@ For more information about GPG keys, see xref:client-configuration:gpg-keys.adoc
 
 [NOTE]
 ====
-Use the same GPG key for both {sles}{nbsp}15 and {sles}{nbsp}12 clients.
-The correct key is called ``sle12-gpg-pubkey-39db7c82.key``.
-====
+* Use the same GPG key for both {sles}{nbsp}15 and {sles}{nbsp}12 clients.
+  The correct key is called ``sle12-gpg-pubkey-39db7c82.key``.
 
-[NOTE]
-====
-{sles}{nbsp}16 clients use a different GPG key.
-The correct key is called ``XXXXXXXXXX``.
+* {sles}{nbsp}16 clients use a different GPG key.
+  The correct key is called ``suse16-gpg-pubkey-09d9ea69.key``.
 ====
 
 


### PR DESCRIPTION
# Description

**[Previous PR](https://github.com/uyuni-project/uyuni-docs/pull/4566)** did not have GPG key details, but only a placeholder.
This PR adds the key name to the file.

# Target branches

- master
