### PR TITLE
Update CI for translations to use galaxy-ci token

### DIFF
--- a/.github/workflows/update_translation_files.yml
+++ b/.github/workflows/update_translation_files.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+      with:
+        token: ${{ secrets.GALAXY_CI_TOKEN }}
 
     - name: 'Install po4a'
       run: |


### PR DESCRIPTION
1. Generate a token (PAT) for the `galaxy-ci` user
2. Add that PAT as a repository secret (e.g., GALAXY_CI_TOKEN) (Settings -> Secrets and variables -> Actions)


When setting up the token on the `galaxy-ci account`, use **Fine-grained PAT**, then select these permissions:
* Repository Access: Select Only select repositories and pick `uyuni-project/uyuni-docs`.
* Repository Permissions:
  * Contents: Select `Read and write` (this allows pushing git commits).
  * Metadata: Select Read-only (automatically added).