### PR TITLE
5.1 - Typos fixed in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@
 - Added documentation for deleting SCAP scan results to Administration Guide (bsc#1262471)
 - Rephrased instructions for RBAC in Administration Guide (bsc#1258079)
 - Added troubleshooting section for BTRFS to Administration
-  Guide (bcs#1258816)
+  Guide (bsc#1258816)
 - Removed mentions of Leap 15.5 and 15.4 and specified SUSE requiring general
   or LTS support in Client Configuration Guide (bsc#1262285)
 - Added information about availability of SLE 16 and SL Micro 6.2 support
   in the product versions 5.1.2 and later (bsc#1260614)
 - Removed mention of CIS profile (bsc#1262460)
-- Corrected path for Salt minion in Retail Guide (#1262090)
+- Corrected path for Salt minion in Retail Guide (bsc#1262090)
 - Added explanation for translating mgradm arguments to YAML in Installation and 
   Upgrade Guide (bsc#1258144)
 - Removed Google Cloud Compute from PAYG documentation (bsc#1261631)
@@ -41,7 +41,6 @@
 - Added online database backup instructions to Administration Guide
 - Fixed comamnd for product deployment in Installation and Upgrade Guide
   (bsc#1259479)
-- Added online database backup instructions
 - Added warning for the proxy key creation and limitations around assigning 
   cloned channels (bsc#1257823)
 - Fixed disk space management instructions in Administration Guide (bsc#1253144)


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Some entries had typos, or were misspelled.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5012
- manger-5.1


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/30997