### PR TITLE
5.1 - Split SW and HW requirements to two separate tables

### DIFF
--- a/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
+++ b/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
@@ -19,17 +19,25 @@ This guide shows you how to install and configure a {productname} {productnumber
 
 == Hardware Requirements for {productname}
 
-This table shows the software and hardware requirements for deploying {productname} Server on your bare metal machine.
+These tables shows the software and hardware requirements for deploying {productname} Server on your bare metal machine.
 For the purposes of this guide your machine should have 16 GB of RAM, and at least 200 GB of disk space.
 For background information about disk space, see xref:installation-and-upgrade:hardware-requirements.adoc[].
 
 [cols="1,1", options="header"]
-.Software and Hardware Requirements
+.Software Requirements
 |===
-| Software and Hardware  | Recommended
+| Software  | Recommended
 | Operating System       | {sl-micro} {microversion} or
 
                            {sles} {bci-mlm}
+|===
+
+
+
+
+[cols="1,1", options="header"]
+.Hardware Requirements
+|===
 | Architecture           | {x86_64}, {arm}, {s390x}, {ppc64le}
 | Processor (CPU)        | Minimum of four (4) 64-bit CPU cores
 | RAM                    | 16 GB


### PR DESCRIPTION
# Description

In order to convert HW requirements to a reusable snippet, SW requirements were moved to its own separate table. 

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master PR #4974
- 5.1


