### PR TITLE
Move box with information about the need to have higher server version before proxy migration

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-51.adoc
@@ -1,6 +1,6 @@
 = Proxy Migration from 5.0 to 5.1
 :description: Upgrade your proxy and host operating system using validated procedures for migrating from SLE Micro 5.5 to SLE Micro 6.1, SLES 15 SP6 to SLES 15 SP7,
-:revdate: 2025-10-19
+:revdate: 2026-01-29
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -18,18 +18,17 @@ The upgrade scenarios covered include:
 * Migrating from **SUSE Linux Enterprise Server (SLES) 15 SP6** to **SLES 15 SP7**
 * Upgrading the **{productname} Proxy Extension** from **version 5.0** to **version {productnumber}**
 
-[IMPORTANT]
-====
-Before migrating the proxy, it is required to first migrate the SUSE Manager 5.0 Server to {productname} {productnumber}.
-====
-
-
 == {sle-micro} 5.5 to {sl-micro} 6.1
 
 This section provides the tested procedure to upgrade a {sle-micro} 5.5 host deployed with {productname} 5.0 Proxy to {sl-micro} 6.1 with {productname} {productnumber} Proxy.
 
 
 === Prerequisites
+
+[IMPORTANT]
+====
+Before migrating the proxy, it is required to first migrate the SUSE Manager 5.0 Server to {productname} {productnumber}.
+====
 
 * {productname} 5.0 Proxy is installed and running on {sle-micro} 5.5.
 * Proxy system is registered with the {productname} Server.


### PR DESCRIPTION
# Description

Move box with information about the need to have higher server version before proxy migration.

# Target branches

Backport targets (edit as needed):

- master
- 5.1 (this PR)
- 5.0
- 4.3


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28616

