### PR TITLE
HW requirements tidy-up (bsc#1260371)

### DIFF
--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
@@ -14,26 +14,20 @@ This guide shows you how to install and configure a {productname} {productnumber
 
 == Hardware Requirements for {productname}
 
-This table shows the software and hardware requirements for deploying {productname} Server on your bare metal machine.
-For the purposes of this guide your machine should have 16 GB of RAM, and at least 200 GB of disk space.
-For background information about disk space, see xref:installation-and-upgrade:hardware-requirements.adoc[].
+This table shows the requirements for deploying {productname} Server on your bare metal machine.
 
-[cols="1,1", options="header"]
-.Software and Hardware Requirements
-|===
-| Software and Hardware  | Recommended
-| Operating System       | {sl-micro} {microversion} or
+//OM: *Drop this statement too?* For the purposes of this guide your machine should have 16 GB of RAM, and at least 200 GB of disk space.
 
-                           {sles} {bci-mlm}
-| Architecture           | {x86_64}, {arm}, {s390x}, {ppc64le}
-| Processor (CPU)        | Minimum of four (4) 64-bit CPU cores
-| RAM                    | 16 GB
-| Disk Space             | 200 GB
-| Channel Requirements   | 50 GB per SUSE or openSUSE product
-                          
-                           360 GB per Red Hat product
-| Swap space:            | 8 to 12 GB
-|===
+
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-hw-requirements.adoc[leveloffset=+1]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../../../partials/snippet-hw-requirements.adoc[leveloffset=+1]
+endif::[]
+
+
 
 .Supported operating system for the Server Container Host
 [NOTE]

--- a/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
@@ -1,13 +1,13 @@
 [[install-hardware-requirements]]
 = Hardware Requirements
-:revdate: 2025-07-03
+:revdate: 2026-06-03
 :page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
 
-This table outlines hardware and software requirements for the {productname} Server and Proxy, on {x86_64}, {arm}, {ppc64le} and {s390x} architecture.
+These tables outline hardware and software requirements for the {productname} Server and Proxy, on {x86_64}, {arm}, {ppc64le} and {s390x} architecture.
 
 
 [WARNING]
@@ -44,42 +44,16 @@ Estimate how much space the [path]``/var/lib/containers/storage/volumes/`` direc
 
 For more information about filesystem and partitioning details, see xref:installation-and-upgrade:hardware-requirements.adoc#install-hardware-requirements-storage[] and the detailed installation instructions in the Installation and Deployment sections of this guide.
 
-[cols="1,3,2", options="header"]
-.Server Hardware Requirements
-|===
 
-| Hardware
-| Details
-| Recommendation
+ifndef::backend-pdf[]
+include::installation-and-upgrade:partial$snippet-hw-requirements.adoc[leveloffset=+1]
+endif::[]
 
-| CPU
-| {x86_64}, {arm}, {ppc64le} or {s390x}
-| Minimum 4 dedicated 64-bit CPU cores
+ifdef::backend-pdf[]
+include::../../../partials/snippet-hw-requirements.adoc[leveloffset=+1]
+endif::[]
 
-| RAM
-| Minimum
-| 16 GB
 
-|
-| Recommended
-| 32 GB
-
-| Disk Space
-| [path]``/`` (root directory)
-| 40 GB
-
-|
-| [path]``/var/lib/containers/storage/volumes``
-| Minimum 150 GB (depending on the number of products)
-
-|
-| [path]``/var/lib/containers/storage/volumes/var-pgsql``
-| Minimum 50 GB
-
-| Swap space
-| Systems can benefit from additional swap space.   {suse} recommends using a swap file instead of a swap partition.  For more information about swap space, see xref:installation-and-upgrade:hardware-requirements.adoc#installation-swap-space[].
-| 8 to 12 GB
-|===
 
 // |
 // | [path]``/var/lib/containers/storage/volumes/var-cache``

--- a/en/modules/installation-and-upgrade/partials/snippet-hw-requirements.adoc
+++ b/en/modules/installation-and-upgrade/partials/snippet-hw-requirements.adoc
@@ -1,0 +1,48 @@
+[cols="1,3,2", options="header"]
+.Server Hardware Requirements
+|===
+
+| Hardware
+| Details
+| Recommendation
+
+| CPU
+| {x86_64}, {arm}, {ppc64le} or {s390x}
+| Minimum 4 dedicated 64-bit CPU cores
+
+  *(Do we need details for Salt worker tuning here?)*
+
+| RAM
+| Minimum
+| 16 GB
+
+|
+| Recommended
+| 32 GB
+
+
+| Disk Space
+| [path]``/`` (root directory)
+| 40 GB
+
+|
+| [path]``/var/lib/containers/storage/volumes``
+| Depends on number of products
+
+  *OLD CONTENT: Minimum 150 GB (depending on the number of products)*
+  
+
+| 
+| [path]``/var/lib/containers/storage/volumes/var-pgsql``
+| 200 GB per SUSE or openSUSE product
+
+  360 GB per Red Hat product
+
+  *OLD CONTENT: Minimum 50 GB*
+
+| Swap space
+| Systems can benefit from additional swap space.   {suse} recommends using a swap file instead of a swap partition.  For more information about swap space, see xref:installation-and-upgrade:hardware-requirements.adoc#installation-swap-space[].
+| 8 to 12 GB
+
+
+|===

--- a/l10n-weblate/installation-and-upgrade.cfg
+++ b/l10n-weblate/installation-and-upgrade.cfg
@@ -57,6 +57,7 @@
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-generate_proxy_config.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-generate_proxy_config.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-hardened-tmpdir.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-hardened-tmpdir.adoc
+[type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-hw-requirements.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-hw-requirements.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-login-into-suse-registry.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-login-into-suse-registry.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-note-deploy-certs.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-note-deploy-certs.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-prepare-micro-host.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-prepare-micro-host.adoc


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

HW requirements are unified into a snippet, and used where necessary, instead of different tables across different documents.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1


# Links
- This PR tracks issue https://github.com/uyuni-project/uyuni-docs/issues/4809 && https://github.com/SUSE/spacewalk/issues/30558.


## Need to clarify before submitting for approvals:
- check the server values (Ricardo)
- in the installation document, should we link to HW requirements (as done in the proxy section), or call the snippet? 
- depending on decision, unify the call to snippet or linking to HW requirements for both server and proxy
- do proxy values need changing?
- check the values for Uyuni too