### PR TITLE
5.1 - Salt minion path fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Corrected path for Salt minion in Retail Guide (#1262090)
 - Added explanation for translating mgradm arguments to YAML in Installation and 
   Upgrade Guide (bsc#1258144)
 - Removed Google Cloud Compute from PAYG documentation (bsc#1261631)

--- a/modules/retail/pages/retail-deploy-terminals-auto.adoc
+++ b/modules/retail/pages/retail-deploy-terminals-auto.adoc
@@ -1,7 +1,7 @@
 [[retail.deployterminals.auto]]
 = Deploy Terminals and Auto-Accept Keys
 :description: Configure SUSE Multi-Linux Manager and Saltboot to automatically accept terminal keys securely within a trusted network
-:revdate: 2024-12-12
+:revdate: 2026-04-30
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -35,18 +35,18 @@ For more information, see xref:retail:retail-deploy-terminals-auto.adoc#retail.d
 
 
 [[retail.deployterminals.auto.server]]
-== Configure the Server to Auto-Accept
-
+== Configure the server to auto-accept
 
 When you have configured {saltboot} using one of these methods, you need to configure the server to accept them.
 The server stores the autosign keys in a file within the [path]``/etc/salt/master.d/`` directory, which is preserved in [systemitem]``etc-salt`` volume.
 You can enable auto-signing by creating an auto-sign file that contains the key you created when you configured {saltboot}.
 
 
-
-.Procedure: Configuring the Server to Auto-Accept
-
+.Procedure: Configuring the server to auto-accept
+[role=procedure]
+____
 . At the command prompt of the {productname} container host, as root, enter the server container:
+
 +
 
 ----
@@ -54,25 +54,34 @@ mgrctl term
 ----
 
 . Inside the container, execute the following steps:
+
 +
 
 --
 .. In directory [path]``/etc/salt/master.d/``, create file [path]``autosign_grains.conf`` and specify [option]``autosign_grains_dir``:
+
 +
+
 ----
 echo "autosign_grains_dir: /etc/salt/autosign_grains" \
   > /etc/salt/master.d/autosign_grains.conf
 ----
 
 .. Create a file at [path]``/etc/salt/autosign_grains/autosign_key``, that contains the auto-sign key you specified with {saltboot} (replace [literal]``<AUTOSIGN_KEY>`` with the key:
+
 +
+
 ----
 mkdir /etc/salt/autosign_grains
 echo "<AUTOSIGN_KEY>" > /etc/salt/autosign_grains/autosign_key
 ----
+
 +
+
 For multiple keys, put each one on a new line.
 --
+
+____
 
 
 For more information about configuring the server to automatically accept grains, see https://docs.saltproject.io/en/latest/topics/tutorials/autoaccept_grains.html.
@@ -80,18 +89,22 @@ For more information about configuring the server to automatically accept grains
 
 
 [[retail.deployterminals.auto.keep]]
-== Configure {saltboot} to Keep Auto-Signed Grains
+== Configure {saltboot} to keep auto-signed grains
 
 Use different procedure for SLE 15 and SLE 12.
 
 
-
 // For SLE15 templates, the procedure is the following:
-.Procedure: Configuring {saltboot} to Keep Auto-Signed Grains (SLE 15)
-. In the location where the image source is built, such as a build host or source repository, create a configuration file called [path]``etc/salt/minion.d/autosign-grains.conf``.
+.Procedure: Configuring {saltboot} to keep auto-signed grains (SLE 15)
+[role=procedure]
+____
+. In the location where the image source is built, such as a build host or source repository, create a configuration file called [path]``etc/venv-salt-minion/minion.d/autosign-grains.conf``.
+
 . Edit the new configuration file with these details.
   You can use any value you like as the auto-sign key:
+
 +
+
 ----
 # create the grain
 grains:
@@ -102,16 +115,22 @@ autosign_grains:
     - autosign_key
 ----
 
+____
 
 
 // For SLE12 and SLE11 templates, the procedure is the following:
-.Procedure: Configuring {saltboot} to Keep Auto-Signed Grains (SLE 12)
-. In the location where the image source is built, such as a build host or source repository, create a configuration file called [path]``etc/salt/minion.d/autosign-grains.conf``.
+.Procedure: Configuring {saltboot} to keep auto-signed grains (SLE 12)
+[role=procedure]
+____
+. In the location where the image source is built, such as a build host or source repository, create a configuration file called [path]``etc/ventv-salt-minion/minion.d/autosign-grains.conf``.
   This must be outside of the [path]``root`` directory provided by the template.
   This way you prevent the inclusion of unwanted files in the ``initrd``.
+
 . Edit the new configuration file with these details.
   You can use any value you like as the auto-sign key:
+
 +
+
 ----
 # create the grain
 grains:
@@ -123,32 +142,42 @@ autosign_grains:
 ----
 
 . Create a tarball of this directory:
+
 +
+
 ----
 tar -czf autosign-grains.tgz etc
 ----
 
 . Edit the [path]``config.xml`` template file.
   In the [literal]``<packages type="image">`` element, add:
+
 +
+
 ----
 <archive name="autosign.tgz" bootinclude="true"/>
 ----
 
 . Save the file and rebuild the image.
 
+____
 
 
 [[retail.deployterminals.auto.pxe]]
-== Configure {saltboot} to Auto-Sign During PXE Boot
+== Configure {saltboot} to auto-sign during PXE boot
 
 
-
-.Procedure: Configuring {saltboot} to Auto-Sign During PXE Boot
+.Procedure: Configuring {saltboot} to auto-sign during PXE boot
+[role=procedure]
+____
 . Configure the PXE formula to specify these kernel parameters during booting:
+
 +
+
 ----
 SALT_AUTOSIGN_GRAINS=autosign_key:<AUTOSIGN_KEY>
 ----
+
 . PXE boot the {salt} client.
   The formula creates the [path]``./etc/salt/minion.d/autosign-grains-onetime.conf`` configuration file and passes it to ``initrd``.
+____

--- a/modules/retail/pages/retail-deploy-terminals-other.adoc
+++ b/modules/retail/pages/retail-deploy-terminals-other.adoc
@@ -93,7 +93,7 @@ For more information about using USB devices to boot, see xref:retail:retail-dep
 [WARNING]
 ====
 Bootstrapping across a wireless network could expose a security risk if you are using encrypted OS images.
-The boot ``initrd`` image and the partition that contains ``/etc/salt`` must be stored unencrypted on the terminal.
+The boot ``initrd`` image and the partition that contains ``/etc/venv-salt-minion`` must be stored unencrypted on the terminal.
 This allows {productname} {smr} to set up the wireless network.
 If this breaches your security requirements, you will need to use a separate production network, with network credentials managed by Salt, so that credentials are not stored on the terminal unencrypted.
 ====


### PR DESCRIPTION
# Description

Salt minion path fixed in Retail Guide.


# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4898
- 5.1


# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1262090