### PR TITLE
manager-5.0 - Add PTF loss warning for mgradm upgrade podman (#29031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added a warning for all instances where mgradm upgrade podman is used. 
 - Added section about container-based Kiwi image build support to Administration
   guide (bsc#1251865)
 - Included global GPG decryption for pillar data in specialized guide (bsc#1255743)

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -31,6 +31,14 @@ zypper up
 . The {productname} Server container can be updated using the following command:
 +
 
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
 ----
 mgradm upgrade podman
 ----
@@ -57,6 +65,16 @@ If you do not specify the tag parameter, it will default to upgrading to the mos
 ====
 
 For more information on the upgrade command and its parameters, use the following command:
+
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+endif::[]
+
 ----
 mgradm upgrade podman -h
 ----

--- a/modules/installation-and-upgrade/partials/snippet-ptf-loss-during-upgrade.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-ptf-loss-during-upgrade.adoc
@@ -1,0 +1,10 @@
+[WARNING]
+====
+*Risk of Automated Version Downgrade and PTF Loss*
+
+Running the `mgradm upgrade podman` command when no newer upgrade is available will cause the system to automatically revert to the base version.
+This process removes all currently applied Program Temporary Fixes (PTFs) without a confirmation prompt.
+
+To avoid unintended data or fix loss, verify upgrade availability before execution.
+Future releases will include a confirmation prompt to prevent this behavior.
+====


### PR DESCRIPTION
# Description

Added a warning for all instances where `mgradm upgrade podman` is used.


# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4693
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4695
- 5.0 (this PR)


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29121
