### PR TITLE
Kubernetes link fixed

### DIFF
--- a/en/modules/specialized-guides/pages/kubernetes-guide/overview.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/overview.adoc
@@ -1,10 +1,10 @@
 [[kubernetes-guide-overview]]
 = Kubernetes Guide
-:revdate: 2026-06-02
+:revdate: 2026-06-24
 :page-revdate: {revdate}
 
 This guide shows you how to deploy {productname} on {kube}.
 
 * xref:kubernetes-guide/server-kubernetes-deployment.adoc[Server Deployment on {kube}]
 
-* xref:kubernetes-guide/proxy-k3s-deployment.adoc[Proxy Deployment on {kube}]
+* xref:kubernetes-guide/proxy-kubernetes-deployment.adoc[Proxy Deployment on {kube}]

--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
@@ -1,6 +1,6 @@
 [[installation-proxy-containers-kube]]
-= {productname} {productnumber}  Proxy Deployment on Kubernetes
-:revdate: 2026-06-03
+= {productname} Proxy Deployment on Kubernetes
+:revdate: 2026-06-24
 :page-revdate: {revdate}
 
 == Proxy on {kube} changes


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Following the change on [PR#5021](https://github.com/uyuni-project/uyuni-docs/pull/5021) some issues were discovered and fixes:
- broken link was fixed
- version name was removed from the title

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
