### PR TITLE
Fix update_translation_files.yml: match master (ubuntu-latest + apt p…

### DIFF
--- a/.github/workflows/update_translation_files.yml
+++ b/.github/workflows/update_translation_files.yml
@@ -1,11 +1,11 @@
+# We keep this workflow without using uyuni-docs-helper as it interacts directly with the repository
 name: Update translation files
-
 on:
   push:
     branches:
     - 'master'
     - 'manager-4.3'
-    - 'manager-4.3-MU-4.3.[0-9][0-9]?'
+    - 'manager-4.3-MU-4.3.[0-9][0-9]?' # MU branches
     - 'manager-5.0'
     - 'manager-5.0-MU-5.0.[0-9][0-9]?'
     - 'manager-5.1'
@@ -14,21 +14,20 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
-
     steps:
     - name: Checkout repo
-      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v4
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
 
-    - name: Build toolchain binary
-      run: task setup
+    - name: 'Install po4a'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y po4a
 
-    - name: Update gettext files
-      run: task pot
+    - name: 'Update gettext files'
+      run: |
+        bash scripts/make_pot.sh
 
-    - name: Commit changes, if any
+    - name: 'Commit changes, if any'
       uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 #v10.0.0
       with:
         author_name: Galaxy CI


### PR DESCRIPTION


Reverts to bare ubuntu-latest runner with apt-get install po4a and bash scripts/make_pot.sh, identical to master. The container runner approach broke because rsync is not installed in the builder image.
