### PR TITLE
Make spacewalk-{common-channels,repo-sync} interactive when adding software channels

### DIFF
--- a/en/modules/client-configuration/partials/addchannels_novendor_cli.adoc
+++ b/en/modules/client-configuration/partials/addchannels_novendor_cli.adoc
@@ -8,7 +8,7 @@ ____
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-common-channels \
+mgrctl exec -ti -- spacewalk-common-channels \
 <base_channel_label> \
 <child_channel_label_1> \
 <child_channel_label_2> \
@@ -32,7 +32,7 @@ mgrctl exec -- spacewalk-common-channels -l
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-repo-sync -p <base_channel_label>
+mgrctl exec -ti -- spacewalk-repo-sync -p <base_channel_label>
 ----
 
 . Ensure the synchronization is complete before continuing.

--- a/en/modules/client-configuration/partials/addchannels_novendor_cli_multiarch.adoc
+++ b/en/modules/client-configuration/partials/addchannels_novendor_cli_multiarch.adoc
@@ -7,7 +7,7 @@
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-common-channels \
+mgrctl exec -ti -- spacewalk-common-channels \
 -a <architecture> \
 <base_channel_name> \
 <child_channel_name_1> \
@@ -20,7 +20,7 @@ mgrctl exec -- spacewalk-common-channels \
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-repo-sync -p <base_channel_label>-<architecture>
+mgrctl exec -ti -- spacewalk-repo-sync -p <base_channel_label>-<architecture>
 ----
 
 . Ensure the synchronization is complete before continuing.


### PR DESCRIPTION
This PR supersedes https://github.com/uyuni-project/uyuni-docs/pull/4808.

# Description

These commands didn't work without interactive mode as the user has to enter credentials in the terminal.

# Target branches

- master
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/4947 