### PR TITLE
Added changelog for old changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Adjusted the URLs and references for 5.2
+- Removed the smdba references
+- Removed the instructions for 4.3 proxy/rbs to 5.1 proxy/rbs
 - Updated minimal RKE2 user permissions for server and proxy in Installation and Upgrade Guide
 - Fixed build errors in PDFs
 - Changed command for updating Uyuni containers in Installation and Upgrade Guide


### PR DESCRIPTION
This is partial re-do of PR #4880.
It is done due to broken documentation building following the merging of the PR.
The changes are consequently being applied in smaller chunks.

This change adds the Changelog from the original PR.
