### PR TITLE
5.1 - Adjusted/added the notes about the rpmnew and rpmsave files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Adjusted the note about *.rpmnew and *.rpmsave files usage (bsc#1245944)
 - Added OS versions currently suported with OVAL in the product (bsc#1262664)
 - Added instructions to migrate from wicked to NetworkManager to Administration Guide
   (bsc#1257295)

--- a/modules/installation-and-upgrade/partials/snippet-check-rpmnew-rpmsave.adoc
+++ b/modules/installation-and-upgrade/partials/snippet-check-rpmnew-rpmsave.adoc
@@ -1,22 +1,6 @@
-. Check for [filename]`+*.rpmnew+` and [filename]`+*.rpmsave+` files inside the container:
-
-+
-
-[source,shell]
-----
-mgrctl exec 'find /etc/ -name "*.rpmnew" -o -name "*.rpmsave"'
-----
-
-+
-
 [NOTE]
 ====
-When an upgrade includes changes to a default configuration file that has been altered after package installation, instead of overwriting the file, one of these file types is created:
+In some upgrades, multiple [filename]`+*.rpmnew+` and [filename]`+*.rpmsave+` files may be generated. The presence or number of these files does not indicate that manual action is required. In SUSE Multi-Linux Manager container environments, required configuration changes are applied automatically during the upgrade process. These files are created as a result of differences between packaged defaults and existing configuration files, and may also include internal or informational changes that are not intended to be merged. If manual action is required for a configuration change, it will be explicitly documented in the release notes or upgrade documentation.
 
-* [filename]`+*.rpmnew+`: contains the new default configuration and leaves your altered file untouched
-* [filename]`+*.rpmsave+`: a copy of your altered configuration that has been replaced by the new default file
+Do not treat these files as a post-upgrade checklist or merge them in bulk. Only review a file if you are actively troubleshooting a specific issue and understand the impact of the configuration it contains. If a change is required, it should be applied intentionally based on a known requirement, not by copying differences from these files. If you are unsure, leave the file unchanged.
 ====
-
-+
-
-. If you find any [filename]`+*.rpmnew+` or [filename]`+*.rpmsave+` files, examine their content and merge desirable changes.


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Adusted/added the notes about the rpmnew and rpmsave files as previous was creating confusion and users were ending up with wrong configs.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5011
- 5.1



# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28712
- Related development PR #<insert PR link, if any>
