### PR TITLE
Fixed Changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,12 @@
 - Updated registration instructions for PowerPC self-install in Common Workflows (bsc#1260617)
 - Added documentation for deleting SCAP scan results to Administration Guide (bsc#1262471)
 - Added troubleshooting section for BTRFS to Administration
-  Guide (bcs#1258816)
+  Guide (bsc#1258816)
 - Rephrased instructions for RBAC in Administration Guide (bsc#1258079)
 - Migrate build toolchain: Go + Task + BCI container
 - Fixed Debian repository URL examples in custom channels
 - Removed mention of CIS profile (bsc#1262460)
-- Corrected path for Salt minion in Retail Guide (#1262090)
+- Corrected path for Salt minion in Retail Guide (bsc#1262090)
 - Added mass migration using UI to Client Configuration Guide
 - Added explanation for translating mgradm arguments to YAML to Installation and 
   Upgrade Guide (bsc#1258144)


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Some entries had typos, or were misspelled.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5013


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/30997