### PR TITLE
Added warning about order of migration steps

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
@@ -268,6 +268,14 @@ After the migration and validation of everything, [path]``var-pgsql-backup`` vol
 
 +
 
+[WARNING]
+====
+* The [command]``--prepare`` step can be run multiple times only as long as a final migration has not been started.
+* Once the final migration is initiated and reaches the database upgrade stage, you must not run the [command]``--prepare`` command again, as it can lead to data corruption.
+====
+
++
+
 ----
 mgradm migrate podman <oldserver.fqdn> --prepare
 ----


### PR DESCRIPTION
# Description

Added supported execution order of prepare and migrate steps.

# Target branches

- master
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4654


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29123