### PR TITLE
master - Update Tumbleweed docs / Navigation sorting

### DIFF
--- a/modules/client-configuration/nav-client-configuration-guide.adoc
+++ b/modules/client-configuration/nav-client-configuration-guide.adoc
@@ -78,8 +78,8 @@ endif::[]
 **** xref:clients-opensuseleap.adoc[openSUSE Leap Clients]
 
 ifeval::[{uyuni-content} == true]
-*** xref:clients-tumbleweed.adoc[{opensuse} {tumbleweed} Clients]
 **** xref:clients-opensuseleapmicro.adoc[openSUSE Leap Micro Clients]
+**** xref:clients-tumbleweed.adoc[{opensuse} {tumbleweed} Clients]
 endif::[]
 
 ifeval::[{uyuni-content} == true]

--- a/modules/client-configuration/pages/clients-tumbleweed.adoc
+++ b/modules/client-configuration/pages/clients-tumbleweed.adoc
@@ -32,7 +32,7 @@ endif::[]
 
 For example, when working with `x86_64` architecture, you need this product:
 
-ifeval::[{uyuni-content} == true]
+ifeval::[{mlm-content} == true]
 
 [[opensuse-channels-wizard]]
 [cols="1,1", options="header"]


### PR DESCRIPTION
# Description

- Fixed Tumbleweed and Leap Micro being sorted separately (now they're under openSUSE)
- Adding products via web UI should be MLM only


# Target branches

Backport targets (edit as needed):

- master (this PR)
- 5.1
- 5.0
- 4.3


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30254
