### PR TITLE
manager-5.1 - Add PTF loss warning for mgradm upgrade podman (#29031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added a warning for all instances where mgradm upgrade podman is used. 
 - Changed the order of reboot/mgrxpy stop instructions during proxy migration in Installation and Upgrade Guide
 - Added section about container-based Kiwi image build support to Administration
   guide (bsc#1251865)

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-51.adoc
@@ -241,6 +241,16 @@ Expected output:
 
 +
 
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
++
+
 [source,console]
 ----
 mgradm upgrade podman
@@ -426,6 +436,16 @@ Expected output:
 +
 
 . Upgrade the server containers.
+
++
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
 
 +
 

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -92,6 +92,16 @@ endif::[]
 
 +
 
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
++
+
 [source,shell]
 ----
 mgradm upgrade podman
@@ -135,6 +145,14 @@ To upgrade to a specific version, provide the tag parameter with the desired ima
 ====
 
 For more information on the upgrade command and its parameters, use the following command:
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
 
 [source,shell]
 ----

--- a/modules/installation-and-upgrade/partials/snippet-ptf-loss-during-upgrade.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-ptf-loss-during-upgrade.adoc
@@ -1,0 +1,10 @@
+[WARNING]
+====
+*Risk of Automated Version Downgrade and PTF Loss*
+
+Running the `mgradm upgrade podman` command when no newer upgrade is available will cause the system to automatically revert to the base version.
+This process removes all currently applied Program Temporary Fixes (PTFs) without a confirmation prompt.
+
+To avoid unintended data or fix loss, verify upgrade availability before execution.
+Future releases will include a confirmation prompt to prevent this behavior.
+====

--- a/modules/specialized-guides/pages/salt/salt-monitoring.adoc
+++ b/modules/specialized-guides/pages/salt/salt-monitoring.adoc
@@ -53,6 +53,16 @@ mgradm scale uyuni-saline --replicas 1
 
 +
 
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
++
+
 ----
 mgradm upgrade podman && mgradm scale uyuni-saline --replicas 1
 ----
@@ -74,6 +84,14 @@ This can be help with tuning large scale deployment installations.
 To configure Prometheus and Grafana dashboards, see xref:specialized-guides:salt/salt-formula-saline.adoc[Saline Formula].
 
 == Removing Saline
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
 
 To remove Saline from the {productname} Server use [command]``mgradm upgrade podman`` with [option]``--saline-replicas 0``.
 


### PR DESCRIPTION
# Description

Added a warning for all instances where `mgradm upgrade podman` is used.


# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4693
- 5.1 (this PR)
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4696


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29121
