### PR TITLE
manager-5.1 - Added migration steps for SL Micro 6.1 to Retail Branch Server 4.3 (bsc#1262168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added migration steps for SL Micro 6.1 as base OS
+  to Retail Branch Server 4.3 migration guide (bsc#1262168)
 - Clarified Jinja templating in Client Configuration Guide (bsc#1262012)
 - Added information about recreating missing Cobbler entries by resaving
   the Saltboot Group formula to Retail Guide (bsc#1265334)

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
@@ -38,6 +38,7 @@ The management of the containerized proxy running with Podman is done using the 
 image::43-proxy-migration.mmaid.svg[scalewidth=80%]
 
 
+[[proxy-backup-43]]
 == Backup existing {susemgrproxy} data
 
 {productname} {smr} 5.1.2 includes automated backup-migration procedure for both kinds of {susemgrproxy} variants. This procedure collects all required data and uploads them to the {productname} Server. For {susemgrbranch} this tool also creates and migrates {saltboot} related entities, see xref:retail:migration-from-43.adoc[].
@@ -74,16 +75,19 @@ It is recommended to do a manual backup of the proxy as well, particularly if th
 
 == Deploy a new {susemgrproxy}
 
-{susemgrproxy} host operating system can be either {sles} 15 SP7 or {sl-micro} {microversion}.
-This guide however considers only {sles} 15 SP7 for AutoYAST based installation. {sl-micro} {microversion}  will require manual redeployment, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc[]
+You can either upgrade the existing host to {sles} 15 SP7 using AutoYaST, or perform a fresh installation of {sl-micro} 6.1.
 
-=== Prepare autoinstallation distribution based on {sles} 15 SP7
+=== Upgrade to {sles} 15 SP7 using AutoYaST
+
+Create and use AutoYAST profiles to migrate or reinstall the proxy host.
+
+==== Prepare autoinstallation distribution based on {sles} 15 SP7
 
 - Download or obtain {sles} 15 SP7 installation ISO to the server host
 - Use [command]``mgradm distribution copy $path_to_the_iso`` to copy installation files to the container
 - Register the autoinstallation distribution, see xref:client-configuration:autoinst-distributions.adoc[].
 
-=== Prepare autoinstallation profile
+==== Prepare autoinstallation profile
 
 For more information, see xref:client-configuration:autoinst-profiles.adoc[].
 
@@ -100,7 +104,7 @@ registration_key='activation_key_for_post_upgrade'
 ----
 - In tab [menuitem]``Autoinstallation File`` you can see complete rendered profile for additional inspection
 
-=== Provision autoinstallation of the proxy
+==== Provision autoinstallation of the proxy
 
 Schedule an autoinstallation on the old {susemgr} Proxy 4.3 using the profile created in previous step.
 
@@ -112,6 +116,46 @@ Schedule an autoinstallation on the old {susemgr} Proxy 4.3 using the profile cr
 mgrctl api login
 mgrctl api post system/provisionSystem '{\"sid\":$proxyid,\"profileName\":\"$profileName\"}'
 ----
+
+=== Reinstall with {sl-micro} 6.1
+
+{sl-micro} 6.1 requires a fresh installation on the host.
+
+[IMPORTANT]
+====
+Perform the backup of the existing 4.3 Proxy as described in xref:#proxy-backup-43[] before proceeding with the host reinstallation.
+====
+
+include::installation-and-upgrade:partial$snippet-prepare-micro-proxy-host.adoc[leveloffset=+1]
+
+==== Register and deploy the proxy
+
+.Procedure: Registering and deploying the proxy
+[role=procedure]
+____
+
+. Once the host is prepared, register the new {sl-micro} 6.1 system to the {productname} Server as a client.
+  It is recommended to use the same minion ID as the original 4.3 Proxy.
+  For more information, see xref:client-configuration:registration-overview.adoc[].
+. On the {productname} Server, generate the proxy configuration for the new proxy server. 
+  For more information, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc#generate-proxy-config[].
+. Transfer the configuration to the {sl-micro} 6.1 host and install the proxy:
++
+[source,bash]
+----
+mgrpxy install podman config.tar.gz
+----
+. Start the proxy:
++
+[source,bash]
+----
+mgrpxy start
+----
+. Once the proxy is operational, the {productname} Server will automatically deploy the backed up configuration during the next [literal]``Hardware Refresh`` step.
+
+____
+
+
 
 == Validate proxy functionality
 

--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
@@ -123,7 +123,8 @@ mgrctl api post system/provisionSystem '{\"sid\":$proxyid,\"profileName\":\"$pro
 
 [IMPORTANT]
 ====
-Perform the backup of the existing 4.3 Proxy as described in xref:#proxy-backup-43[] before proceeding with the host reinstallation.
+Perform the backup of the existing 4.3 Proxy before proceeding with the host reinstallation.
+For more information see xref:#proxy-backup-43[].
 ====
 
 include::installation-and-upgrade:partial$snippet-prepare-micro-proxy-host.adoc[leveloffset=+1]

--- a/modules/retail/pages/migration-from-43.adoc
+++ b/modules/retail/pages/migration-from-43.adoc
@@ -136,7 +136,8 @@ mgrctl api post system/provisionSystem '{\"sid\":$proxyid,\"profileName\":\"$pro
 
 [IMPORTANT]
 ====
-Perform the backup of the existing 4.3 Branch Server as described in xref:#retail-backup-43[] before proceeding with the host reinstallation.
+Perform the backup of the existing 4.3 Branch Server before proceeding with the host reinstallation.
+For more information see xref:#proxy-backup-43[].
 ====
 
 include::installation-and-upgrade:partial$snippet-prepare-micro-proxy-host.adoc[leveloffset=+2]

--- a/modules/retail/pages/migration-from-43.adoc
+++ b/modules/retail/pages/migration-from-43.adoc
@@ -24,6 +24,7 @@ Depending on the host operating system:
 * [literal]``SUSE Linux Micro 6.1`` uses [literal]``SUSE Multi-Linux Manager Retail Branch Server Extension 5.1`` channels
 * [literal]``SUSE Linux Enterprise Server 15 SP7`` uses [literal]``SUSE Multi-Linux Manager Retail Branch Server Extension for SLE 5.1`` channels
 
+[[retail-backup-43]]
 == Backup existing {susemgrbranch} 4.3
 
 {productname} {smr} 5.1.2 includes automated backup-migration procedure for both kinds of {susemgrproxy} variants. This procedure collects all required data and uploads them to the {productname} Server. For {susemgrbranch} this tool also creates and migrates {saltboot} related entities.
@@ -87,15 +88,19 @@ Backup/migration step will create new Saltboot objects:
 
 == Migrate {susemgrbranch} host
 
+You can either upgrade the existing host to {sles} 15 SP7 using AutoYaST, or perform a fresh installation of {sl-micro} 6.1.
+
+=== Upgrade to {sles} 15 SP7 using AutoYaST
+
 Create and use AutoYAST profiles to migrate or reinstall the proxy host.
 
-=== Prepare autoinstallation distribution based on {sles} 15 SP7
+==== Prepare autoinstallation distribution based on {sles} 15 SP7
 
 - Download or obtain {sles} 15 SP7 installation ISO to the server host
 - Use [literal]``mgradm distribution copy $path_to_the_iso`` to copy installation files to the container
 - Register the autoinstallation distribution, see xref:client-configuration:autoinst-distributions.adoc[].
 
-=== Prepare autoinstallation profile
+==== Prepare autoinstallation profile
 
 For more information, see xref:client-configuration:autoinst-profiles.adoc[].
 
@@ -112,7 +117,7 @@ registration_key='activation_key_for_post_upgrade'
 ----
 - In tab [menuitem]``Autoinstallation File`` you can see complete rendered profile for additional inspection
 
-=== Provision autoinstallation of the proxy
+==== Provision autoinstallation of the proxy
 
 Schedule an autoinstallation on the old {susemgr} Branch Server 4.3 using the profile created in previous step.
 
@@ -124,6 +129,46 @@ Schedule an autoinstallation on the old {susemgr} Branch Server 4.3 using the pr
 mgrctl api login
 mgrctl api post system/provisionSystem '{\"sid\":$proxyid,\"profileName\":\"$profileName\"}'
 ----
+
+=== Reinstall with {sl-micro} 6.1
+
+{sl-micro} 6.1 requires a fresh installation on the host.
+
+[IMPORTANT]
+====
+Perform the backup of the existing 4.3 Branch Server as described in xref:#retail-backup-43[] before proceeding with the host reinstallation.
+====
+
+include::installation-and-upgrade:partial$snippet-prepare-micro-proxy-host.adoc[leveloffset=+2]
+
+==== Register and deploy the proxy
+
+.Procedure: Registering and deploying the proxy
+[role=procedure]
+____
+
+. Once the host is prepared, register the new {sl-micro} 6.1 system to the {productname} Server as a client.
+  It is recommended to use the same minion ID as the original 4.3 Branch Server.
+  For more information, see xref:client-configuration:registration-overview.adoc[].
+. On the {productname} Server, generate the proxy configuration for the new branch server. 
+  For more information, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc#generate-proxy-config[].
+. Transfer the configuration to the {sl-micro} 6.1 host and install the proxy:
++
+[source,bash]
+----
+mgrpxy install podman config.tar.gz
+----
+. Start the proxy:
++
+[source,bash]
+----
+mgrpxy start
+----
+. Once the proxy is operational, the {productname} Server will automatically deploy the backed up configuration during the next [literal]``Hardware Refresh`` step.
+
+____
+
+
 
 == Validate proxy functionality
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

- Added migration steps for SL Micro 6.1 to Retail Branch Server 4.3 (bsc#1262168)
- Adjusted the proxy guide as well (verifying with Geronimo whether this makes sense)


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1 (this PR)
- 5.0
- 4.3


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30556 / https://bugzilla.suse.com/show_bug.cgi?id=1262168
