### PR TITLE
Update hashbang in build scripts

### DIFF
--- a/cleanup_pdfs.sh
+++ b/cleanup_pdfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Define directories and variables

--- a/extract-release-notes.sh
+++ b/extract-release-notes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Path to the changelog file
 CHANGELOG_FILE="CHANGELOG.md"

--- a/find_unused
+++ b/find_unused
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 EXIT_CODE=0

--- a/l10n-weblate/update-cfg-files
+++ b/l10n-weblate/update-cfg-files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Execute from the ./l10n-weblate directory !!!
 

--- a/make_pot.sh
+++ b/make_pot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # You need po4a > 0.58, see https://github.com/mquinson/po4a/releases
 # There is no need of system-wide installation of po4a
 # Usage: PERLLIB=/path/to/po4a/lib make_pot.sh

--- a/modules/revdate-cleanup.sh
+++ b/modules/revdate-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find all .adoc files excluding Antora nav files (nav-*.adoc)
 find . -type f -name "*.adoc" ! -name "nav-*.adoc" | while read -r ADOC; do

--- a/modules/revdate.sh
+++ b/modules/revdate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Find all .adoc files excluding Antora nav files (nav-*.adoc)
 find . -type f -name "*.adoc" ! -name "nav-*.adoc" | while read -r ADOC; do

--- a/use_po.sh
+++ b/use_po.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # You need po4a > 0.54, see https://github.com/mquinson/po4a/releases
 # There is no need of system-wide installation of po4a
 # Usage: PERLLIB=/path/to/po4a/lib use_po.sh


### PR DESCRIPTION
# Description

On some systems /bin/bash doesn't exist (NixOS, for one) so using the `env` binary is a safe way to find out where `bash` is located.

Tested on:
* NixOS
* Debian 12
* Ubuntu 25.04
* openSUSE Leap 15.6
* openSUSE Tumbleweed

# Target branches

Backport targets (edit as needed):

- master
- 5.1
- 5.0
- 4.3
