### PR TITLE
Document use of custom SELinux type

### DIFF
--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -645,7 +645,13 @@ semodule_package -o systemdcontainerpolicy.pp -m systemdcontainerpolicy.mod
 semodule -i systemdcontainerpolicy.pp
 ----
 
-No helm value is required for SELinux — applying the policy module on the node is sufficient.
+Then configure the custom SELinux type in the helm values (using [literal]``uyuni_container_t`` if using the recommended policy from the README):
+
+[source,yaml]
+----
+server:
+  selinuxType: uyuni_container_t
+----
 
 
 == Installation


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

The helm chart README now recommends using custom SELinux type.
This PR aligns kubernetes guide with it.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30968
- Related development PR https://github.com/uyuni-project/uyuni/pull/12124
