### PR TITLE
Remove Kiwi RPM repackaging instructions from SSL CA migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed obsolete Kiwi OS image certificate RPM repackaging steps.
 - Documented how to configure channel automatic synchronization in Administration
   Guide
 -  Added SSL CA migration guide and warnings about new Basic Constraints

--- a/en/modules/administration/pages/ssl-certs-ca-migration.adoc
+++ b/en/modules/administration/pages/ssl-certs-ca-migration.adoc
@@ -78,15 +78,6 @@ You also need to run a similar command for [literal]``db-ca``.
 Once the server trusts the new CA, distribute it to every client and proxy.
 Deploy the new CA to all Salt clients by applying the highstate, as described in xref:administration:ssl-certs-imported.adoc#ssl-certs-import-deploy-root-ca[].
 
-If you build images with Kiwi, repackage the OS image RPM now so it includes the updated CA bundle with both the old and new root CAs, then apply the highstate on the image build hosts:
-
-[source,shell]
-----
-mgrctl exec -- mgr-package-rpm-certificate-osimage
-----
-
-This way, images built during the overlap period already trust the new CA, so hosts deployed from them keep working after the switch.
-
 On each {productname} Proxy, make it trust the new CA without a full redeployment.
 The proxy reads its trusted CA from the [literal]``uyuni-ca`` Podman secret, so update that secret directly.
 After [command]``mgradm ssl add-ca``, the server publishes the combined CA bundle, which contains both the old and new root CAs, at [path]``http://SERVER_FQDN/pub/RHN-ORG-TRUSTED-SSL-CERT``.
@@ -206,5 +197,3 @@ endif::[]
 ifeval::[{uyuni-content} == true]
 xref:installation-and-upgrade:container-deployment/uyuni/proxy-deployment-uyuni.adoc#proxy-setup-containers-generate-config[Proxy Deployment].
 endif::[]
-
-If you build images with Kiwi, repackage the OS image RPM again using [command]``mgrctl exec -- mgr-package-rpm-certificate-osimage`` now that the server uses the new CA, then apply the highstate on the image build hosts.

--- a/en/modules/administration/pages/ssl-certs-imported.adoc
+++ b/en/modules/administration/pages/ssl-certs-imported.adoc
@@ -206,22 +206,6 @@ endif::[]
 If the Root CA was changed, it needs to get deployed to all the clients connected to {productname}.
 This is ideally done in advance to minimize the disruption.
 
-[NOTE]
-====
-If the CA certificate was updated, a RPM file with Kiwi certificate needs to be repackaged.
-
-On the {productname} Server container host, execute following command:
-
-[source,shell]
-----
-mgrctl exec mgr-package-rpm-certificate-osimage
-----
-
-After that, apply highstate on the Image Build hosts to deploy the new certificates for Kiwi to use.
-====
-
-
-
 [[ssl-certs-import-deploy-root-ca]]
 .Procedure: Deploying the root CA on clients
 [role=procedure]


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

These instructions are not required anymore and the same logic is run automatically by Uyuni now, so this PR removes them.

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
