### PR TITLE
Fix API call and add output examples for channel auto-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Fixed incorrect API call and added output examples for channel automatic 
+  synchronization in Administration Guide (bsc#1269155)
 - Documented how to configure channel automatic synchronization in Administration
   Guide
 -  Added SSL CA migration guide and warnings about new Basic Constraints

--- a/en/modules/administration/pages/skip_auto_sync_channels.adoc
+++ b/en/modules/administration/pages/skip_auto_sync_channels.adoc
@@ -3,7 +3,7 @@
 :revdate: 2026-05-08
 :page-revdate: {revdate}
 
-By default, channels are automatically synchronized with the upstream repositories to ensure that clients have access to the latest content and updates. 
+By default, channels are automatically synchronized with the upstream repositories to ensure that clients have access to the latest content and updates.
 However, in some cases, you may want to disable this automatic synchronization for specific channels.
 
 This chapter explains how to disable automatic synchronization for a channel.
@@ -16,13 +16,19 @@ This chapter explains how to disable automatic synchronization for a channel.
 
 To check if a channel is set to be automatically synchronized user can call an API.
 
-To check the synchronization status of a channel using the API, use the following command. 
+To check the synchronization status of a channel using the API, use the following command.
 Replace `<Channel_Label>` with the actual label of the channel you want to check
 
 [source,console]
 ----
 spacecmd api -- --args "<Channel_Label>" channel.software.isAutoSync
+INFO: Connected to http://localhost/rpc/api as admin
+[
+  true
+]
 ----
+
+The command will return `true` if automatic synchronization is enabled, or `false` if it is disabled.
 
 This information is also available in the {webui}.
 To check the synchronization status, navigate to the channel details page and look for the field [litera]``Automatic Repository Synchronization``.
@@ -37,7 +43,22 @@ Here is an example of how to set a channel to skip automatic synchronization usi
 
 [source,console]
 ----
-spacecmd api -- --args '["<Channel_Label>", true] channel.software.isAutoSync
+spacecmd api -- --args '["<Channel_Label>", false]' channel.software.setAutoSync
+INFO: Connected to http://localhost/rpc/api as admin
+[
+  false
+]
+----
+
+To re-enable automatic synchronization, set the second parameter to `true`:
+
+[source,console]
+----
+spacecmd api -- --args '["<Channel_Label>", true]' channel.software.setAutoSync
+INFO: Connected to http://localhost/rpc/api as admin
+[
+  true
+]
 ----
 
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

- **Fixed**: Corrected API call from `channel.software.isAutoSync` to `channel.software.setAutoSync` for setting sync status
- Added output examples for `channel.software.isAutoSync` (checking status)
- Added output examples for `channel.software.setAutoSync` with both `true` and `false` parameters
- Added explanation of what `true`/`false` return values mean
- Included example for re-enabling automatic synchronization (previously only showed how to disable)
- Added changelog entry with the bug number


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master current PR
- 5.1
- 5.0
- 4.3


# Links
- This PR tracks issue no issue, directly from doc review in GMC testing
- Related development PR #<insert PR link, if any>
