### PR TITLE
master - Remove Ubuntu 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 - Reformatted storage-scripts table to use plain paragraphs instead of bullet 
   lists to fix po4a extraction issue causing missing bullets in CJK translations
+- Removed Ubuntu 20.04 for SUSE Multi-Linux Manager from the list of
+  supported clients in Client Configuration Guide
 - Added instructions to install and enable Podman before running mgradm in
   Uyuni Server Deployment guide
 - Added a warning for all instances where mgradm upgrade podman is used.

--- a/modules/administration/partials/install_scap_security_guide_package.adoc
+++ b/modules/administration/partials/install_scap_security_guide_package.adoc
@@ -27,6 +27,6 @@ For executing remediations you need to install the SCAP security guide package o
 | Debian 12
 
 | scap-security-guide-ubuntu
-| Ubuntu 20.04, Ubuntu 22.04
+| Ubuntu 22.04
 
 |===

--- a/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -100,22 +100,6 @@ The channels you need for this procedure are:
 
 | {ubuntu} 24.04 | ubuntu-2404-pool-amd64-uyuni | ubuntu-2404-amd64-main-uyuni | ubuntu-2404-amd64-main-updates-uyuni | ubuntu-2404-amd64-main-security-uyuni | ubuntu-2404-amd64-uyuni-client
 | {ubuntu} 22.04 | ubuntu-2204-pool-amd64-uyuni | ubuntu-2204-amd64-main-uyuni | ubuntu-2204-amd64-main-updates-uyuni | ubuntu-2204-amd64-main-security-uyuni | ubuntu-2204-amd64-uyuni-client
-| {ubuntu} 20.04 | ubuntu-2004-pool-amd64-uyuni | ubuntu-2004-amd64-main-uyuni | ubuntu-2004-amd64-main-updates-uyuni | ubuntu-2004-amd64-main-security-uyuni | ubuntu-2004-amd64-uyuni-client
-|===
-
-Version 20.04 also requires the Universe channels:
-
-[[ubuntu-universe-channels-cli-uyuni]]
-[cols="1,1", options="header"]
-.Ubuntu 20.04 Universe Channels - CLI
-|===
-
-| {ubuntu} 20.04           | {nbsp}
-| Universe Channel         | ubuntu-2004-amd64-universe-uyuni
-| Universe Updates Channel | ubuntu-2004-amd64-universe-updates-uyuni
-| Universe Security Updates Channel | ubuntu-2004-amd64-universe-security-uyuni
-| Universe Backports Channel | ubuntu-2004-amd64-universe-backports-uyuni
-
 |===
 
 ifndef::backend-pdf[]

--- a/modules/client-configuration/pages/supported-features-ubuntu.adoc
+++ b/modules/client-configuration/pages/supported-features-ubuntu.adoc
@@ -210,62 +210,50 @@ ifeval::[{uyuni-content} == true]
 |===
 
 | Feature
-| {ubuntu}{nbsp}20.04
 | {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
 
 | Client
 | {check}
 | {check}
-| {check}
 
 | System packages
-| Canonical
 | Canonical
 | Canonical
 
 | Registration
 | {check}
 | {check}
-| {check}
 
 | Install packages
-| {check}
 | {check}
 | {check}
 
 | Apply patches
 | {check}
 | {check}
-| {check}
 
 | Remote commands
-| {check}
 | {check}
 | {check}
 
 | System package states
 | {check}
 | {check}
-| {check}
 
 | System custom states
-| {check}
 | {check}
 | {check}
 
 | Group custom states
 | {check}
 | {check}
-| {check}
 
 | Organization custom states
 | {check}
 | {check}
-| {check}
 
 | System set manager (SSM)
-| {check}
 | {check}
 | {check}
 
@@ -277,140 +265,112 @@ ifeval::[{uyuni-content} == true]
 | Basic Virtual Guest Management {star}
 | {check}
 | {check}
-| {check}
 
 | Advanced Virtual Guest Management {star}
-| {check}
 | {check}
 | {check}
 
 | Virtual Guest Installation (Kickstart), as Host OS
 | {cross}
 | {cross}
-| {cross}
 
 | Virtual Guest Installation (image template), as Host OS
-| {check}
 | {check}
 | {check}
 
 | System deployment (PXE/Kickstart)
 | {cross}
 | {cross}
-| {cross}
 
 | System redeployment (Kickstart)
-| {cross}
 | {cross}
 | {cross}
 
 | Contact methods
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
-| {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
-| {check}
 | {check}
 | {check}
 
 | Action chains
 | {check}
 | {check}
-| {check}
 
 | Staging (pre-download of packages)
-| {check}
 | {check}
 | {check}
 
 | Duplicate package reporting
 | {check}
 | {check}
-| {check}
 
 | CVE auditing
-| {question}
 | {question}
 | {question}
 
 | SCAP auditing
 | {question}
 | {question}
-| {question}
 
 | Package verification
-| {cross}
 | {cross}
 | {cross}
 
 | Package locking
 | {check}
 | {check}
-| {check}
 
 | System locking
-| {cross}
 | {cross}
 | {cross}
 
 | System snapshot
 | {cross}
 | {cross}
-| {cross}
 
 | Configuration file management
-| {check}
 | {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
-| {check} Profiles supported, Sync not supported
 
 | Power management
-| {check}
 | {check}
 | {check}
 
 | Monitoring
 | {check}
 | {check}
-| {check}
 
 | Docker buildhost
-| {question}
 | {question}
 | {question}
 
 | Build Docker image with OS
 | {check}
 | {check}
-| {check}
 
 | Kiwi buildhost
-| {cross}
 | {cross}
 | {cross}
 
 | Build Kiwi image with OS
 | {cross}
 | {cross}
-| {cross}
 
 | Recurring Actions
-| {check}
 | {check}
 | {check}
 
 | AppStreams
 | N/A
 | N/A
-| N/A
 
 | Yomi
-| N/A
 | N/A
 | N/A
 

--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -295,7 +295,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {ubuntu} 24.04, 22.04, 20.04 (*)
+| {ubuntu} 24.04, 22.04
 | {check}
 | {cross}
 | {cross}
@@ -309,7 +309,7 @@ endif::[]
 
 [NOTE]
 ====
-(*) {debian} and {ubuntu} list the {x86_64} architecture as {amd64}.
+(*) {debian} lists the {x86_64} architecture as {amd64}.
 ====
 
 //EOL clients


### PR DESCRIPTION
# Description

Removed all mentions of Ubuntu 20.04.


# Target branches

Backport targets (edit as needed):

- master


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29559
- Related: https://github.com/SUSE/spacewalk/issues/26604
