### PR TITLE
5.1 - Fix table with supported Leap features

### DIFF
--- a/modules/client-configuration/pages/supported-features.adoc
+++ b/modules/client-configuration/pages/supported-features.adoc
@@ -79,8 +79,8 @@ ifeval::[{mlm-content} == true]
 
 | {opensuse} Leap 15
 | {check}
-| {cross}
-| {cross}
+| {check}
+| {check}
 | {check}
 
 | {sll} 10, 9, 8, 7


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Short summary of why you created this PR (if you added documentation, please add any relevant diagram).

Fix table with supported Leap features. In master this is already fixed.

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- 

- [x]  master is already there.
- [x] 5.1 current PR
- [x] 5.0 https://github.com/uyuni-project/uyuni-docs/pull/4977
- 4.3


# Links
- This PR tracks issue: no issue, directly from review
- Related development PR #<insert PR link, if any>
