### PR TITLE
Use conditions for the API sample script links

### DIFF
--- a/modules/reference/pages/help/api-sample-scripts.adoc
+++ b/modules/reference/pages/help/api-sample-scripts.adoc
@@ -6,4 +6,9 @@
 The menu:Help:[API > Sample Scripts] section contains example API calls for you to copy.
 The scripts are written in Ruby, Perl, and Python.
 
+ifeval::[{mlm-content} == true]
 See: https://documentation.suse.com/multi-linux-manager/{productnumber}/api/docs/api/scripts.html
+endif::[]
+ifeval::[{uyuni-content} == true]
+See: https://www.uyuni-project.org/uyuni-docs-api/uyuni/api/scripts.html
+endif::[]


### PR DESCRIPTION
# Description

Without conditions, we were always pointing to documentation.suse.com, even for Uyuni.

Now it points to Uyuni:

<img width="1396" height="650" alt="imagen" src="https://github.com/user-attachments/assets/51771d72-5033-49a5-9ed5-fd1d130fc508" />

I can't, however, build for SUSE Multi Linux Manager:
```
$ ./uyuni-docs-helper -p uyuni -c "html-mlm-en" -l ../uyuni-docs/ 
[INFO] Output will be stored at ../uyuni-docs//build
[INFO] Pulling the latest container image ghcr.io/uyuni-project/uyuni-docs-helper:main...
Trying to pull ghcr.io/uyuni-project/uyuni-docs-helper:main...
Getting image source signatures
Copying blob ca893822f38d skipped: already exists  
Copying blob 3456d9d67a59 skipped: already exists  
Copying blob fe8f09573d3b skipped: already exists  
Copying blob f32515a1780e skipped: already exists  
Copying blob e78d47e8a2eb skipped: already exists  
Copying blob 89c8fda491cf skipped: already exists  
Copying blob 269146233876 skipped: already exists  
Copying blob aafa57e22ded skipped: already exists  
Copying blob 4f4fb700ef54 skipped: already exists  
Copying blob 64cfa2a65095 skipped: already exists  
Copying blob a7b6d95cfa19 skipped: already exists  
Copying blob 4f4fb700ef54 skipped: already exists  
Copying config 1df7c63a35 done   | 
Writing manifest to image destination
1df7c63a35072eeb01184bd74eb0fff9da0d731f10bd16039c7658f4157b9d10
[INFO] Bulding the doc...
====================================================================
 Git repository: A folder from outside the container is being used
 Product: uyuni
 Make command: html-mlm-en
====================================================================
```
And at the end:
```
cd /home/docs/uyuni-docs/
cd /home/docs/uyuni-docs/
cd ./translations/en && sed -i "s/^ # *\(name: *docs\)/\1/; s/^ # *\(title: *docs\)/\1/; s/^ *\(title: *Uyuni\)/#\1/; s/^ *\(name: *uyuni\)/#\1/;" /home/docs/uyuni-docs//translations/en/antora.yml
cd /home/docs/uyuni-docs/ && cd /home/docs/uyuni-docs//translations/en && DOCSEARCH_ENABLED=true SITE_SEARCH_PROVIDER=lunr LANG=en LC_ALL=en LC_ALL=en npx antora /home/docs/uyuni-docs//translations/en/mlm-site.yml --stacktrace
[10:54:32.278] FATAL (antora): antora.yml is missing a name in /home/docs/uyuni-docs/ (branch: api-doc-bug-link <worktree> | start path: translations/en)
    Cause: Error
        at loadComponentDescriptor (/home/docs/.nvm/versions/node/v24.13.1/lib/node_modules/@antora/site-generator/node_modules/@antora/content-aggregator/lib/aggregate-content.js:720:32)
        at /home/docs/.nvm/versions/node/v24.13.1/lib/node_modules/@antora/site-generator/node_modules/@antora/content-aggregator/lib/aggregate-content.js:455:52
        at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
        at async collectFilesFromStartPaths (/home/docs/.nvm/versions/node/v24.13.1/lib/node_modules/@antora/site-generator/node_modules/@antora/content-aggregator/lib/aggregate-content.js:444:18)
        at async Promise.all (index 0)
        at async Promise.all (index 0)
        at async generateSite (/home/docs/.nvm/versions/node/v24.13.1/lib/node_modules/@antora/site-generator/lib/generate-site.js:23:5)
        at async Command.parseAsync (/home/docs/.nvm/versions/node/v24.13.1/lib/node_modules/@antora/cli/node_modules/commander/lib/command.js:936:5)
make: *** [Makefile.en:56: html-mlm-en] Error 1
cp: cannot stat '/home/docs/uyuni-docs/build': No such file or directory
[ERROR] There were errors! Please review the log!
[ERROR] Depending on the error, there could also be build outputs at ../uyuni-docs//build
```

It doesn't tell what name is missing, but I doubt it `{mlm-content}` as we use it other places, and `{productnumber}` was used until now?

# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version): **Uyuni**
* Does this PR need to be backported? **NO**


# Links
- This PR tracks issue: **NONE**
- Related development PR **NONE**
