### PR TITLE
Selection of smaller changes referencing version 5.2 implicitly

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 
 = {productname} Documentation
-:revdate: 2025-04-30
+:revdate: 2026-04-29
 :page-revdate: {revdate}
 
 ifeval::[{mlm-content} == true]
@@ -21,7 +21,7 @@ ifeval::[{mlm-content} == true]
 We are currently in the process of updating and enhancing the [.currentrel]**{productnumber}** documentation.
 Please note that this documentation is currently in **draft** form and should be considered a work in progress (WIP).
 
-The final release of version 5.1 is expected mid 2025. Until then, content may evolve, and certain sections may be incomplete or subject to change.
+The final release of version 5.2 is expected mid 2026. Until then, content may evolve, and certain sections may be incomplete or subject to change.
 
 Your Feedback Matters:
 We welcome and appreciate your feedback. If you encounter unclear information, gaps in coverage, or have suggestions for improvement, please let us know. Your input is invaluable in helping us deliver accurate and useful documentation.

--- a/modules/client-configuration/pages/autoinst-pxeboot.adoc
+++ b/modules/client-configuration/pages/autoinst-pxeboot.adoc
@@ -1,12 +1,12 @@
 [[autoinst-pxeboot]]
 = Install via the Network (PXE Boot)
 :description: Configure a network boot installation via PXE using DHCP to provide the client with an IP address, mask, installation server, and bootloader file for automatic
-:revdate: 2026-03-02
+:revdate: 2026-04-29
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
-:page-product-version: 5.12
+:page-product-version: 5.2
 
 
 During a network boot installation:

--- a/modules/common-workflows/pages/workflow-customize-apache-config.adoc
+++ b/modules/common-workflows/pages/workflow-customize-apache-config.adoc
@@ -1,12 +1,12 @@
 [[workflow-customize-apache-configuration]]
 = Customize Apache Configuration
 :description: Adding custom configuration to the Apache HTTP server within a containerized environment.
-:revdate: 2025-02-02
+:revdate: 2026-04-29
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
-:page-product-version: 5.1
+:page-product-version: 5.2
 
 
 This workflow shows you how to add custom configuration to {productname} components, specifically the Apache HTTP server, within a containerized environment. 

--- a/modules/reference/pages/command-line-tools.adoc
+++ b/modules/reference/pages/command-line-tools.adoc
@@ -1,6 +1,6 @@
 [[ref-cli]]
 = Command Line Tools
-:revdate: 2024-06-24
+:revdate: 2026-04-29
 :page-revdate: {revdate}
 
 [IMPORTANT]
@@ -20,10 +20,6 @@ Manage package and channel synchronization with:
 Manage bootstrapping with:
 
 * ``mgr-create-bootstrap-repo``
-
-Manage the database with:
-
-* ``smdba``
 
 
 Some of these command line tools are installed by default.

--- a/parameters.yml
+++ b/parameters.yml
@@ -314,7 +314,7 @@ asciidoc:
   - attribute: sl-micro
     value: 'SL Micro'
   - attribute: microversion
-    value: '6.1'
+    value: '6.2'
   - attribute: microversionforuyuni
     value: '5.5'
   - attribute: leap


### PR DESCRIPTION
This is partial re-do of PR #4880.
It is done due to broken documentation building following the merging of the PR.
The changes are consequently being applied in smaller chunks.

This change deals with some minor changes that include implicit use of the product version.
