### PR TITLE
SANs for internal names are no longer needed.

### DIFF
--- a/en/modules/administration/pages/ssl-certs-imported.adoc
+++ b/en/modules/administration/pages/ssl-certs-imported.adoc
@@ -26,7 +26,8 @@ Supported Key types are [literal]``RSA`` and [literal]``EC`` (Elliptic Curve).
 
 [IMPORTANT]
 ====
-Database SSL certificates require [literal]``reportdb`` and [literal]``db`` as [literal]``Subject Alternative Name``.
+In previous versions the database SSL certificates required [literal]``reportdb`` and [literal]``db`` as [literal]``Subject Alternative Name``.
+This is no longer needed.
 ====
 
 Third-party authorities commonly use intermediate CAs to sign requested server certificates.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
@@ -18,29 +18,7 @@ include::../../../../../partials/snippet-hardened-tmpdir.adoc[leveloffset=+2]
 include::../../../../../partials/snippet-ssl-requirements.adoc[leveloffset=+1]
 endif::[]
 
-During a migration the server SSL certificate and CA chain are copied from the source server, meaning that only the database certificates are required
-
-[NOTE]
-====
-{productname} 5.0 peripheral servers are always using third-party SSL certificates.
-If the hub server has generated the certificates for the peripheral server, it needs to generate the certificate for the peripheral database too.
-
-On the hub server, run the following command for each of the peripheral server to migrate.
-
-[source,shell]
-----
-mgrctl exec -ti -- rhn-ssl-tool --gen-server --dir="/root/ssl-build" --set-country="COUNTRY" \
-  --set-state="STATE" --set-city="CITY" --set-org="ORGANIZATION" \
-  --set-org-unit="ORGANIZATION UNIT" --set-email="name@example.com" \
-  --set-hostname=<hostname>-reportdb --set-cname="example.com" --set-cname=db --set-cname=reportdb
-----
-
-The files to use will be inside the server container and need to be copied to the new peripheral server host:
-
-. [litteral]``/root/ssl-build/RHN-ORG-TRUSTED-SSL-CERT`` as the root CA,
-. [litteral]``/root/ssl-build/<hostname>-reportdb/server.crt`` as the db certificate and
-. [litteral]``/root/ssl-build/<hostname>-reportdb/server.key`` as the db certificate's key.
-====
+During a migration the server SSL certificate and CA chain are copied from the source server.
 
 
 == {sle-micro} 5.5 to {sl-micro} 6.2

--- a/en/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -119,15 +119,17 @@ podman image prune -a
 ____
 
 .Upgrading with third-party SSL certificate
-[IMPORTANT]
+[NOTE]
 ====
-If you are using third-party certificates, the database container needs to have an SSL certificate with the following Subject Alternate Names (SANs):
+In previous versions, the database container needed to have an SSL certificate with the following Subject Alternate Names (SANs):
 
 * [literal]``db``
 * [literal]``reportdb``
-* the externally facing fully qualified domain name
 
-The same certificate can be used for both the main container and the database one, but it needs to have those SANs too.
+This is no longer required. The database container needs only the externally facing fully qualified domain name.
+The old certificates with [literal]``db`` and [literal]``reportdb`` SANs can be still used.
+
+The same certificate can be used for both the main container and the database one.
 
 In order to pass the new certificate to the upgrade command, use the [command]``--ssl-db-ca-root``, [command]``--ssl-db-cert`` and [command]``--ssl-db-key`` parameters.
 ====

--- a/en/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-management/updating-server-containers.adoc
@@ -126,7 +126,8 @@ In previous versions, the database container needed to have an SSL certificate w
 * [literal]``db``
 * [literal]``reportdb``
 
-This is no longer required. The database container needs only the externally facing fully qualified domain name.
+This is no longer required. 
+The database container needs only the externally facing fully qualified domain name.
 The old certificates with [literal]``db`` and [literal]``reportdb`` SANs can be still used.
 
 The same certificate can be used for both the main container and the database one.

--- a/en/modules/installation-and-upgrade/partials/snippet-ssl-requirements.adoc
+++ b/en/modules/installation-and-upgrade/partials/snippet-ssl-requirements.adoc
@@ -13,7 +13,8 @@ You can set the hostnames in the [literal]``X509v3 Subject Alternative Name`` se
 You can also list multiple hostnames if your environment requires it.
 Supported Key types are [literal]``RSA`` and [literal]``EC`` (Elliptic Curve).
 
-[IMPORTANT]
+[NOTE]
 ====
-Database SSL certificate requires [literal]``reportdb`` and [literal]``db`` and the FQDN used to access the report database as [literal]``Subject Alternative Name``.
+Database SSL certificate required [literal]``reportdb`` and [literal]``db`` and the FQDN used to access the report database as [literal]``Subject Alternative Name``.
+This is no longer needed.
 ====

--- a/en/modules/specialized-guides/pages/large-deployments/hub-install.adoc
+++ b/en/modules/specialized-guides/pages/large-deployments/hub-install.adoc
@@ -21,12 +21,6 @@ You can deploy a hub environment either with third party certificates or with se
 //        while deploying the hub infrastructure?
 Prepare third party certificates for both the Hub Server and the Peripheral servers first.
 
-[IMPORTANT]
-====
-Database SSL certificates require [literal]``reportdb`` and [literal]``db`` as [literal]``Subject Alternative Name``.
-The same certificate can be used for server and database, as long the required alternative names are added.
-====
-
 // Hub:
 // mgradm install podman --ssl-ca-root CA-Certificate.crt --ssl-server-cert hub.crt --ssl-server-key hub.key --hubxmlrpc-replicas 1
 
@@ -130,12 +124,6 @@ Next step, peripheral server
 [[lsd-hub-install-self-peripheral]]
 === Peripheral servers
 
-[IMPORTANT]
-====
-Database SSL certificates require [literal]``reportdb`` and [literal]``db`` as [literal]``Subject Alternative Name``.
-The same certificate can be used for server and database, as long the required alternative names are added.
-====
-
 .Procedure: Peripheral servers with self-generated certificates
 [role=procedure]
 _____
@@ -159,7 +147,7 @@ mgrctl term
 rhn-ssl-tool --gen-server --dir="/root/ssl-build" --set-country="COUNTRY" \
   --set-state="STATE" --set-city="CITY" --set-org="ORGANIZATION" \
   --set-org-unit="ORGANIZATION UNIT" --set-email="name@example.com" \
-  --set-hostname=PERIPHAL-FQDN --set-cname="reportdb" --set-cname="db"
+  --set-hostname=PERIPHAL-FQDN
 ----
 
 . For every peripheral server:


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

SANs for internal names `db` and `reportdb`are no longer needed. This PR removes the requirement from documentation.

Kubernetes part is handled in https://github.com/uyuni-project/uyuni-docs/pull/4988


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1 (starting with 5.1.5) https://github.com/uyuni-project/uyuni-docs/pull/4991


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30434
- Related development PR https://github.com/uyuni-project/uyuni-tools/pull/790
