### PR TITLE
5.1 - Make spacewalk-{common-channels,repo-sync} interactive when adding software channels

### DIFF
--- a/modules/client-configuration/partials/addchannels_novendor_cli.adoc
+++ b/modules/client-configuration/partials/addchannels_novendor_cli.adoc
@@ -7,7 +7,7 @@
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-common-channels \
+mgrctl exec -ti -- spacewalk-common-channels \
 <base_channel_label> \
 <child_channel_label_1> \
 <child_channel_label_2> \
@@ -31,7 +31,7 @@ mgrctl exec -- spacewalk-common-channels -l
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-repo-sync -p <base_channel_label>
+mgrctl exec -ti -- spacewalk-repo-sync -p <base_channel_label>
 ----
 
 . Ensure the synchronization is complete before continuing.

--- a/modules/client-configuration/partials/addchannels_novendor_cli_multiarch.adoc
+++ b/modules/client-configuration/partials/addchannels_novendor_cli_multiarch.adoc
@@ -7,7 +7,7 @@
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-common-channels \
+mgrctl exec -ti -- spacewalk-common-channels \
 -a <architecture> \
 <base_channel_name> \
 <child_channel_name_1> \
@@ -20,7 +20,7 @@ mgrctl exec -- spacewalk-common-channels \
 
 [source,shell]
 ----
-mgrctl exec -- spacewalk-repo-sync -p <base_channel_label>-<architecture>
+mgrctl exec -ti -- spacewalk-repo-sync -p <base_channel_label>-<architecture>
 ----
 
 . Ensure the synchronization is complete before continuing.


### PR DESCRIPTION
# Description

These commands didn't work without interactive mode as the user has to enter credentials in the terminal.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/4945
- manager-5.1