### PR TITLE
5.0 - Fix for partials links

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-suma.adoc
@@ -106,7 +106,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-micro-pro
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-micro-proxy-host.adoc[leveloffset=+1]
+include::../../../partials/container-deployment/prepare-micro-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/suma/proxy-deployment-suma.adoc#deploy-suma-proxy-persistent-storage[].
@@ -117,7 +117,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-sles-prox
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-sles-proxy-host.adoc[leveloffset=+1]
+include::../../../partials/container-deployment/prepare-sles-proxy-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/suma/proxy-deployment-suma.adoc#deploy-suma-proxy-persistent-storage[].
@@ -167,7 +167,7 @@ include::installation-and-upgrade:partial$container-deployment/actkey-bootstrap-
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
+include::../../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
 endif::[]
 
 // (New) Snippet for bootsrapping the proxy
@@ -177,7 +177,7 @@ include::installation-and-upgrade:partial$container-deployment/bootstrap-proxy-c
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/bootstrap-proxy-client.adoc[]
+include::../../../partials/container-deployment/bootstrap-proxy-client.adoc[]
 endif::[]
 
 ifndef::backend-pdf[]
@@ -185,7 +185,7 @@ include::installation-and-upgrade:partial$container-deployment/generate_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/generate_proxy_config.adoc[]
+include::../../../partials/container-deployment/generate_proxy_config.adoc[]
 endif::[]
 
 ifndef::backend-pdf[]
@@ -193,7 +193,7 @@ include::installation-and-upgrade:partial$container-deployment/transfer_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/transfer_proxy_config.adoc[]
+include::../../../partials/container-deployment/transfer_proxy_config.adoc[]
 endif::[]
 
 ifndef::backend-pdf[]
@@ -201,7 +201,7 @@ include::installation-and-upgrade:partial$container-deployment/ensure-proxy-prer
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/ensure-proxy-prerequisites.adoc[]
+include::../../../partials/container-deployment/ensure-proxy-prerequisites.adoc[]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-vm-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-vm-suma.adoc
@@ -146,7 +146,7 @@ include::installation-and-upgrade:partial$container-deployment/register-proxy-su
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/register-proxy-suma.adoc[]
+include::../../../partials/container-deployment/register-proxy-suma.adoc[]
 endif::[]
 
 
@@ -155,7 +155,7 @@ include::installation-and-upgrade:partial$container-deployment/actkey-bootstrap-
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
+include::../../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
 endif::[]
 
 
@@ -164,7 +164,7 @@ include::installation-and-upgrade:partial$container-deployment/generate_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/generate_proxy_config.adoc[]
+include::../../../partials/container-deployment/generate_proxy_config.adoc[]
 endif::[]
 
 
@@ -173,7 +173,7 @@ include::installation-and-upgrade:partial$container-deployment/transfer_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/transfer_proxy_config.adoc[]
+include::../../../partials/container-deployment/transfer_proxy_config.adoc[]
 endif::[]
 
 
@@ -182,7 +182,7 @@ include::installation-and-upgrade:partial$container-deployment/start_proxy.adoc[
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/start_proxy.adoc[]
+include::../../../partials/container-deployment/start_proxy.adoc[]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-vmdk-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-deployment-vmdk-suma.adoc
@@ -102,7 +102,7 @@ include::installation-and-upgrade:partial$container-deployment/register-proxy-su
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/register-proxy-suma.adoc[]
+include::../../../partials/container-deployment/register-proxy-suma.adoc[]
 endif::[]
 
 
@@ -111,7 +111,7 @@ include::installation-and-upgrade:partial$container-deployment/actkey-bootstrap-
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
+include::../../../partials/container-deployment/actkey-bootstrap-proxy-suma.adoc[]
 endif::[]
 
 ifndef::backend-pdf[]
@@ -119,7 +119,7 @@ include::installation-and-upgrade:partial$container-deployment/generate_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/generate_proxy_config.adoc[]
+include::../../../partials/container-deployment/generate_proxy_config.adoc[]
 endif::[]
 
 
@@ -128,7 +128,7 @@ include::installation-and-upgrade:partial$container-deployment/transfer_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/transfer_proxy_config.adoc[]
+include::../../../partials/container-deployment/transfer_proxy_config.adoc[]
 endif::[]
 
 
@@ -137,7 +137,7 @@ include::installation-and-upgrade:partial$container-deployment/start_proxy.adoc[
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/start_proxy.adoc[]
+include::../../../partials/container-deployment/start_proxy.adoc[]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-k3s-deployment-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/proxy-k3s-deployment-suma.adoc
@@ -47,7 +47,7 @@ include::installation-and-upgrade:partial$container-deployment/generate_proxy_co
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/generate_proxy_config.adoc[tags=generate-proxy-config-section]
+include::../../../partials/container-deployment/generate_proxy_config.adoc[tags=generate-proxy-config-section]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/server-deployment-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/server-deployment-suma.adoc
@@ -121,7 +121,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-micro-hos
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-micro-host.adoc[leveloffset=+1]
+include::../../../partials/container-deployment/prepare-micro-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/suma/server-deployment-suma.adoc#deploy-suma-server-persistent-storage[].
@@ -133,7 +133,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-sles-host
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-sles-host.adoc[leveloffset=+1]
+include::../../../partials/container-deployment/prepare-sles-host.adoc[leveloffset=+1]
 endif::[]
 
 To continue with deployment, see xref:installation-and-upgrade:container-deployment/suma/server-deployment-suma.adoc#deploy-suma-server-persistent-storage[].

--- a/modules/installation-and-upgrade/pages/container-deployment/suma/server-migration-suma.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/suma/server-migration-suma.adoc
@@ -94,7 +94,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-micro-hos
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-micro-host.adoc[leveloffset=+2]
+include::../../../partials/container-deployment/prepare-micro-host.adoc[leveloffset=+2]
 endif::[]
 
 [[deploy-sles-host]]
@@ -103,7 +103,7 @@ include::installation-and-upgrade:partial$container-deployment/prepare-sles-host
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/container-deployment/prepare-sles-host.adoc[leveloffset=+2]
+include::../../../partials/container-deployment/prepare-sles-host.adoc[leveloffset=+2]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-proxy-containers.adoc
@@ -66,7 +66,7 @@ include::installation-and-upgrade:partial$snippet-check-rpmnew-rpmsave.adoc[]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../../../partials/snippet-check-rpmnew-rpmsave.adoc[]
+include::../../partials/snippet-check-rpmnew-rpmsave.adoc[]
 endif::[]
 
 ____

--- a/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -40,7 +40,7 @@ include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+include::../../partials/snippet-ptf-loss-during-upgrade.adoc[]
 endif::[]
 
 +
@@ -69,7 +69,7 @@ include::installation-and-upgrade:partial$snippet-check-rpmnew-rpmsave.adoc[]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../../../partials/snippet-check-rpmnew-rpmsave.adoc[]
+include::../../partials/snippet-check-rpmnew-rpmsave.adoc[]
 endif::[]
 
 ____
@@ -89,7 +89,7 @@ include::installation-and-upgrade:partial$snippet-ptf-loss-during-upgrade.adoc[]
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../../../../partials/snippet-ptf-loss-during-upgrade.adoc[]
+include::../../partials/snippet-ptf-loss-during-upgrade.adoc[]
 endif::[]
 
 ----


### PR DESCRIPTION
Fixes for links to partials that were showing as errors during building process.

Covers part of the issues as https://github.com/uyuni-project/uyuni-docs/pull/4875.