### PR TITLE
manager-5.1 - Use podman save with -m argument to save both images

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
@@ -91,7 +91,7 @@ podman pull registry.suse.com/suse/kea:2.6
 
 [source,shell]
 ----
-podman save -o formula-images.tar registry.suse.com/suse/bind:latest registry.suse.com/suse/kea:2.6
+podman save -m -o formula-images.tar registry.suse.com/suse/bind:latest registry.suse.com/suse/kea:2.6
 ----
 
 . Transfer the `formula-images.tar` file to your air-gapped system.

--- a/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -62,7 +62,7 @@ The images are available from `registry.opensuse.org`.
  +
  [source,shell]
  ----
- podman save -o formula-images.tar registry.opensuse.org/opensuse/bind:latest registry.opensuse.org/opensuse/kea:latest
+ podman save -m -o formula-images.tar registry.opensuse.org/opensuse/bind:latest registry.opensuse.org/opensuse/kea:latest
  ----
  . Transfer the `formula-images.tar` file to your air-gapped system.
  . Load the images on the air-gapped system:


### PR DESCRIPTION
# Description

Use podman save with -m argument to save both images

# Target branches

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4851
- 5.1 (this PR)


# Links
- This PR tracks issue https://bugzilla.suse.com/show_bug.cgi?id=1261297 / https://github.com/SUSE/spacewalk/issues/30192
