### PR TITLE
Use proxy credentials for logging into SUSE Registry

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -81,12 +81,7 @@ ____
 
 +
 
-[source,shell]
-----
-set +o history
-echo SCC_MIRRORING_PASSWORD | podman login -u "SCC_MIRRORING_USER" --password-stdin registry.suse.com
-set -o history
-----
+include::../../../partials/snippet-login-into-suse-registry.adoc[]
 
 +
 

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
@@ -205,12 +205,7 @@ endif::[]
 If the executed command fails ensure that you have registered {productname} {productnumber}.
 If you skipped registration during installation and now need to register from the command line, follow the steps below to log in to the registry:
 
-[source,shell]
-----
-set +o history
-echo SCC_MIRRORING_PASSWORD | podman login -u "SCC_MIRRORING_USER" --password-stdin registry.suse.com
-set -o history
-----
+include::../../../partials/snippet-login-into-suse-registry.adoc[]
 
 Use the {productname} {productnumber} registration key when prompted.
 ====

--- a/modules/installation-and-upgrade/partials/snippet-login-into-suse-registry.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-login-into-suse-registry.adoc
@@ -1,0 +1,6 @@
+[source,shell]
+----
+set +o history
+echo SCC_MIRRORING_PASSWORD | podman login -u "SCC_MIRRORING_USER" --password-stdin registry.suse.com
+set -o history
+----


### PR DESCRIPTION
# Description

Changed instructions to use proxy credentials instead of e-mail for logging into SUSE Registry.
Used existing instructions found elsewhere in the docs:

https://github.com/uyuni-project/uyuni-docs/blob/b4ae4aa042d31b3dc0b69bbe7668d96ab86be75c/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc#L86-L88

# Target branches

Backport targets (edit as needed):

- master (this PR)
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4663
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4665


# Links
- This PR tracks issue #27617
