### PR TITLE
master - Use podman save with -m argument to save both images

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
@@ -86,7 +86,7 @@ podman pull registry.suse.com/suse/kea:2.6
 
 [source,shell]
 ----
-podman save -o formula-images.tar registry.suse.com/suse/bind:latest registry.suse.com/suse/kea:2.6
+podman save -m -o formula-images.tar registry.suse.com/suse/bind:latest registry.suse.com/suse/kea:2.6
 ----
 
 . Transfer the `formula-images.tar` file to your air-gapped system.

--- a/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -22,7 +22,7 @@ You can easily pull container images using [systemitem]``Podman`` or [systemitem
 .Podman
 ----
 podman pull registry.opensuse.org/uyuni/server:latest registry.opensuse.org/uyuni/server-postgresql:latest
-podman save --output images.tar registry.opensuse.org/uyuni/server:latest registry.opensuse.org/uyuni/server-postgresql:latest
+podman save -m --output images.tar registry.opensuse.org/uyuni/server:latest registry.opensuse.org/uyuni/server-postgresql:latest
 ----
 +
 .Docker


### PR DESCRIPTION
# Description

Use podman save with -m argument to save both images

# Target branches

Backport targets (edit as needed):

- master (this PR)
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/4850


# Links
- This PR tracks issue https://bugzilla.suse.com/show_bug.cgi?id=1261297 / https://github.com/SUSE/spacewalk/issues/30192
