### PR TITLE
Update README.adoc to match master structure for manager-5.1

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,54 +7,31 @@ ifdef::env-github,backend-html5[]
 :caution-caption: :fire:
 :warning-caption: :warning:
 :linkattrs:
-// SUSE ENTITIES FOR GITHUB
-// System Architecture
-:zseries: z Systems
-:ppc: POWER
-:ppc64le: ppc64le
-:ipf : Itanium
-:x86: x86
-:x86_64: x86_64
-// Rhel Entities
-:rhel: Red Hat Enterprise Linux
-:rhnminrelease6: Red Hat Enterprise Linux Server 6
-:rhnminrelease7: Red Hat Enterprise Linux Server 7
-// SUSE Multi-Linux Manager Entities
-:susemgr: SUSE Multi-Linux Manager
-:susemgrproxy: SUSE Multi-Linux Manager Proxy
-:susemgrbranch: :susemgr: Retail Branch Server
-:productnumber: 3.2
-:saltversion: 2018.3.0
-:webui: WebUI
-// SUSE Product Entities
-:sles-version: 12
-:sp-version: SP3
-:jeos: JeOS
-:scc: SUSE Customer Center
-:sls: SUSE Linux Enterprise Server
-:sle: SUSE Linux Enterprise
-:slsa: SLES
-:suse: SUSE
-:ay: AutoYaST
 endif::[]
-// Asciidoctor Front Matter
-:doctype: book
-:sectlinks:
-:icons: font
-:experimental:
-:sourcedir: .
-:imagesdir: images
 
-testing
 
-== Statuses and artifacts
 
-=== Build and archive
+== Statuses and Artifacts
 
-==== Development branches
+This section provides the live status of GitHub Actions workflows for the Uyuni documentation.
+Each badge reflects the current state of automated builds, tests, and artifact generation across branches.
+
+=== Build and Archive Workflows
+
+Build workflows validate and archive documentation from both development and release branches.
+
+=== Build Artifacts
+Release branches contain stable documentation builds:
+https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_release_docs.yml[Builds and Artifacts]
+
+==== Major Branch Build Tests
+The following branches are under active development and continuously tested:
 
 [cols="1,1"]
 |===
+|`manager-5.1`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml/badge.svg?branch=manager-5.1["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml"]
+
 |`master`
 |image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml"]
 
@@ -65,15 +42,56 @@ testing
 |image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_devel_docs.yml"]
 |===
 
-
-==== Release branches
-
-https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_release_docs.yml[Builds and Artifacts]
-
-=== Find unused files
+==== Test PDF Translations
+This job tests PDF builds of translated documentation.
+NOTE: The `en` locale is excluded, as it is built as part of the *Build and Archive Documentation from Branches* workflow.
 
 [cols="1,1"]
 |===
+|`manager-5.1`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=manager-5.1["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
+
+|`master`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
+
+|`manager-5.0`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=manager-5.0["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
+
+|`manager-4.3`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
+|===
+
+==== Update Translation Files
+This job updates translation templates for supported locales:
+
+[cols="1,1"]
+|===
+|`manager-5.1`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml/badge.svg?branch=manager-5.1["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml"]
+
+|`master`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml"]
+
+|`manager-5.0`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml/badge.svg?branch=manager-5.0["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml"]
+
+|`manager-4.3`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml"]
+|===
+
+
+=== File and Content Validation
+
+These workflows help maintain repository cleanliness and translation consistency.
+
+==== Find Unused Files
+This job identifies unused files in the documentation source:
+
+[cols="1,1"]
+|===
+|`manager-5.1`
+|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml/badge.svg?branch=manager-5.1["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml"]
+
 |`master`
 |image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml"]
 
@@ -84,373 +102,31 @@ https://github.com/uyuni-project/uyuni-docs/actions/workflows/build_and_archive_
 |image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/find_unused_files.yml"]
 |===
 
-//=== Linting
-//[cols="1,1"]
-//|===
-//|`master`
-//|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/linting.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows///linting.yml"]
-//
-//|`manager-4.3`
-//|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/linting.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/linting.yml"]
-//|===
-
-
-//=== Enforced checkstyle
-//[cols="1,1"]
-//|===
-//|`master`
-//|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/enforced_checkstyle.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows///enforced_checkstyle.yml"]
-//
-//|`manager-4.3`
-//|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/enforced_checkstyle.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/enforced_checkstyle.yml"]
-//|===
-
-=== Update translation files
-[cols="1,1"]
-|===
-|`master`
-|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/update_translation_files.yml"]
-|===
-
-=== Test PDF translations
-**Note:** `en` is not include as part of this test, as it is built as part of the `Build and archive documentation from branches` test.
-
-[cols="1,1"]
-|===
-|`master`
-|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=master["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
-
-|`manager-4.3`
-|image:https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml/badge.svg?branch=manager-4.3["Build Status", link="https://github.com/uyuni-project/uyuni-docs/actions/workflows/test_pdf_translations.yml"]
-|===
 
 [suma.doc.intro]
 == Introduction
-This is the source for the official Uyuni and SUSE Manager documentation.
-We welcome pull requests.
 
-For more details on contributing to Uyuni documentation, visit the https://github.com/uyuni-project/uyuni-docs/wiki[Uyuni Documentation Wiki].
-The wiki contains information about word usage, markup conventions, team processes, our docs toolchain, building locally, and publishing documentation.
-It also contains project planning information.
+This repository contains the official Uyuni and SUSE Multi-Linux Manager 5.1 documentation.
+Contributions are welcome. Pull requests are encouraged.
 
-
-
-[suma.doc.first.contribution]
-== First Contribution
-
-To contribute to Uyuni documentation:
-
-.Procedure: Configure Git commit signing (if needed)
-. Signing commits with a GPG/SSH key is mandatory for contributing. That way your commits will be marked as verified on GitHub so other people can be confident that the changes come from a trusted source.
-. If you are not doing it already, check out the https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification[GitHub documentation].
-
-.Procedure: Contributing Using a Fork
-. Make sure you have a [github](github.com) account, and that you a`re signed in.
-. Navigate to the [Uyuni Documentation Repo](https://github.com/uyuni-project/uyuni-docs.git), click the `Fork` button in the top-right corner, and select the account you want to use.
-. Wait for github to create your fork and redirect you.
-. Clone the repository to your local machine.
-To find this URL, click the green `Code` button and copy the HTTPS URL:
-+
-----
-git clone https://github.com/<username>/uyuni-docs.git
-----
-. Change into the directory that contains the repo, and check out the ``/master`` branch:
-+
-----
-cd uyuni-docs
-git checkout master
-----
-. List the current remote branches:
-+
-----
-git remote -v
-----
-+
-This command should list two remotes, both marked `origin`, like this:
-+
-----
-origin  https://github.com/<username>/uyuni-docs.git (fetch)
-origin  https://github.com/<username>/uyuni-docs.git (push)
-----
-+
-The `origin` remotes are your own fork, and you can do whatever you want here without changing the upstream repository.
-. Add the uyuni-docs repo as an upstream:
-+
-----
-git remote add upstream https://github.com/uyuni-project/uyuni-docs.git
-----
-. Check:
-+
-----
-git remote -v
-----
-+
-This command should now have the same two `origin` remotes as before, plus two more labelled `upstream`, like this:
-+
-----
-origin  https://github.com/<username>/uyuni-docs.git (fetch)
-origin  https://github.com/<username>/uyuni-docs.git (push)
-upstream  https://github.com/uyuni-project/uyuni-docs.git (fetch)
-upstream  https://github.com/uyuni-project/uyuni-docs.git (push)
-----
-. Check out your fork's `master` branch:
-+
-----
-git checkout master
-----
-. Fetch the branches in the upstream repository:
-+
-----
-git fetch upstream
-----
-. Merge the changes from the upstream `master` branch, into your fork's `master` branch:
-+
-----
-git merge upstream/master
-----
-. Create a new branch for the work you want to do.
-  Make sure you give it an appropriate name, and include your username:
-+
-----
-git checkout -b update-readme-username
-----
+For details on contributing, refer to the https://github.com/uyuni-project/uyuni-docs/wiki[Uyuni Documentation Wiki].
+It provides guidance on terminology, markup conventions, processes, toolchain usage, local builds, publishing, and project planning.
 
 
-If you have write access to the repository, use this method instead:
+== Building the Documentation
+
+The build system uses https://taskfile.dev[Task].
+Run `task` (no arguments) to see all available targets grouped by category.
+
+For setup instructions and a full build target reference, see:
+
+* link:docs/container-setup.md[docs/container-setup.md] — Container build using Podman or Docker (recommended, no local toolchain required)
+* link:docs/local-toolchain-setup.md[docs/local-toolchain-setup.md] — Local toolchain build (Task, Go, Antora, Asciidoctor PDF, po4a)
 
 
 
-.Procedure: Contributing With Write Access
-. Clone the repository to your local machine:
-+
-----
-git clone https://github.com/uyuni-project/uyuni-docs.git
-----
-. Change into the directory that contains the repo, and check out the ``/master`` branch:
-+
-----
-cd uyuni-docs
-git checkout master
-----
-. Create a new working branch for your changes:
-+
-----
-git checkout -b branchname
-----
-
-
-Regardless of whether you use a fork or commit directly, when you have made your changes you can make a pull request (PR).
-Always check that your changes build locally first.
-
-
-
-.Procedure: Committing Changes and Creating a Pull Request
-. Make your changes and ensure your changes build locally. This step requires that you have your local environment set up correctly.
-. Add the updated files to your commit:
-+
-----
-git add .
-----
-. Commit your changes:
-+
-----
-git commit -m "Commit message here"
-----
-. Push your changes:
-+
-----
-git push
-----
-+
-If git prompts you to set an upstream in order to push, use this command:
-+
-----
-git push --set-upstream origin <branchname>
-----
-. Create a pull request (PR) by navigating to https://github.com/uyuni-project/uyuni-docs and clicking [btn]``Compare and Create Pull Request``.
-Write an informative commit message detailing your changes, choose reviewers, and save your PR.
-If you haven't yet finished the work you want to do, make sure you create a Draft PR by selecting it from the drop down box in the github web UI.
-This lets your reviewers know that you haven't finished work yet, while still being transparent about what you are working on, and making sure we all understand current progress.
-
-
-[NOTE]
-====
-Choose your reviewers carefully!
-If you have made changes to the technical detail of the documentation, choose an appropriate subject matter expert (SME) to review those changes.
-Additionally, every change requires at least one documentation team member to approve.
-====
-
-
-.Review Standards
-
-These standards ensure that our documentation is accurate, that PRs are not left to age, and that the source code remains clean.
-Ensure you follow these standards if you are participating in the Uyuni documentation repository.
-
-* If you are still working on a PR, add ``[WIP]`` to the title of your PR.
-This allows people to review the PR, but notifies reviewers that you have not completed work.
-* Only the original author should merge PRs, do not merge other author's PRs unless you have express permission from them to do so.
-* _Do not_ merge a PR until you have received the following approvals:
-** For a technical change, approval from at least one SME
-** For all changes, approval from at least one other member of the documentation team
-
-
-[suma.doc.second.contribution]
-== Second Contribution
-
-Once you have checked out the repo and want to keep working on things, you need to ensure that your local copy of the repo remains up to date.
-If you don't do this, you *will* end up with merge conflicts.
-
-
-
-.Procedure: Second Contribution with a Fork
-. Check out your fork's `master` branch:
-+
-----
-git checkout master
-----
-You will get a message like this:
-+
-----
-Switched to branch 'master'
-Your branch is up to date with 'origin/master'.
-----
-+
-[IMPORTANT]
-====
-BEWARE! This is usually a lie!
-====
-. Fetch the branches in the upstream repository:
-+
-----
-git fetch upstream
-----
-. Merge the changes from the upstream `master` branch, into your fork's `master` branch:
-+
-----
-git merge upstream/master
-----
-. If you are continuing work you began earlier, check out the branch that contains your work.
-For new work, create a new branch.
-
-
-
-.Procedure: Second Contribution with Write Access
-. Check out the ``/master`` branch:
-+
-----
-git checkout master
-----
-You will get a message like this:
-+
-----
-Switched to branch 'master'
-Your branch is up to date with 'origin/master'.
-----
-+
-[IMPORTANT]
-====
-BEWARE! This is usually a lie!
-====
-+
-. Fetch all current branches:
-+
-----
-git fetch --all
-----
-. Update your local copy to match the remotes:
-+
-----
-git pull -ff
-----
-. If you are continuing work you began earlier, check out the branch that contains your work.
-For new work, create a new branch.
-
-
-Doing this regularly as you are working will mean you keep your local copies up to date and avoid conflicts.
-You should do it at least every day before you begin work, and again whenever you switch branches.
-
-For example, you are working on two separate pieces of content, one in the ``feature_1`` branch, and the other in the ``feature_2`` branch:
-
-. Start your day by checking out master, fetching the branches, and updating your local copy:
-+
-----
-git checkout master
-git fetch upstream
-git merge upstream/master
-----
-+
-Or:
-----
-git checkout master
-git fetch --all
-git pull -ff
-----
-. Begin work on the first piece of content by creating a new feature branch:
-+
-----
-git checkout -b feature_1
-----
-. Make your changes for Feature 1, then commit them to your branch:
-+
-----
-git commit -m "Content for Feature 1"
-git push
-----
-. Make a PR for Feature 1, by navigating to https://github.com/uyuni-project/uyuni-docs/ and clicking on [btn]``Compare and Create Pull Request``.
-Write an informative commit message detailing your changes, choose reviewers, and save your PR.
-If you haven't yet finished the work you want to do on Feature 1, make sure you create a Draft PR by selecting it from the drop down box in the github web UI.
-That way, you can come back to Feature 1 later on.
-. Switch your local copy back to master, and update your local copy again:
-+
-----
-git checkout master
-git fetch upstream
-git merge upstream/master
-----
-+
-Or:
-----
-git checkout master
-git fetch --all
-git pull -ff
-----
-. Now you can start work on Feature 2:
-+
-----
-git checkout -b feature_2
-----
-. When you are finished on Feature 2, commit your changes and create another PR, just the same as you did for Feature 1.
-
-[WARNING]
-====
-Never leave feature branches lying around on your local system.
-Create your PR as soon as possible, and make liberal use of the Draft feature.
-Commit to your feature branch early and often!
-Update your local copy from master whenever you switch branches.
-====
-
-== Changelog Entries
-
- Write your changes to the `CHANGELOG.md` file. New entries are added to the top, in the following format. Each collection of release entries should be separated by dashed lines. These lines are used to extract the automated changelog notes for releases.
-
-----
-
------------------------------------------------------------------------
-
-- Updated Foo chapter in Installation and Upgrade Guide for readability
-- Documented Bar feature in Administration Guide
-- Fixed error in Bat section of Upgrade Guide (bsc#1234567)
-
------------------------------------------------------------------------
-
-----
-
-For guidelines: https://en.opensuse.org/openSUSE:Creating_a_changes_file_(RPM)
-
-
-[suma.docs.team]
 == The Uyuni Documentation Team
 
-* Joseph Cayouette @jcayouette
-* Karl Eichwalder @keichwa
-* Ornela Marić @0rnela
+* Joseph Cayouette https://github.com/orgs/uyuni-project/people/jcayouette[@jcayouette]
+* Ornela Marić https://github.com/orgs/uyuni-project/people/0rnela[@0rnela]
+* Lukáš Kucharczyk https://github.com/orgs/uyuni-project/people/KucharczykL[@KucharczykL]


### PR DESCRIPTION
- Replace old legacy README (old entities, old Makefile toolchain refs) with the clean master-style README
- manager-5.1 listed as primary branch in all badge tables
- Introduction updated to reference SUSE Multi-Linux Manager 5.1
- Building section updated to reference Task-based toolchain and docs/
- Removed outdated entity definitions, Makefile references, and cruft
