### PR TITLE
manager-5.0 - Document use_bundle_build custom info key for KIWI builds (bsc#1243168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Document use_bundle_build custom info key for KIWI builds (bsc#1243168)
 - Move Prometheus as the first section in Monitoring Formulas
 - Add information about optional TLS Grafana configuration (bsc#1268567)
 - Clarified Jinja templating in Client Configuration Guide (bsc#1262012)

--- a/modules/administration/pages/image-management.adoc
+++ b/modules/administration/pages/image-management.adoc
@@ -527,6 +527,8 @@ Administrators can override the default behavior using the following pillar or c
 * [literal]``use_kiwi_ng``: force the use of Kiwi 9,
 * [literal]``use_kiwi_container``: force the use of containerized Kiwi 10.
   To enable this, set the value to [literal]``1``.
+* [literal]``use_bundle_build``: upload additional KIWI bundle build artifacts (like [path]``.install.tar`` which contains PXE files, and [path]``.raw.xz``) to the server.
+  To enable this, set the value to [literal]``true``.
 
 
 ==== Version-specific configurations


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Short summary of why you created this PR (if you added documentation, please add any relevant diagram).


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5046
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5045
- 5.0 (this PR)
- 4.3 https://github.com/uyuni-project/uyuni-docs/pull/5044


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30249 / https://bugzilla.suse.com/show_bug.cgi?id=1243168
