### PR TITLE
Update language selection container builds

### DIFF
--- a/.github/workflows/build_and_archive_devel_docs.yml
+++ b/.github/workflows/build_and_archive_devel_docs.yml
@@ -15,7 +15,9 @@ on:
       - completed
 
 jobs:
-  run:
+
+  # ── Uyuni HTML ─────────────────────────────────────────────────────────────
+  uyuni-html:
     runs-on: ubuntu-latest
 
     container:
@@ -28,62 +30,75 @@ jobs:
     - name: Build toolchain binary and generate configs
       run: task setup && task gen
 
-    # ── Uyuni HTML (master only) ────────────────────────────────────────────
-
     - name: Build Uyuni HTML documentation
       run: task publish:uyuni
-      if: github.ref_name == 'master'
 
     - name: Archive Uyuni HTML documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: documentation-uyuni-${{ github.ref_name }}
         path: build/en/
-      if: github.ref_name == 'master'
 
-    # ── Uyuni PDFs — English only (master only, for translator review) ──────
+  # ── MLM HTML ───────────────────────────────────────────────────────────────
+  mlm-html:
+    runs-on: ubuntu-latest
 
-    - name: Build Uyuni PDFs (English)
-      run: task pdf:uyuni LANGUAGES=en
-      if: github.ref_name == 'master'
+    container:
+      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
 
-    - name: Collect Uyuni PDFs
-      run: task pdf-collect:uyuni LANGUAGES=en
-      if: github.ref_name == 'master'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v4
 
-    - name: Archive Uyuni PDFs (English)
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-      with:
-        name: documentation-uyuni-pdf-en-${{ github.ref_name }}
-        path: build/pdf/en/
-      if: github.ref_name == 'master'
-
-    # ── MLM HTML (master only — future branches will uncomment trigger above) ──
+    - name: Build toolchain binary and generate configs
+      run: task setup && task gen
 
     - name: Build SUSE Multi-Linux Manager HTML documentation
       run: task publish:dsc
-      if: github.ref_name == 'master'
 
     - name: Archive SUSE Multi-Linux Manager HTML documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: documentation-suse-multi-linux-manager-${{ github.ref_name }}
         path: build/en/
-      if: github.ref_name == 'master'
 
-    # ── MLM PDFs — English only (master only, for translator review) ──────────
+  # ── PDFs — English only (for translator review) ────────────────────────────
+  pdfs:
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v4
+
+    - name: Build toolchain binary and generate configs
+      run: task setup && task gen
+
+    - name: Build Uyuni PDFs (English)
+      run: task pdf:uyuni LANGUAGES=en
+
+    - name: Collect Uyuni PDFs
+      run: task pdf-collect:uyuni LANGUAGES=en
+
+    - name: Archive Uyuni PDFs (English)
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+      with:
+        name: documentation-uyuni-pdf-en-${{ github.ref_name }}
+        path: build/pdf/en/
+
+    - name: Clean PDF output before MLM build
+      run: rm -rf build/pdf/en/
 
     - name: Build SUSE Multi-Linux Manager PDFs (English)
       run: task pdf:mlm LANGUAGES=en
-      if: github.ref_name == 'master'
 
     - name: Collect MLM PDFs
       run: task pdf-collect:mlm LANGUAGES=en
-      if: github.ref_name == 'master'
 
     - name: Archive SUSE Multi-Linux Manager PDFs (English)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: documentation-suse-multi-linux-manager-pdf-en-${{ github.ref_name }}
         path: build/pdf/en/
-      if: github.ref_name == 'master'

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,11 +27,13 @@
 #  OPTION B — Container (only requires Podman or Docker, nothing else to install)
 #    task container:build               Build the uyuni-docs-builder image locally (registry.suse.com/bci/nodejs:22)
 #    task container:shell               Interactive shell with repo mounted
-#    task container:draft:mlm-dsc       MLM HTML — documentation.suse.com branding (all languages)
-#    task container:draft:mlm-webui     MLM HTML — product WebUI branding (all languages)
-#    task container:draft:uyuni-website Uyuni HTML — website (all languages)
-#    task container:draft:uyuni-webui   Uyuni HTML — product WebUI (all languages)
-#    task container:draft:all           All four HTML output targets
+#    task container:draft:mlm-dsc                MLM HTML — documentation.suse.com branding (all languages)
+#    task container:draft:mlm-dsc LANGUAGES=en     MLM HTML — English only
+#    task container:draft:mlm-webui                MLM HTML — product WebUI branding (all languages)
+#    task container:draft:uyuni-website             Uyuni HTML — website (all languages)
+#    task container:draft:uyuni-webui               Uyuni HTML — product WebUI (all languages)
+#    task container:draft:all                       All four HTML output targets
+#    (All draft/publish/pdf container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
 #    task container:pdf:mlm             All MLM PDFs
 #    task container:pdf:uyuni           All Uyuni PDFs
 #    task container:pdf:all             All PDFs
@@ -93,6 +95,11 @@ tasks:
         echo "    draft:uyuni-website            (local) Uyuni HTML — website branding"
         echo "    draft:uyuni-webui              (local) Uyuni HTML — WebUI branding with language selector"
         echo ""
+        echo "  Tip: append LANGUAGES=en (or \"en ja\") to any draft/publish/pdf task to limit languages."
+        echo "    Example:  task container:draft:mlm-dsc LANGUAGES=en"
+        echo "    Example:  task draft:uyuni-website LANGUAGES=\"en ja\""
+        echo "    Example:  task publish:dsc LANGUAGES=en"
+        echo ""
         echo "  ── LOCAL  (Go + Task + Antora + asciidoctor-pdf installed locally) ──────────"
         echo "    publish:dsc              Full MLM publish — HTML (d.s.c branding) + PDFs + zips"
         echo "    publish:uyuni            Full Uyuni publish — HTML (website branding) + PDFs + zips"
@@ -103,6 +110,7 @@ tasks:
         echo "    pdf:all                  All PDFs — both products, all languages"
         echo "    obs:mlm                  OBS source packages for MLM"
         echo "    obs:uyuni                OBS source packages for Uyuni"
+        echo "    (All local tasks accept LANGUAGES=en or LANGUAGES=\"en ja\" to limit languages)"
         echo ""
         echo "  ── SINGLE BOOK PDF ──────────────────────────────────────────────────────────"
         echo "    task pdf BOOK=<book> PRODUCT=<product> LANG=<lang>"
@@ -563,66 +571,66 @@ tasks:
 
   # HTML builds
   container:draft:mlm-dsc:
-    desc: "[Draft] MLM HTML — documentation.suse.com branding, via container (all languages)"
+    desc: "[Draft] MLM HTML — documentation.suse.com branding, via container (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:mlm-dsc"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:mlm-dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:mlm-webui:
-    desc: "[Draft] MLM HTML — WebUI branding with language selector, via container (all languages)"
+    desc: "[Draft] MLM HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:mlm-webui"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:mlm-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-website:
-    desc: "[Draft] Uyuni HTML — website branding, via container (all languages)"
+    desc: "[Draft] Uyuni HTML — website branding, via container (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:uyuni-website"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:uyuni-website LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-webui:
-    desc: "[Draft] Uyuni HTML — WebUI branding with language selector, via container (all languages)"
+    desc: "[Draft] Uyuni HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:uyuni-webui"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:uyuni-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:all:
-    desc: "[Draft] All four HTML output targets, via container (sequential)"
+    desc: "[Draft] All four HTML output targets, via container (sequential; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:all"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task draft:all LANGUAGES='{{.LANGUAGES}}'"
 
   # PDF builds
   container:pdf:mlm:
-    desc: "[Container] All MLM PDFs — all books, all languages"
+    desc: "[Container] All MLM PDFs — all books, all languages (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:uyuni:
-    desc: "[Container] All Uyuni PDFs — all books, all languages"
+    desc: "[Container] All Uyuni PDFs — all books, all languages (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:all:
-    desc: "[Container] All PDFs — both products, all languages"
+    desc: "[Container] All PDFs — both products, all languages (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:all"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task pdf:all LANGUAGES='{{.LANGUAGES}}'"
 
   # Publish targets
   container:publish:dsc:
-    desc: "[Container] Full MLM publish — HTML (d.s.c branding) + PDFs + zips"
+    desc: "[Container] Full MLM publish — HTML (d.s.c branding) + PDFs + zips (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:dsc"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:uyuni:
-    desc: "[Container] Full Uyuni publish — HTML (website branding) + PDFs + zips"
+    desc: "[Container] Full Uyuni publish — HTML (website branding) + PDFs + zips (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-mlm:
-    desc: "[Container] MLM WebUI publish — HTML (with language selector) + PDFs + zips"
+    desc: "[Container] MLM WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:webui-mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:webui-mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-uyuni:
-    desc: "[Container] Uyuni WebUI publish — HTML (with language selector) + PDFs + zips"
+    desc: "[Container] Uyuni WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:webui-uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs uyuni-docs-builder:latest task publish:webui-uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # OBS packages
   container:obs:mlm:


### PR DESCRIPTION
This PR allows language selection at build time for both draft and publishing container builds.


```
 Tip: append LANGUAGES=en (or "en ja") to any draft/publish/pdf task to limit languages.
    Example:  task container:draft:mlm-dsc LANGUAGES=en
    Example:  task draft:uyuni-website LANGUAGES="en ja"
    Example:  task publish:dsc LANGUAGES=en
```