### PR TITLE
Update proxy installation guide to avoid manual registration

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -37,15 +37,15 @@ _____
 
 . Install {sl-micro} or {sles} on a bare-metal machine.
 
-. During the installation, register {sl-micro} or {sles} along with the {productname} Proxy extension.
-
-. Create a {salt} activation key.
+. Create a {salt} activation key with Proxy extension.
 
 . Bootstrap the proxy as a client with the [systemitem]``default`` connection method.
 
 . Generate a proxy configuration.
 
 . Transfer the proxy configuration from server to proxy.
+
+. Install packages on the proxy.
 
 . Use the proxy configuration to register the client as a proxy with {productname}.
 
@@ -105,11 +105,11 @@ In the following subsections, you either prepare the proxy host with {sle-micro}
 
 [[deploy-mlm-proxy-micro]]
 ifndef::backend-pdf[]
-include::installation-and-upgrade:partial$snippet-prepare-micro-host.adoc[leveloffset=+1]
+include::installation-and-upgrade:partial$snippet-prepare-micro-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../partials/snippet-prepare-micro-host.adoc[leveloffset=+1]
+include::../../../partials/snippet-prepare-micro-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc#deploy-mlm-proxy-persistent-storage[].
@@ -118,11 +118,11 @@ To continue with deployment, see xref:installation-and-upgrade:container-deploym
 
 [[deploy-mlm-proxy-sles]]
 ifndef::backend-pdf[]
-include::installation-and-upgrade:partial$snippet-prepare-sles-host.adoc[leveloffset=+1]
+include::installation-and-upgrade:partial$snippet-prepare-sles-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../partials/snippet-prepare-sles-host.adoc[leveloffset=+1]
+include::../../../partials/snippet-prepare-sles-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc#deploy-mlm-proxy-persistent-storage[].
@@ -198,6 +198,14 @@ endif::[]
 
 ifdef::backend-pdf[]
 include::../../../partials/snippet-transfer_proxy_config.adoc[]
+endif::[]
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ensure-proxy-prerequisites.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../partials/snippet-ensure-proxy-prerequisites.adoc[]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc
@@ -1,0 +1,40 @@
+:description: Learn how to prepare the proxy host to be used as proxy
+== Install packages and enable podman
+
+Before using proxy, some packages need to be present on host and [package]``podman`` needs to be running.
+
+
+.Procedure: Preparing the prerequisites
+[role=procedure]
+_____
+
+. On the proxy host, ensure that the following packages are installed:
+
+* [package]``podman``
+* [package]``mgrpxy-bash-completion``
+* [package]``suse-multi-linux-manager-5.1-x86_64-proxy-httpd-image``
+* [package]``suse-multi-linux-manager-5.1-x86_64-proxy-salt-broker-image``
+* [package]``suse-multi-linux-manager-5.1-x86_64-proxy-squid-image``
+* [package]``suse-multi-linux-manager-5.1-x86_64-proxy-ssh-image``
+* [package]``suse-multi-linux-manager-5.1-x86_64-proxy-tftpd-image``
+
++
+
+. Start the Podman service on the proxy host by rebooting the system, or running a command:
+
++
+
+[source, shell]
+----
+systemctl enable --now podman.service
+----
+
+. On the proxy host, install the Proxy with:
+
++
+
+----
+mgrpxy install podman config.tar.gz
+----
+
+_____

--- a/modules/installation-and-upgrade/partials/snippet-prepare-micro-host.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-prepare-micro-host.adoc
@@ -16,8 +16,6 @@ ____
 
 === Install {sl-micro} {microversion}
 
-For more information about preparing your machines (virtual or physical), see the link:https://documentation.suse.com/sle-micro/6.1[{sl-micro} Deployment Guide].
-
 .Procedure: Installing {sl-micro} {microversion}
 [role=procedure]
 ____
@@ -80,7 +78,7 @@ The {sl-micro} {microversion} entitlement is included within the {productname} e
 ____
 
 This concludes installation of {sl-micro} {microversion} and {productname} {productnumber} as an extension.
-
+For more information about preparing your machines (virtual or physical), see the link:https://documentation.suse.com/sle-micro/6.1[{sl-micro} Deployment Guide].
 
 
 === OPTIONAL: Registration from the command line

--- a/modules/installation-and-upgrade/partials/snippet-prepare-micro-proxy-host.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-prepare-micro-proxy-host.adoc
@@ -1,0 +1,86 @@
+== Prepare {sl-micro} {microversion} Host
+
+
+=== Download the installation media
+
+.Procedure: Downloading the installation media
+[role=procedure]
+____
+
+. Locate the {sl-micro} {microversion} installation media at https://www.suse.com/download/sle-micro/, and download the appropriate media file.
+
+. Prepare a DVD or USB flash drive with the downloaded [filename]``.iso`` image for installation.
+
+____
+
+
+=== Install {sl-micro} {microversion}
+
+For more information about preparing your machines (virtual or physical), see the link:https://documentation.suse.com/sle-micro/6.1[{sl-micro} Deployment Guide].
+
+.Procedure: Installing {sl-micro} {microversion}
+[role=procedure]
+____
+
+. Insert the DVD or USB flash drive (USB disk or key) containing the installation image for {sle-micro} {microversion}.
+
+. Boot or reboot your system.
+
+. Use the arrow keys to select [systemitem]``Installation``.
+
+. Adjust Keyboard and language.
+
+. Click the [systemitem]``checkbox`` to accept the license agreement.
+
+. Click [systemitem]``Next`` to continue.
+
+. Skip the registration. The {sl-micro} {microversion} entitlement is included within the {productname} entitlement, so it does not require a separate registration code.
+
+. Click btn:[Next] to continue.
+
+. On the [systemitem]``NTP Configuration`` page click btn:[Next].
+
+. On the [systemitem]``Authentication for the System`` page enter a password for the root user.
+  Click btn:[Next].
+
+. On the [systemitem]``Installation Settings`` page click btn:[Install].
+
+____
+
+This concludes installation of {sl-micro} {microversion} and {productname} {productnumber} as an extension.
+
+
+=== Update the system
+
+.Procedure: Updating the system
+[role=procedure]
+____
+. Log in as *root*.
+
+. Run **transactional-update**:
+
++
+
+[source, shell]
+----
+transactional-update
+----
+
+. Reboot.
+
+____
+
+
+[IMPORTANT]
+====
+{sl-micro} is designed to update itself automatically by default and will reboot after applying updates.
+However, this behavior is not desirable for the {productname} environment.
+To prevent automatic updates on your server, {productname} disables the transactional-update timer during the bootstrap process.
+
+If you prefer the {sl-micro} default behavior, enable the timer by running the following command:
+
+[source, shell]
+----
+systemctl enable --now transactional-update.timer
+----
+====

--- a/modules/installation-and-upgrade/partials/snippet-prepare-sles-host.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-prepare-sles-host.adoc
@@ -14,7 +14,7 @@ ____
 
 . Locate and download {sles} {bci-mlm} [literal]``.iso`` at https://www.suse.com/download/sles/.
 
-. Make sure that you have regsistration codes both for the host operating system ({sles} {bci-mlm}) and extensions
+. Make sure that you have registration codes both for the host operating system ({sles} {bci-mlm}) and extensions
 
 . Start the installation of {sles} {bci-mlm}.
 

--- a/modules/installation-and-upgrade/partials/snippet-prepare-sles-proxy-host.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-prepare-sles-proxy-host.adoc
@@ -1,0 +1,60 @@
+== Prepare {sles} {bci-mlm} host
+
+
+Alternatively, you can deploy {productname} on {sles} {bci-mlm}.
+
+The following procedures describe the main steps of the installation process.
+
+
+=== Install {productname} extensions on {sles}
+
+.Procedure: Installing {productname} Extensions on {sles}
+[role=procedure]
+____
+
+. Locate and download {sles} {bci-mlm} [literal]``.iso`` at https://www.suse.com/download/sles/.
+
+. Make sure that you have registration codes both for the host operating system ({sles} {bci-mlm}) and extensions
+
+. Start the installation of {sles} {bci-mlm}.
+
+  .. On the [literal]``Language, keyboard and product selection`` select the product to install.
+
+  .. On the [literal]``License agreement`` read the agreement and check [guimenu]``I Agree to the License Terms``.
+
+. Skip the registration.
+
+. Click [systemitem]``Next`` to continue.
+
++
+
+[IMPORTANT]
+====
+Please note that for {sles} {bci-mlm}, you are required to have a valid {sles} subscription configured on the server.
+====
+
+. In the screen [literal]``Extensions and Modules Selection`` check the following:
+
++
+
+  * Basesystem Module
+  * Containers Module
+
+. Click btn:[Next] to continue.
+
+. Complete the installation.
+
+. When the installation completes, log in to the newly installed server as root.
+
+. Update the System (optional, if the system was not set to download updates during install):
+
++
+
+[source,shell]
+----
+zypper up
+----
+
+. Reboot.
+
+____

--- a/modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc
@@ -25,13 +25,5 @@ mgrctl cp server:/root/config.tar.gz .
 scp config.tar.gz <proxy-FQDN>:/root
 ----
 
-. On the proxy host, install the Proxy with:
-
-+
-
-----
-mgrpxy install podman config.tar.gz
-----
-
 _____
 


### PR DESCRIPTION
# Description

* Removed all mentions of manual registration, everything is handled by the server
* Host setup now has an new proxy-only version since it differs from the server host setup


# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4671
- 5.1 (this PR)
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4638


# Links
- Closes https://github.com/SUSE/spacewalk/issues/28725
