### PR TITLE
5.1 - Add link for alternative proxy creation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added link to proxy creation from client to an existing document in Installation
+  and Upgrade Guide
 - Updated features table for EL 10 based distributions
 - Document Debian 13
 - Added support for Open Enterprise Server 25.4

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -1,5 +1,5 @@
 [[installation-proxy-containers]]
-= {productname} {productnumber} Proxy Deployment
+= {productname} Proxy Deployment
 :description: Configure a SUSE Multi-Linux Manager 5.1 proxy container on SL Micro or SLES using this deployment guide for a fully functional setup
 :revdate: 2025-06-26
 :page-revdate: {revdate}
@@ -28,11 +28,11 @@ It is possible to convert existing client to proxy.
 For more information, see xref:installation-and-upgrade:container-deployment/mlm/proxy-conversion-from-client-mlm.adoc[].
 ====
 
-To successfully deploy, you will perform the following actions:
+To successfully deploy a new proxy, follow the procedure:
 
 
 // Add certificate tasks item
-.Procedure: Deploying Proxy
+.Procedure: Deploying proxy
 [role=procedure]
 _____
 
@@ -69,21 +69,21 @@ The container host supplies the necessary resources such as CPU, memory, and sto
 ====
 
 
-== Hardware Requirements for the Proxy
+== Hardware requirements for the proxy
 
 
 For more information about hardware requirements for deploying {productname} Proxy, see xref:installation-and-upgrade:hardware-requirements.adoc#proxy-hardware-requirements[].
 
 
 
-== Synchronize the Parent and Proxy Extension Child Channels
+== Synchronize the parent and proxy extension child channels
 
 This section presumes that you have already entered your organization credentials under the menu:Admin[Setup Wizard > Organization Credentials] in the server's {webui}.
 Products are listed on the menu:Admin[Setup Wizard > Products] page.
 This channel must be fully synchronized on the server, with the child channel [systemitem]``Proxy`` as an extension option selected.
 
 
-.Procedure: Synchronizing the Parent Channel and Proxy Extension
+.Procedure: Synchronizing the parent channel and proxy extension
 [role=procedure]
 _____
 
@@ -104,7 +104,7 @@ _____
 
 
 [[deploy-mlm-proxy-host]]
-==  Prepare {productname} Proxy Host
+==  Prepare the {productname} proxy host
 
 In the following subsections, you either prepare the proxy host with {sle-micro} or {sles}.
 
@@ -135,7 +135,7 @@ To continue with deployment, see xref:installation-and-upgrade:container-deploym
 
 
 [[deploy-mlm-proxy-persistent-storage]]
-== Configure Custom Persistent Storage
+== Configure custom persistent storage
 
 Configuring persistent storage is optional, but it is the only way to avoid serious trouble with container full disk conditions.
 If custom persistent storage is required for your infrastructure, use the [command]``mgr-storage-proxy`` tool.
@@ -216,7 +216,7 @@ endif::[]
 
 
 [[proxy-setup-containers-transfer-start]]
-== Start the {productname} Proxy
+== Start the {productname} proxy
 
 Container can now be started with the [literal]`mgrpxy` command:
 
@@ -255,7 +255,7 @@ _____
 
 
 
-== Use a Custom Container Image for a Service
+== Use a custom container image for a service
 
 By default, the {productname} Proxy suite is configured to use the same image version and registry path for each of its services.
 However, it is possible to override the default values for a specific service using the install parameters ending with [literal]``-tag`` and [literal]``-image``.

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -205,7 +205,7 @@ include::installation-and-upgrade:partial$snippet-ensure-proxy-prerequisites.ado
 endif::[]
 
 ifdef::backend-pdf[]
-include::../../partials/snippet-ensure-proxy-prerequisites.adoc[]
+include::../../../partials/snippet-ensure-proxy-prerequisites.adoc[]
 endif::[]
 
 

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -22,6 +22,11 @@ This guide presumes you have already successfully deployed a {productname} {prod
 We are working on managing it as Salt SSH client ([systemitem]``salt-ssh`` contact method), too.
 ====
 
+[NOTE]
+====
+It is possible to convert existing client to proxy.
+For more information, see xref:installation-and-upgrade:container-deployment/mlm/proxy-conversion-from-client-mlm.adoc[].
+====
 
 To successfully deploy, you will perform the following actions:
 

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -1,7 +1,7 @@
 [[installation-proxy-containers]]
 = {productname} Proxy Deployment
 :description: Configure a SUSE Multi-Linux Manager 5.1 proxy container on SL Micro or SLES using this deployment guide for a fully functional setup
-:revdate: 2025-06-26
+:revdate: 2026-04-29
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg


### PR DESCRIPTION
Added link to converting the existing client to proxy to doc.

Plus some minor random fixes.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4882
- 5.1

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30476 / https://bugzilla.suse.com/show_bug.cgi?id=1261325