### PR TITLE
Update parameters and fix retail build on Uyuni

### DIFF
--- a/modules/reference/pages/spacecmd/configuring-spacecmd.adoc
+++ b/modules/reference/pages/spacecmd/configuring-spacecmd.adoc
@@ -1,6 +1,6 @@
 [[ref-spacecmd-config]]
 = Configuring spacecmd
-:description: Learn how to configure spacecmd with a credentials file in your home directory to avoid being prompted for a username and password each time you log in to the
+:description: Learn how to configure spacecmd with a credentials file in your home directory to avoid being prompted for a username and password each time you log in to the server.
 :revdate: 2024-06-24
 :page-revdate: {revdate}
 
@@ -11,8 +11,7 @@ To access a shell inside the Server container, run [literal]``mgrctl term`` on t
 
 The following section provides configuration tips for spacecmd.
 
-== Setup [comamnd]``spacecmd`` credentials
-
+== Setup [command]``spacecmd`` credentials
 
 Normally spacecmd prompts you for a username and password each time you attempt to login to the interactive shell.
 Alternatively you can configure spacecmd with a credentials file to avoid this requirement.
@@ -21,32 +20,23 @@ Alternatively you can configure spacecmd with a credentials file to avoid this r
 [role=procedure]
 ____
 . Create a hidden spacecmd directory in your home directory and set permissions:
-
 +
-
 [source]
 ----
 mkdir ~/.spacecmd
 chmod 700 ~/.spacecmd
 ----
 
-+
-
 . Create a [literal]``config`` file in [path]``~/.spacecmd/`` and provide proper permissions:
-
 +
-
 [source]
-
 ----
 touch ~/.spacecmd/config
 chmod 600 ~/.spacecmd/config
 ----
 
 . Edit the [literal]``config`` file and add the following configuration lines. (You can use either localhost, when running spacecmd from your {productname} server container, or the FQDN of your {productname} server):
-
 +
-
 [source]
 ----
 [spacecmd]
@@ -58,20 +48,14 @@ password=password-here
 ----
 
 . Check connectivity by entering [command]``spacecmd`` as root:
-
 +
-
 [source]
 ----
- # spacecmd
+# spacecmd
 ----
-
 ____
 
-
-
 == [command]``spacecmd`` quiet mode
-
 
 By default spacecmd prints server status messages during connection attempts.
 These messages can cause a lot of clutter when parsing system lists.
@@ -79,17 +63,16 @@ The following alias will force spacecmd to use quiet mode thus preventing this b
 Add the following line to your `~/.bashrc` file:
 
 [source]
---
+----
 alias spacecmd='spacecmd -q'
---
+----
 
 == [command]``spacecmd`` help
 
-
-spacecmd help can be access by typing spacecmd [command]``-h --help``
+spacecmd help can be accessed by typing spacecmd [command]``-h --help``
 
 [source]
---
+----
 Usage: spacecmd [options] [command]
 
 Options:
@@ -107,13 +90,12 @@ Options:
   -q, --quiet           print only error messages
   -d, --debug           print debug messages (can be passed multiple times)
   -h, --help            show this help message and exit
---
-
+----
 
 As root you can access available functions without entering the spacecmd shell:
 
 [source]
---
+----
 # spacecmd -- help
 
         Documented commands (type help <topic>):
@@ -132,4 +114,4 @@ activationkey_disable                  repo_clearfilters
 activationkey_disableconfigdeployment  repo_create
 
 ...
---
+----

--- a/modules/retail/pages/retail-formulas-intro.adoc
+++ b/modules/retail/pages/retail-formulas-intro.adoc
@@ -16,9 +16,9 @@ All formulas must be accurately configured for your {productname} {smr} installa
 Branch servers are configured using formulas. Formulas can be configured using {productname} {webui}, or the {productname} API.
 
 
-=== Containerized branch server ({productname} 5.2)
+=== Containerized branch server ({productname} {productnumber})
 
-On a {productname} 5.2 Proxy, PXE, TFTP and image synchronization are provided as containerized services, which do not use formulas.
+On a {productname} {productnumber} Proxy, PXE, TFTP and image synchronization are provided as containerized services, which do not use formulas.
 
 You can use other formulas on the salt-managed Proxy container host if you need them:
 

--- a/parameters.yml
+++ b/parameters.yml
@@ -82,7 +82,7 @@ products:
     # Antora site configuration
     antora:
       name: "uyuni"
-      title: 'Uyuni 2026.03'
+      title: 'Uyuni 2026.04'
     # AsciiDoc attributes for content processing
     asciidoc:
       attributes:
@@ -250,7 +250,7 @@ asciidoc:
     value: "15.6"
   # Version information
   - attribute: opensuse-version
-    value: 15.5
+    value: 15.6
   - attribute: saltversion
     value: "'3006.0'"
   - attribute: postgresql


### PR DESCRIPTION
# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.


# Description

After the Uyuni 2026.04 release I noticed some issues that I tried to fix in this PR.

- modules/retail/pages/retail-formulas-intro.adoc: use macros for version and product name
- parameters.yml: update antora title for Uyuni and update openSUSE version
- modules/reference/pages/spacecmd/configuring-spacecmd.adoc: fix unterminated quote block


# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
