### PR TITLE
Added command to generate password hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Enhanced Prometheus formula with command to generate password hash in
+  Specialized Guides (bsc#1268570)
 - Updated SSO / SAML integration with Keycloak in Administration Guide (bsc#1261195)
 - Move Prometheus as the first section in Monitoring Formulas
 - Add information about optional TLS Grafana configuration (bsc#1268567)

--- a/en/modules/specialized-guides/pages/salt/salt-formula-monitoring.adoc
+++ b/en/modules/specialized-guides/pages/salt/salt-formula-monitoring.adoc
@@ -1,6 +1,6 @@
 [[monitoring-formula]]
 = Monitoring Formula
-:revdate: 2025-02-06
+:revdate: 2026-06-29
 :page-revdate: {revdate}
 
 The monitoring services in {productname} are configured using formulas with forms.
@@ -30,6 +30,12 @@ For more information about using monitoring, see xref:administration:monitoring.
 * In the [guimenu]``Server Key`` field, type the path to the TLS server key.
 * In the [guimenu]``User`` field, type the user name for Prometheus server.
 * In the [guimenu]``Password Hash`` field, type the password for Prometheus server hashed with bcrypt.
+** To generate password hash, use tool `htpassswd` available from `apache2-utils` package.
+** For example:
++
+----
+htpasswd -nbBC 10 "" "thePassword" | tr -d ':'
+----
 . In the [guimenu]``Uyuni Server`` section, set these parameters:
 * Check the [guimenu]``Enabled`` box to enable monitoring on this server.
 * Check the [guimenu]``Autodiscover clients`` box to enable Prometheus to automatically find and monitor new clients when they are added to the server.


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

Existing procedure enhanced with the instruction to generate password hash.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1 ?
- 5.0 ?

# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/31042 / bug https://bugzilla.suse.com/show_bug.cgi?id=1268570