### PR TITLE
5.1 - Updated table for OES 25.4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added support for Open Enterprise Server 25.4
 - Clarified how to get PTF images in air-gapped setup in Installation and 
   Upgrade Guide (bsc#1261307)
 - SUSE Multi-Linux Support does not support autoinstallation (bsc#1259261)

--- a/modules/client-configuration/pages/clients-oes.adoc
+++ b/modules/client-configuration/pages/clients-oes.adoc
@@ -1,7 +1,7 @@
 [[clients-oes]]
 = Registering {oes} Clients
 :description: Learn about registering Open Enterprise Server clients and configuring software channels for synchronization
-:revdate: 2025-02-06
+:revdate: 2026-04-20
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -34,6 +34,9 @@ The products you need for this procedure are:
 
 | OS Version
 | Product Name
+
+| {oes} 25.4
+| Open Enterprise Server 25.4 x86_64
 
 | {oes} 24.4
 | Open Enterprise Server 24.4 x86_64
@@ -70,6 +73,10 @@ The channels you need for this procedure are:
 | OS Version
 | Base Channel
 | Name
+
+| {oes} 25.4
+| oes25.4-pool-x86_64
+| OES25.4-Pool for x86_64
 
 | {oes} 24.4
 | oes24.4-pool-x86_64

--- a/modules/client-configuration/pages/supported-features-oes.adoc
+++ b/modules/client-configuration/pages/supported-features-oes.adoc
@@ -1,7 +1,7 @@
 [[supported-features-oes]]
 = Supported {oes} Features
 :description: Find available features on Open Enterprise Server clients to determine which capabilities are supported by Micro Focus or OpenText
-:revdate: 2024-12-12
+:revdate: 2026-04-20
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -24,159 +24,197 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {oes} Operating Systems
 |===
 
 | Feature
+| {oes}{nbsp}25.4
 | {oes}{nbsp}24.4
 | {oes}{nbsp}23.4
 
 | Client
 | {check}
 | {check}
+| {check}
 
 | System packages
+| {suse}
 | {suse}
 | {suse}
 
 | Registration
 | {check}
 | {check}
+| {check}
 
 | Install packages
+| {check}
 | {check}
 | {check}
 
 | Apply patches
 | {check}
 | {check}
+| {check}
 
 | Remote commands
+| {check}
 | {check}
 | {check}
 
 | System package states
 | {check}
 | {check}
+| {check}
 
 | System custom states
+| {check}
 | {check}
 | {check}
 
 | Group custom states
 | {check}
 | {check}
+| {check}
 
 | Organization custom states
+| {check}
 | {check}
 | {check}
 
 | System set manager (SSM)
 | {check}
 | {check}
+| {check}
 
 | Product migration
+| {check}
 | {check}
 | {check}
 
 | System deployment (PXE/{ay})
 | {check}
 | {check}
+| {check}
 
 | System redeployment ({ay})
+| {check}
 | {check}
 | {check}
 
 | Contact methods
 | {cross}
 | {cross}
+| {cross}
 
 | Works with {productname} Proxy
+| {check}
 | {check}
 | {check}
 
 | Action chains
 | {check}
 | {check}
+| {check}
 
 | Staging (pre-download of packages)
+| {check}
 | {check}
 | {check}
 
 | Duplicate package reporting
 | {check}
 | {check}
+| {check}
 
 | CVE auditing
+| {check}
 | {check}
 | {check}
 
 | SCAP auditing
 | {check}
 | {check}
+| {check}
 
 | Package locking
+| {check}
 | {check}
 | {check}
 
 | System locking
 | {cross}
 | {cross}
+| {cross}
 
 | Maintenance Windows
+| {check}
 | {check}
 | {check}
 
 | System snapshot
 | {cross}
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 | {check}
 
 | Monitoring server
 | {check}
 | {check}
+| {check}
 
 | Monitored clients
+| {check}
 | {check}
 | {check}
 
 | Docker buildhost
 | {check}
 | {check}
+| {check}
 
 | Build Docker image with OS
+| {check}
 | {check}
 | {check}
 
 | Kiwi buildhost
 | {question}
 | {question}
+| {question}
 
 | Build Kiwi image with OS
+| {question}
 | {question}
 | {question}
 
 | Recurring Actions
 | {check}
 | {check}
+| {check}
 
 | AppStreams
 | N/A
 | N/A
+| N/A
 
 | Yomi
+| {cross}
 | {cross}
 | {cross}
 


### PR DESCRIPTION
# Description

5.1.3 and Uyuni will be coming with OES 25.04 support. This PR updates the column.


# Target branches

* Which product version this PR applies to (Uyuni, 5.1, 5.2).  T

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4847
- 5.1



# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
