### PR TITLE
5.0 - Changes example for the third-party repository GPG keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Changes example for the third-party repository GPG keys (bsc#1255857)
 - Added SLE16 and openSUSE Leap 16 as supported clients
 - Explained how to generate the proxy certificates on a peripheral server 
   (bsc#1249425)

--- a/modules/administration/pages/third-party-channels.adoc
+++ b/modules/administration/pages/third-party-channels.adoc
@@ -16,15 +16,15 @@ mgradm gpg add <path-to-gpg-key-file-or-URL>
 ----
 
 . Example: Adding a GPG key from a file: 
-
++
 ----
 mgradm gpg add repomd.xml.key
 ----
 
 . Example: Adding a GPG key from a remote repository using a URL:
-
++
 ----
-mgradm gpg add https://public.dhe.ibm.com/software/server/POWER/Linux/yum/OSS/SLES/15/ppc64le/repodata/repomd.xml.key
+mgradm gpg add https://<3rd-party-domain>/path/to/repository/repodata/repomd.xml.key
 ----
 
 To list the keys currently held in the {productname} GPG database, run the following command:


### PR DESCRIPTION
# Description
Changed example, used generic placeholder for URL.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4598
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4601
- 5.0


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1255857