### PR TITLE
Update pages related to GPG upload from mgradm to mgrctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update pages related to GPG upload from mgradm to mgrctl
 - Added OS versions currently suported with OVAL in the product (bsc#1262664)
 - Enhanced large deployments guide with information on avoiding tasks getting stuick in 
   pending state in containerized environments (bsc#1258815)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update pages related to GPG upload from mgradm to mgrctl
 - Added ppc64le support for AlmaLinux 8 in Uyuni
 - Corrected the architectures of Rocky Linux 8 in Uyuni, which has no ppc64le build upstream
 - Corrected the s390x information for AlmaLinux and Rocky Linux 9 and 10 in Uyuni

--- a/en/modules/administration/pages/custom-channels.adoc
+++ b/en/modules/administration/pages/custom-channels.adoc
@@ -114,13 +114,13 @@ The key would also persist if the chroot environment would be cleaned.
 .Procedure: Creating a software repository with GPG key
 [role=procedure]
 ____
-. On the container host, the command to import a key into the keyring, is:
+. The command to import a key into the keyring, is:
 
 +
 
 [source,shell]
 ----
-mgradm gpg add /path/to/gpg.key
+mgrctl gpg upload /path/to/gpg.key
 ----
 
 . For more information, see xref:client-configuration:autoinst-owngpgkey.adoc[].

--- a/en/modules/administration/pages/third-party-channels.adoc
+++ b/en/modules/administration/pages/third-party-channels.adoc
@@ -3,31 +3,46 @@
 
 {productname} includes the ability to synchronize the content of optional third-party repositories with some of the products that can be managed by it.
 
-Some third-party GPG keys are included by default in the {productname} database, and some are not. 
+Some third-party GPG keys are included by default in the {productname} database, and some are not.
 For third-party keys that are not included, the relevant keys need to be imported when choosing to synchronize such third-party repositories.
 
-To import a GPG key, use the following command syntax, executing the command on the {productname} host server:
+GPG key management is performed through the {productname} XML-RPC API.
+The [command]``mgrctl gpg`` subcommands read a key from a local file or remote URL and upload it to the server, so they can be run from any host that has [systemitem]``mgrctl`` installed and network access to the server's API; they no longer require shell access into the server container.
+
+Because the commands call the API, valid administrator credentials must be supplied.
+They can be provided on the command line with the [option]``--api-server``, [option]``--api-user``, and [option]``--api-password`` flags, through environment variables, or in the [systemitem]``mgrctl`` configuration file.
+
+To import a GPG key, use the following command syntax:
 
 ----
-mgradm gpg add <path-to-gpg-key-file-or-URL>
+mgrctl gpg upload <path-to-gpg-key-file-or-URL>
 ----
 
-. Example: Adding a GPG key from a file
+The argument can be either a path to a local file containing an ASCII-armored GPG key, or an URL from which [systemitem]``mgrctl`` can download the key from.
+
+. Example: Uploading a GPG key from a local file
 +
 ----
-mgradm gpg add repomd.xml.key
+mgrctl gpg upload repomd.xml.key
 ----
 
-. Example: Adding a GPG key from a remote repository using a URL
+. Example: Uploading a GPG key from a remote repository using a URL
 +
 ----
-mgradm gpg add https://<3rd-party-domain>/path/to/repository/repodata/repomd.xml.key
+mgrctl gpg upload https://<3rd-party-domain>/path/to/repository/repodata/repomd.xml.key
 ----
 
-To list the keys currently held in the {productname} GPG database, run the following command:
+To list the keys currently held in the {productname} GPG keyring, run:
 
 ----
-mgrctl exec -ti -- gpg --homedir /var/lib/spacewalk/gpgdir --list-keys
+mgrctl gpg list
+----
+
+The output includes, for each key, its fingerprint, key type and size, and the associated user IDs.
+The fingerprint can be used to remove a key from the keyring:
+
+----
+mgrctl gpg remove <fingerprint>
 ----
 
 [NOTE]

--- a/en/modules/client-configuration/pages/autoinst-owngpgkey.adoc
+++ b/en/modules/client-configuration/pages/autoinst-owngpgkey.adoc
@@ -16,8 +16,8 @@ This technique applies to {suse} clients only.
 . Create a GPG key.
 . Use it to sign the package's metadata.
 . Add it to the initial RAM disk of your installation media.
-. To copy GPG keys to the container use [command]``mgradm gpg add``.
-  This command copies the GPG key and adds it to the customer keyring.
+. To upload the GPG key to the server use [command]``mgrctl gpg upload <PATH_TO_KEY_FILE_OR_URL>``.
+  This command calls the {productname} API to add the key to the customer keyring; valid administrator credentials are required.
 . Run command [command]``mgradm restart``.
   This command creates a unique keyring using the SUSE and the customer keyring.
 

--- a/en/modules/client-configuration/pages/autoinst-owngpgkey.adoc
+++ b/en/modules/client-configuration/pages/autoinst-owngpgkey.adoc
@@ -16,8 +16,8 @@ This technique applies to {suse} clients only.
 . Create a GPG key.
 . Use it to sign the package's metadata.
 . Add it to the initial RAM disk of your installation media.
-. To copy GPG keys to the container use `mgradm gpg add`.
-  This command copies the GPG key and adds it to the customer keyring.
+. To upload the GPG key to the server use `mgrctl gpg upload <PATH_TO_KEY_FILE_OR_URL>`.
+  This command calls the {productname} API to add the key to the customer keyring. Valid administrator credentials are required.
 . Run command `mgradm restart`.
   This command creates a unique keyring using the SUSE and the customer keyring.
 

--- a/en/modules/client-configuration/pages/clients-debian.adoc
+++ b/en/modules/client-configuration/pages/clients-debian.adoc
@@ -220,13 +220,13 @@ Packages will not be re-signed by Uyuni.
 To see which GPG keys are already imported to {productname} Server, run the following command:
 
 ----
-mgrctl exec -- gpg --homedir /var/lib/spacewalk/gpgdir --list-keys
+mgrctl gpg list
 ----
 
 To import a new GPG key, run the following command:
 
 ----
-mgradm gpg add <filename>.gpg
+mgrctl gpg upload <filename>.gpg
 ----
 
 

--- a/en/modules/client-configuration/pages/clients-debian.adoc
+++ b/en/modules/client-configuration/pages/clients-debian.adoc
@@ -199,13 +199,13 @@ Packages will not be re-signed by Uyuni.
 To see which GPG keys are already imported to {productname} Server, run the following command:
 
 ----
-mgrctl exec -- gpg --homedir /var/lib/spacewalk/gpgdir --list-keys
+mgrctl gpg list
 ----
 
 To import a new GPG key, run the following command:
 
 ----
-mgradm gpg add <filename>.gpg
+mgrctl gpg upload <filename>.gpg
 ----
 
 

--- a/en/modules/client-configuration/pages/clients-raspberrypios.adoc
+++ b/en/modules/client-configuration/pages/clients-raspberrypios.adoc
@@ -340,13 +340,13 @@ Packages will not be re-signed by {productname}.
 To see which GPG keys are already imported to {productname} Server, run the following command:
 
 ----
-mgrctl exec -- gpg --homedir /var/lib/spacewalk/gpgdir --list-keys
+mgrctl gpg list
 ----
 
 To import a new GPG key, run the following command:
 
 ----
-mgradm gpg add <filename>.gpg
+mgrctl gpg upload <filename>.gpg
 ----
 
 

--- a/en/modules/client-configuration/pages/clients-raspberrypios.adoc
+++ b/en/modules/client-configuration/pages/clients-raspberrypios.adoc
@@ -270,13 +270,13 @@ Packages will not be re-signed by {productname}.
 To see which GPG keys are already imported to {productname} Server, run the following command:
 
 ----
-mgrctl exec -- gpg --homedir /var/lib/spacewalk/gpgdir --list-keys
+mgrctl gpg list
 ----
 
 To import a new GPG key, run the following command:
 
 ----
-mgradm gpg add <filename>.gpg
+mgrctl gpg upload <filename>.gpg
 ----
 
 

--- a/en/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -182,7 +182,7 @@ Replace `<token>` with your personal Bearer Token. Also, `arch` and `release` mu
 In order for {productname} to synchronize the repositories, the corresponding GPG keys (`ubuntu-advantage-esm-infra-trusty.gpg`, `ubuntu-advantage-esm-apps.gpg`) must be imported. These are located on a system registered with Ubuntu Pro under `/etc/apt/trusted.gpg.d`. Copy these files to the {productname} system and import them as follows:
 
 ----
-mgradm gpg add /path/to/gpg.key
+mgrctl gpg upload /path/to/gpg.key
 ----
 
 Create the appropriate child channels below already synchronized {ubuntu} parent channels. After that, repositories can be synchronized.

--- a/en/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -185,7 +185,7 @@ Replace `<token>` with your personal Bearer Token. Also, `arch` and `release` mu
 In order for {productname} to synchronize the repositories, the corresponding GPG keys (`ubuntu-advantage-esm-infra-trusty.gpg`, `ubuntu-advantage-esm-apps.gpg`) must be imported. These are located on a system registered with Ubuntu Pro under `/etc/apt/trusted.gpg.d`. Copy these files to the {productname} system and import them as follows:
 
 ----
-mgradm gpg add /path/to/gpg.key
+mgrctl gpg upload /path/to/gpg.key
 ----
 
 Create the appropriate child channels below already synchronized {ubuntu} parent channels. After that, repositories can be synchronized.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-to-a-container.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-to-a-container.adoc
@@ -51,8 +51,9 @@ During a migration, the server SSL certificate and CA chain are copied from the 
 
 
 .Procedure: Manual Migration of the GPG Keys to New Server
-. Copy the keys from the legacy Uyuni server to the container host of the new server.
-. Later, add each key to the migrated server with the command [command]``mgradm gpg add <PATH_TO_KEY_FILE>``.
+. Make the keys from the legacy Uyuni server available on a host that has [systemitem]``mgrctl`` installed and network access to the API of the new server.
+. Upload each key to the migrated server with the command [command]``mgrctl gpg upload <PATH_TO_KEY_FILE_OR_URL>``.
+  The command uses the {productname} API, so it requires valid administrator credentials (for example via the [option]``--api-user`` and [option]``--api-password`` flags).
 
 
 === Initial Preparation on the Legacy Server


### PR DESCRIPTION
# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.


# Description

Updated pages mentioning GPG upload via mgradm to the new mgrctl API.

# Target branches

* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

Backport targets (edit as needed):

- master

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/29690
- Related development PR https://github.com/uyuni-project/uyuni/pull/11997 and https://github.com/uyuni-project/uyuni-tools/pull/797
