### PR TITLE
QE: fix redundant Tumbleweed in requirements table

### DIFF
--- a/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
+++ b/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
@@ -26,7 +26,7 @@ Do not use NFS for storage because it does not support SELinux file labeling.
 | Details
 | Recommendation
 
-| {tumbleweed}
+| Operating System
 | Clean installation, up-to-date
 | {tumbleweed}
 
@@ -80,7 +80,7 @@ Double the space if the server is an ISS Master.
 | Details
 | Recommendation
 
-| {tumbleweed}
+| Operating System
 | Clean installation, up-to-date
 | {tumbleweed}
 


### PR DESCRIPTION
# Description

I noticed that the "tumbleweed" is redundant ( written under both the "Software/Hardware" Column and "Recommendation" Column ). Having "Operating System" instead of "Tumleweed" in the "Software/Hardware" Column would match other generic names like CPU, RAM etc. 

This PR replaced the first-row label from {tumbleweed} to Operating System in both:
- Server Requirements table
- Proxy Requirements table

Before: 
<img width="1021" height="282" alt="image" src="https://github.com/user-attachments/assets/79a4d2fe-5bb2-4147-99ca-dfafc3137f0b" />

After: 
<img width="1027" height="331" alt="image" src="https://github.com/user-attachments/assets/d5ba52b8-51d5-410f-97de-75b5979b34f7" />



# Target branches

- master ( This PR ) 
- 5.1
- 5.0
- 4.3


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
