### PR TITLE
5.0 - Improve GPG-encrypted pillars documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Included global GPG decryption for pillar data in specialized guide (bsc#1255743)
 - CIS removed from list of supported OpenSCAP profiles
 - Changes example for the third-party repository GPG keys (bsc#1255857)
 - Added SLE16 and openSUSE Leap 16 as supported clients

--- a/modules/specialized-guides/pages/salt/salt-gpg-encrypted-pillars.adoc
+++ b/modules/specialized-guides/pages/salt/salt-gpg-encrypted-pillars.adoc
@@ -1,11 +1,11 @@
 [[salt-gpg-encrypted-pillars]]
 = GPG Encrypted Pillars
 :description: Learn how to securely configure and use GPG encryption with Salt for transparent decryption of pillar data within the Salt Master
-:revdate: 2023-01-23
+:revdate: 2026-01-12
 :page-revdate: {revdate}
 
 {salt} has support to transparently decrypt GPG-encrypted Pillar data built-in.
-The decryption happens on the {salt} Master.
+The decryption happens on the {salt} Master during Pillar rendering.
 
 
 == Generate GPG keyring for {salt} Master
@@ -54,18 +54,33 @@ systemctl reload-or-restart salt-master
 
 == Use GPG for encrypting Pillar secrets
 
-Salt GPG renderer decrypts GPG encrypted contents that are ASCI-armored. 
-To use the GPG renderer in a Pillar YAML file, change 
+Salt's GPG renderer decrypts GPG encrypted contents that are ASCII-armored.
+To use the GPG renderer in a single Pillar YAML file, change
 
 ----
-#!yaml
+#!jinja|yaml
 ----
 
-to 
+to
 
 ----
-#!yaml|gpg
+#!jinja|yaml|gpg
 ----
+
+To use Salt's GPG renderer globally, including for xref:client-configuration:custom-info.adoc[], configure Salt Master as follows
+
+----
+cat >/etc/salt/master.d/z-gpg-pillar.conf <<EOF
+ext_pillar:
+  - gpg: True
+EOF
+----
+
+[NOTE]
+====
+The filename should have a [literal]``z-`` prefix to ensure the GPG renderer runs after other configured pillar renderers.
+====
+
 
 Encrypting pillar secrets can be done anywhere as long as the GPG and the public key generated in <<proc-key-pair-generation>> are available. 
 


### PR DESCRIPTION
# Description


Explain how to globally enable GPG decryption which also works in Custom Info.
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1255743

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4611
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4650
- 5.0


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29309
- Related development PR #<insert PR link, if any>
