### PR TITLE
QE: Proxy Migration 5.0 > 5.1 inconsistencies

### DIFF
--- a/l10n-weblate/installation-and-upgrade/cs.po
+++ b/l10n-weblate/installation-and-upgrade/cs.po
@@ -1384,28 +1384,6 @@ msgid ""
 msgstr "SUSEConnect --status-text\n"
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-#, fuzzy
-#| msgid "Configure {productname} Server"
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "Konfigurace serveru {productname}"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1479,7 +1457,7 @@ msgstr ""
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 msgstr ""
 
 #. type: Plain text

--- a/l10n-weblate/installation-and-upgrade/es.po
+++ b/l10n-weblate/installation-and-upgrade/es.po
@@ -1335,28 +1335,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-#, fuzzy
-#| msgid "Procedure: {productname} Setup"
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "Procedimiento: instalación de {productname}"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1426,7 +1404,7 @@ msgstr ""
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 msgstr ""
 
 #. type: Plain text

--- a/l10n-weblate/installation-and-upgrade/installation-and-upgrade.pot
+++ b/l10n-weblate/installation-and-upgrade/installation-and-upgrade.pot
@@ -1437,26 +1437,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr ""
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99

--- a/l10n-weblate/installation-and-upgrade/ja.po
+++ b/l10n-weblate/installation-and-upgrade/ja.po
@@ -1200,26 +1200,6 @@ msgstr ""
 "SUSEConnect --status-text\n"
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr "以下が表示されるはずです。"
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1285,8 +1265,8 @@ msgstr "RPMパッケージとして新しいプロキシコンテナイメージ
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
-msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
+msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 
 #. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:62

--- a/l10n-weblate/installation-and-upgrade/ko.po
+++ b/l10n-weblate/installation-and-upgrade/ko.po
@@ -1266,26 +1266,6 @@ msgstr ""
 "SUSEConnect --status-text\n"
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr "다음을 참조해야 합니다."
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "{productname} 서버 확장"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1351,8 +1331,8 @@ msgstr "새 프록시 컨테이너 이미지를 RPM 패키지로 설치합니다
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
-msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
+msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 
 #. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:62

--- a/l10n-weblate/installation-and-upgrade/mk.po
+++ b/l10n-weblate/installation-and-upgrade/mk.po
@@ -1206,26 +1206,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr ""
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1291,7 +1271,7 @@ msgstr ""
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 msgstr ""
 
 #. type: Plain text

--- a/l10n-weblate/installation-and-upgrade/pt_BR.po
+++ b/l10n-weblate/installation-and-upgrade/pt_BR.po
@@ -1318,28 +1318,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-#, fuzzy
-#| msgid "xref:server-intro.adoc[Upgrade the Server]"
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "xref:server-intro.adoc[Atualizar o servidor]"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1411,7 +1389,7 @@ msgstr ""
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 msgstr ""
 
 #. type: Plain text

--- a/l10n-weblate/installation-and-upgrade/sk.po
+++ b/l10n-weblate/installation-and-upgrade/sk.po
@@ -1221,28 +1221,6 @@ msgstr ""
 "SUSEConnect --status-text\n"
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr ""
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-#, fuzzy
-#| msgid "Selecting the {productname} Extension"
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "Výber rozšírenia {productname}"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1313,7 +1291,7 @@ msgstr ""
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 msgstr ""
 
 #. type: Plain text

--- a/l10n-weblate/installation-and-upgrade/zh_CN.po
+++ b/l10n-weblate/installation-and-upgrade/zh_CN.po
@@ -1201,26 +1201,6 @@ msgstr ""
 "SUSEConnect --status-text\n"
 
 #. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:48
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:116
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:46
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:64
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:96
-msgid "You should see:"
-msgstr "您应看到以下内容："
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:49
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:47
-msgid "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-msgstr "[literal]``PRETTY_NAME=\"SUSE Linux Micro 6.1\"``"
-
-#. type: Plain text
-#: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:50
-msgid "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-msgstr "[literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``"
-
-#. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:51
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:119
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc:99
@@ -1286,8 +1266,8 @@ msgstr "以 RPM 软件包形式安装新的代理容器映像。"
 #. type: delimited block -
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:61
 #, no-wrap
-msgid "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
-msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*\n"
+msgid "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
+msgstr "transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*\n"
 
 #. type: Plain text
 #: modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc:62

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc
@@ -159,13 +159,6 @@ SUSEConnect --status-text
 
 +
 
-You should see:
-
-* [literal]``PRETTY_NAME="SUSE Linux Micro 6.1"``
-* [literal]``SUSE Multi-Linux Manager Proxy 5.1 Extension``
-
-+
-
 . Verify {productname} tools version.
 
 +
@@ -216,7 +209,7 @@ For more information, see xref:administration:troubleshooting/tshoot-remote-root
 
 [source,shell]
 ----
-transactional-update pkg install suse-multi-linux-manager-5.1-x86_64-proxy*
+transactional-update pkg install suse-multi-linux-manager-5.1-<arch>-proxy*
 ----
 
 . Reboot the P-roxy.


### PR DESCRIPTION
Superseded by https://github.com/uyuni-project/uyuni-docs/pull/4661.

# Description

Solves https://github.com/uyuni-project/uyuni-docs/issues/4657.

# Target branches

- 5.1

# Links

- https://documentation.suse.com/multi-linux-manager/5.1/en/docs/installation-and-upgrade/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.html
