### PR TITLE
5.1 - Rephrased some RBAC-related statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Rephrased instructions for RBAC in Administration Guide (bsc#1258079)
 - Added troubleshooting section for BTRFS to Administration
   Guide (bcs#1258816)
 - Removed mentions of Leap 15.5 and 15.4 and specified SUSE requiring general


### PR DESCRIPTION
Rephrased some RBAC-related statements as requested in the extensive report.

The remaining points mentioned in the bug report are not bugs, but suggestions for improvements or additional content and **[are tracked on separate card](https://github.com/SUSE/spacewalk/issues/30682)**.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4938
- manager-5.1

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29658 / bug https://bugzilla.suse.com/show_bug.cgi?id=1258079