### PR TITLE
Update minimal RKE2 user permissions for server and proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Update minimal RKE2 user permissions for server and proxy
+- Updated minimal RKE2 user permissions for server and proxy in Installation and Upgrade Guide
 - Fixed build errors in PDFs
 - Changed command for updating Uyuni containers in Installation and Upgrade Guide
 - Updated uyuni-tools installation in Installation and Upgrade Guide

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update minimal RKE2 user permissions for server and proxy
 - Fixed build errors in PDFs
 - Changed command for updating Uyuni containers in Installation and Upgrade Guide
 - Updated uyuni-tools installation in Installation and Upgrade Guide

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
@@ -247,7 +247,7 @@ Add the following to the rules of the previously defined role:
   verbs: ["*"]
 ----
 
-If instead the Gateway API is used, add the following to the rules of the previously defined role:
+If Gateway API is used instead, add the following to the rules of the previously defined role:
 
 [source,yaml]
 ----

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
@@ -32,7 +32,8 @@ Installing the {kube} cluster and configuring it is out of the scope of this doc
 
 The cluster is assumed to be ready to be used with a user having rights on a namespace dedicated to {productname}.
 
-If there isn't one defined yet, a [literal]``Role`` and [literal]``RoleBinding`` with minimum rights required to deploy [literal]``proxy-helm`` would look like the following:
+Create [literal]``Role`` and [literal]``RoleBinding`` if they do not exist already. 
+The minimum rights required to deploy [literal]``proxy-helm`` are defined as:
 
 [source,yaml]
 ----

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
@@ -237,7 +237,7 @@ spec:
         containerPort: 4506
 ----
 
-If Traefik is used as the ingress controller, the user needs access to additional resources.
+If Traefik is used as the Ingress controller, the user needs access to additional resources.
 Add the following to the rules of the previously defined role:
 
 [source,yaml]

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
@@ -32,6 +32,42 @@ Installing the {kube} cluster and configuring it is out of the scope of this doc
 
 The cluster is assumed to be ready to be used with a user having rights on a namespace dedicated to {productname}.
 
+If there isn't one defined yet, a [literal]``Role`` and [literal]``RoleBinding`` with minimum rights required to deploy [literal]``proxy-helm`` would look like the following:
+
+[source,yaml]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: example-resource-manager
+  namespace: $NAMESPACE
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "services", "secrets", "configmaps", "persistentvolumeclaims"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["*"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: example-resource-manager-binding
+  namespace: $NAMESPACE
+subjects:
+- kind: User
+  name: $USERNAME
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: example-resource-manager
+  apiGroup: rbac.authorization.k8s.io
+----
+
+
 [IMPORTANT]
 ====
 This guide assumes the reader knows how to work with {kube}: the concepts will not be explained here as they are extensively documented in the official {kube} documentation.
@@ -198,6 +234,25 @@ spec:
         protocol: TCP
         hostPort: 4506
         containerPort: 4506
+----
+
+If Traefik is used as the ingress controller, the user needs access to additional resources.
+Add the following to the rules of the previously defined role:
+
+[source,yaml]
+----
+- apiGroups: ["traefik.io", "traefik.containo.us"]
+  resources: ["ingressroutetcps"]
+  verbs: ["*"]
+----
+
+If instead the Gateway API is used, add the following to the rules of the previously defined role:
+
+[source,yaml]
+----
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["gateways", "httproutes", "tcproutes"]
+  verbs: ["*"]
 ----
 
 TFTP is complex to expose from a {kube} pod due to the nature of the protocol: the TFTP server receives requests on port 69, but negotiates another random port to continue.

--- a/modules/installation-and-upgrade/pages/server-kubernetes-deployment.adoc
+++ b/modules/installation-and-upgrade/pages/server-kubernetes-deployment.adoc
@@ -39,10 +39,10 @@ metadata:
   namespace: $NAMESPACE
 rules:
 - apiGroups: [""]
-  resources: ["pods", "pods/log", "services", "secrets", "configmaps", "serviceaccounts", "persistentvolumeclaims"]
+  resources: ["pods", "pods/log", "services", "secrets", "configmaps", "persistentvolumeclaims"]
   verbs: ["*"]
 - apiGroups: ["apps"]
-  resources: ["deployments", "statefulsets"]
+  resources: ["deployments"]
   verbs: ["*"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
@@ -308,6 +308,15 @@ Add the following to the rules of the previously defined role:
 ----
 - apiGroups: ["traefik.io", "traefik.containo.us"]
   resources: ["ingressroutetcps", "middlewares"]
+  verbs: ["*"]
+----
+
+If instead the Gateway API is used, add the following to the rules of the previously defined role:
+
+[source,yaml]
+----
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources: ["gateways", "httproutes", "tcproutes"]
   verbs: ["*"]
 ----
 

--- a/modules/installation-and-upgrade/pages/server-kubernetes-deployment.adoc
+++ b/modules/installation-and-upgrade/pages/server-kubernetes-deployment.adoc
@@ -311,7 +311,7 @@ Add the following to the rules of the previously defined role:
   verbs: ["*"]
 ----
 
-If instead the Gateway API is used, add the following to the rules of the previously defined role:
+If Gateway API is used instead, add the following to the rules of the previously defined role:
 
 [source,yaml]
 ----


### PR DESCRIPTION
# Description

Consolidated the user permissions required to deploy a server and proxy on RKE2.
Also added a small section for Gateway API rules.

# Target branches

Backport targets (edit as needed):

- master