### PR TITLE
manager-5.1 - Clarify Leap and SLES support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Removed mentions of Leap 15.5 and 15.4 and specified SUSE requiring general
+  or LTS support in Client Configuration Guide (bsc#1262285)
 - Added information about availability of SLE 16 and SL Micro 6.2 support
   in the product versions 5.1.2 and later (bsc#1260614)
 - Corrected path for Salt minion in Retail Guide (#1262090)

--- a/modules/client-configuration/pages/clients-opensuseleap.adoc
+++ b/modules/client-configuration/pages/clients-opensuseleap.adoc
@@ -52,12 +52,6 @@ ifeval::[{mlm-content} == true]
 | {leap} 15.6
 | {leap} 15.6 x86_64
 
-| {leap} 15.5
-| {leap} 15.5 x86_64
-
-| {leap} 15.4
-| {leap} 15.4 x86_64
-
 |===
 
 ifndef::backend-pdf[]
@@ -79,8 +73,6 @@ The channels you need for this procedure are:
 | OS Version | Base Channel
 | {leap} 16.0 | opensuse-leap-16.0
 | {leap} 15.6 | opensuse-leap-15.6-pool
-| {leap} 15.5 | opensuse-leap-15.5-pool
-| {leap} 15.4 | opensuse-leap-15.4-pool
 
 |===
 

--- a/modules/client-configuration/pages/supported-features-sles.adoc
+++ b/modules/client-configuration/pages/supported-features-sles.adoc
@@ -15,8 +15,11 @@ This table covers all variants of the {sle} operating system, including {slsa}, 
 [IMPORTANT]
 ====
 The operating system you run on a client is supported by the organization that supplies the operating system.
-{sle} is supported by {suse}.
-{opensuse} is supported by the {suse} community.
+
+* {sle} is supported by {suse}.
+** {suse} only supports products that are under general support or Long-term Support (LTS).
+* {opensuse} is supported by the {suse} community.
+
 ====
 
 The icons in this table indicate:


### PR DESCRIPTION
# Description

* Remove mentions of Leap 15.5 and 15.4
* Specify SUSE requiring general or LTS support


# Target branches

Backport targets (edit as needed):

- 5.1 (this PR)


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30555 / https://bugzilla.suse.com/show_bug.cgi?id=1262285