### PR TITLE
removed bullets

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
@@ -13,17 +13,16 @@ endif::[]
 
 == Requirements and considerations
 
-* To migrate a SUSE Manager 4.3 Proxy to {productname} {productnumber}, you require a new machine with {sl-micro} {microversion} or {sles} {bci-mlm} and [literal]``mgrpxy`` installed.
+To migrate a SUSE Manager 4.3 Proxy to {productname} {productnumber}, you require a new machine with {sl-micro} {microversion} or {sles} {bci-mlm} and [literal]``mgrpxy`` installed.
 
-* An in-place migration from SUSE Manager 4.3 to {productnumber} requires host operating system reinstallation, regardless of whether the chosen host operating system is {sl-micro} {microversion} or {sles} {bci-mlm}.
+An in-place migration from SUSE Manager 4.3 to {productnumber} requires host operating system reinstallation, regardless of whether the chosen host operating system is {sl-micro} {microversion} or {sles} {bci-mlm}.
 
-* Before migrating from SUSE Manager 4.3 to {productnumber}, any existing traditional clients including the traditional proxies must be migrated to {salt}.
+Before migrating from SUSE Manager 4.3 to {productnumber}, any existing traditional clients including the traditional proxies must be migrated to {salt}.
 For more information about migrating traditional {productname} 4.3 clients to {salt} clients, see https://documentation.suse.com/suma/4.3/en/suse-manager/client-configuration/contact-methods-migrate-traditional.html.
 
-* Traditional contact protocol is no longer supported in {productname} 5.0 and later.
+Traditional contact protocol is no longer supported in {productname} 5.0 and later.
 
-* Before migrating a SUSE Manager 4.3 Proxy to {productname} {productnumber}, the SUSE Manager 4.3 Server
-needs to be migrated first, see xref:installation-and-upgrade:container-deployment/mlm/migrations/server/server-mlm-43-51.adoc[].
+Before migrating a SUSE Manager 4.3 Proxy to {productname} {productnumber}, the SUSE Manager 4.3 Server needs to be migrated first, see xref:installation-and-upgrade:container-deployment/mlm/migrations/server/server-mlm-43-51.adoc[].
 
 
 == Introduction


### PR DESCRIPTION
Removed bullets from normal para content. It appears very long list items with double sentences can break in CJK languages. I had not seen this behavior before so it could be a regression in Po4a. 