### PR TITLE
manager-4.3 - Document use_bundle_build custom info key for KIWI builds (bsc#1243168)

### DIFF
--- a/modules/administration/pages/image-management.adoc
+++ b/modules/administration/pages/image-management.adoc
@@ -860,6 +860,17 @@ Details include where the image files are located and provided, image checksums,
 The generated pillar is available to all connected clients.
 ====
 
+[NOTE]
+====
+When building KIWI images with network boot (PXE) enabled (for example, using `installpxe="true"` and `installiso="true"` in the KIWI profile), the netboot artifacts might not be collected and uploaded to the server by default.
+To ensure that all bundle artifacts (including `.install.tar` containing the PXE files, and `.raw.xz`) are uploaded to the {productname} server, you must define the `use_bundle_build` custom info key on the build host.
+
+To configure this:
+
+. Navigate to menu:Systems[Custom System Info] in the {webui} and create a custom system info key named `use_bundle_build`.
+. Assign the `use_bundle_build` key with a value of `true` on the designated OS Image Build Host.
+====
+
 
 
 [[at.images.kiwi.troubleshooting]]


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Short summary of why you created this PR (if you added documentation, please add any relevant diagram).


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5046
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5045
- 5.0 https://github.com/uyuni-project/uyuni-docs/pull/5043
- 4.3 (this PR)


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30249 / https://bugzilla.suse.com/show_bug.cgi?id=1243168
