### PR TITLE
5.1 - Updated HUB XML-RPC API to use SSL connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Updated HUB XML-RPC API to use SSL connection in Specialized Guides
 - Fixed issue for third-party certificates during migration (bsc#1253350)
 - Explained how to generate the proxy certificates on a peripheral server 
   (bsc#1249425)

--- a/modules/specialized-guides/pages/large-deployments/hub-api.adoc
+++ b/modules/specialized-guides/pages/large-deployments/hub-api.adoc
@@ -8,7 +8,7 @@
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
 
-When XMLRPC API is running, connect to the service at port 2830 using any XMLRPC-compliant client libraries.
+When XMLRPC API is running, connect to it through server FQDN at the location `/hub/rpc/api` using any XMLRPC-compliant client libraries.
 For examples, see xref:specialized-guides:large-deployments/hub-auth.adoc[].
 
 Logs are saved in ``/var/log/hub/hub-xmlrpc-api.log``.

--- a/modules/specialized-guides/pages/large-deployments/hub-auth.adoc
+++ b/modules/specialized-guides/pages/large-deployments/hub-auth.adoc
@@ -58,7 +58,7 @@ In this case, the response will be a single value and not a map, in the same way
 #!/usr/bin/python3
 import xmlrpc.client
 
-HUB_XMLRPC_API_URL = "<HUB_XMLRPC_API_URL>"
+HUB_XMLRPC_API_URL = "https://<SERVER_FQDN>/hub/rpc/api"
 HUB_USERNAME = "<USERNAME>"
 HUB_PASSWORD = "<PASSWORD>"
 
@@ -124,7 +124,7 @@ A typical workflow for relay authentication is:
 #!/usr/bin/python3
 import xmlrpc.client
 
-HUB_XMLRPC_API_URL = "<HUB_XMLRPC_API_URL>"
+HUB_XMLRPC_API_URL = "https://<SERVER_FQDN>/hub/rpc/api"
 HUB_USERNAME = "<USERNAME>"
 HUB_PASSWORD = "<PASSWORD>"
 
@@ -180,7 +180,7 @@ A typical workflow for auto-connect authentication is:
 #!/usr/bin/python3
 import xmlrpc.client
 
-HUB_XMLRPC_API_URL = "<HUB_XMLRPC_API_URL>"
+HUB_XMLRPC_API_URL = "https://<SERVER_FQDN>/hub/rpc/api"
 HUB_USERNAME = "<USERNAME>"
 HUB_PASSWORD = "<PASSWORD>"
 

--- a/modules/specialized-guides/pages/large-deployments/hub-namespaces.adoc
+++ b/modules/specialized-guides/pages/large-deployments/hub-namespaces.adoc
@@ -9,7 +9,7 @@
 :page-product-version: 5.1
 
 The Hub XMLRPC API operates in a similar way to the {productname} API.
-For {productname} API documentation, see https://documentation.suse.com/MLM.
+For {productname} API documentation, see https://documentation.suse.com/multi-linux-manager/{productnumber}/api/docs/index.html.
 
 The Hub XMLRPC API exposes the same methods that are available from the server's XMLRPC API, with a few differences in parameter and return types.
 Additionally, the Hub XMLRPC API supports some Hub-specific end points which are not available in the {productname} API.


### PR DESCRIPTION
# Description

Update documentation about the usage of HUB XML-RPC API to go through the apache service and use SSL.


# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4589
- 5.1


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
