### PR TITLE
manager-5.1 - Document Debian 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Document Debian 13
 - Added support for Open Enterprise Server 25.4
 - Clarified how to get PTF images in air-gapped setup in Installation and 
   Upgrade Guide (bsc#1261307)

--- a/modules/client-configuration/pages/clients-debian.adoc
+++ b/modules/client-configuration/pages/clients-debian.adoc
@@ -19,7 +19,7 @@ ifeval::[{mlm-content} == true]
 [IMPORTANT]
 ====
 * {debian} repository URLs are available from {scclongform}.
-* Packages and metadata are provided by Debian, not by {suse}.
+* Packages and metadata are provided by {debian}, not by {suse}.
 * For supported products, see the release notes and the support table at xref:client-configuration:supported-features-debian.adoc[].
 ====
 endif::[]
@@ -55,11 +55,12 @@ The products you need for this procedure are:
 
 [[debian-channels-wizard]]
 [cols="1,1", options="header"]
-.Debian Products - WebUI
+.{debian} Products - WebUI
 |===
 
 | OS Version  | Product Name
-| {debian} 12 | Debian 12
+| {debian} 12 | {debian} 12
+| {debian} 13 | {debian} 13
 |===
 
 ifndef::backend-pdf[]
@@ -75,11 +76,12 @@ The channels you need for this procedure are:
 
 [[debian-channels-cli]]
 [cols="1,1", options="header"]
-.Debian Channels - CLI
+.{debian} Channels - CLI
 |===
 
 | OS Version  | Product Name
 | {debian} 12 | debian-12-pool-amd64
+| {debian} 13 | debian-13-pool-amd64
 |===
 
 ifndef::backend-pdf[]
@@ -99,7 +101,7 @@ The channels you need for this procedure are:
 
 [[debian-channels-cli]]
 [cols="1,1,1,1,1", options="header"]
-.Debian Channels - CLI
+.{debian} 12 Channels - CLI
 |===
 
 | OS Version
@@ -113,6 +115,31 @@ The channels you need for this procedure are:
 | debian-12-amd64-uyuni-client
 | debian-12-amd64-main-updates-uyuni
 | debian-12-amd64-main-security-uyuni
+
+|===
+
+[cols="1,1", options="header"]
+.{debian} 13 Channels - CLI
+|===
+
+| Channel description         | Channel name
+| Main                        | debian-13-pool-amd64-uyuni
+| Main Updates                | debian-13-amd64-main-updates-uyuni
+| Main Security               | debian-13-amd64-main-security-uyuni
+| Main Backports              | debian-13-amd64-main-backports-uyuni
+| Contrib                     | debian-13-amd64-contrib-uyuni
+| Contrib Updates             | debian-13-amd64-contrib-updates-uyuni
+| Contrib Security            | debian-13-amd64-contrib-security-uyuni
+| Contrib Backports           | debian-13-amd64-contrib-backports-uyuni
+| Non-Free                    | debian-13-amd64-non-free-uyuni
+| Non-Free Updates            | debian-13-amd64-non-free-updates-uyuni
+| Non-Free Security           | debian-13-amd64-non-free-security-uyuni
+| Non-Free Backports          | debian-13-amd64-non-free-backports-uyuni
+| Non-Free-Firmware           | debian-13-amd64-non-free-firmware-uyuni
+| Non-Free-Firmware Updates   | debian-13-amd64-non-free-firmware-updates-uyuni
+| Non-Free-Firmware Security  | debian-13-amd64-non-free-firmware-security-uyuni
+| Non-Free-Firmware Backports | debian-13-amd64-non-free-firmware-backports-uyuni
+| Client Tools                | debian-13-amd64-uyuni-client
 
 |===
 

--- a/modules/client-configuration/pages/supported-features-debian.adoc
+++ b/modules/client-configuration/pages/supported-features-debian.adoc
@@ -23,122 +23,180 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1", options="header"]
+[cols="1,1,1", options="header"]
 .Supported Features on {debian} Operating Systems
 |===
 
 | Feature
 | {debian}{nbsp}12
+| {debian}{nbsp}13
 
 | Client
+| {check}
 | {check}
 
 | System packages
 | {debian} Community
+| {debian} Community
 
 | Registration
+| {check}
 | {check}
 
 | Install packages
 | {check}
+| {check}
 
 | Apply patches
+| {question}
 | {question}
 
 | Remote commands
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 
 | System custom states
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 
 | Organization custom states
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 
 | Product migration
 | N/A
+| N/A
+
+| Basic Virtual Guest Management {star}
+| {check}
+| {check}
+
+| Advanced Virtual Guest Management {star}
+| {check}
+| {check}
+
+| Virtual Guest Installation (Kickstart), as Host OS
+| {check}
+| {check}
+
+| Virtual Guest Installation (image template), as Host OS
+| {check}
+| {check}
 
 | System deployment (PXE/Kickstart)
-| {cross}
+| {check}
+| {check}
 
 | System redeployment (Kickstart)
+| {cross}
 | {cross}
 
 | Contact methods
 | {check} ZeroMQ, Salt-SSH
+| {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
+| {check}
 | {check}
 
 | Action chains
 | {check}
+| {check}
 
 | Staging (pre-download of packages)
+| {check}
 | {check}
 
 | Duplicate package reporting
 | {check}
+| {check}
 
 | CVE auditing
+| {question}
 | {question}
 
 | SCAP auditing
 | {question}
+| {question}
+
+| Package verification
+| {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 
 | System locking
 | {cross}
+| {cross}
 
 | Maintenance Windows
+| {check}
 | {check}
 
 | System snapshot
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 
 | Monitoring server
 | {cross}
+| {cross}
 
 | Monitoring clients
+| {check}
 | {check}
 
 | Docker buildhost
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {salt}
 | {salt}
 
 | Kiwi buildhost
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 
 | Recurring Actions
 | {check}
+| {check}
 
 | AppStreams
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 
 |===

--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -113,7 +113,7 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {check}
 
-| {debian} 12 (*)
+| {debian} 12, 13 (*)
 | {check}
 | {cross}
 | {cross}
@@ -151,6 +151,165 @@ ifeval::[{mlm-content} == true]
 
 |===
 endif::[]
+
+
+
+
+ifeval::[{uyuni-content} == true]
+[[uyuni.supported.clients]]
+[cols="4,1,1,1,1,1", options="header"]
+.Supported Client Systems and Architectures
+|===
+| Operating System
+| {x86_64}
+| {ppc64le}
+| {ibmz}
+| {aarch64}
+| {arm64} / {armhf}
+
+| {sle} 16, 15, 12
+| {check}
+| {check}
+| {check}
+| {check}
+| {cross}
+
+| {sles} for SAP 16, 15, 12
+| {check}
+| {check}
+| {cross}
+| {cross}
+| {cross}
+
+| {sle-micro}
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {sl-micro}
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {leap} Micro
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {opensuse} {tumbleweed}
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {leap} 16
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {leap} 15
+| {check}
+| {check}
+| {check}
+| {check}
+| {cross}
+
+| {alibabaclo} 2
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {almalinux} 9, 8
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {amazon} 2003, 2
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {centos} 7
+| {check}
+| {check}
+| {cross}
+| {check}
+| {cross}
+
+| {debian} 12, 13 (*)
+| {check}
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+
+| {openeuler} 22.03
+| {check}
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+
+| {oes} 24.4, 23.4
+| {check}
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+
+| {oracle} 9, 8, 7
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {raspberrypios} 12, 13
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+| {check}
+
+| {rhel} 9, 8, 7
+| {check}
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+
+| {rocky} 9, 8
+| {check}
+| {cross}
+| {cross}
+| {check}
+| {cross}
+
+| {ubuntu} 24.04, 22.04
+| {check}
+| {cross}
+| {cross}
+| {cross}
+| {cross}
+
+|===
+endif::[]
+
 
 
 [NOTE]


### PR DESCRIPTION
# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.


# Description

Short summary of why you created this PR (if you added documentation, please add any relevant diagram).


# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master https://github.com/uyuni-project/uyuni-docs/pull/4568
- 5.1 (this PR)


# Links
- https://github.com/SUSE/spacewalk/issues/29116
- https://github.com/uyuni-project/uyuni/pull/11279
