### PR TITLE
QE: Change the name of the proxy secret example keys

### DIFF
--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
@@ -139,7 +139,7 @@ In a cloud-native setup the certificates are typically managed externally (for e
 [source, Shell]
 ----
 kubectl create secret tls proxy-cert -n uyuni-proxy \
-    --cert=server.crt --key=server.key
+    --cert=proxy.crt --key=proxy.key
 
 kubectl create configmap uyuni-ca -n uyuni-proxy \
     --from-file=ca.crt=/path/to/uyuni-ca.crt


### PR DESCRIPTION

<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

I have seen that in that example we are calling server.crt and server.key to a key pair generated specifically for the proxy and can be mismatched with the key pair of the server and cause problems. Therefore, I think that we should call it proxy.cert and proxy.key.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master



# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
