### PR TITLE
Backport client feature tables and broken xref fixes from uyuni-2026.06.

### DIFF
--- a/en/modules/client-configuration/pages/clients-rh-rhui.adoc
+++ b/en/modules/client-configuration/pages/clients-rh-rhui.adoc
@@ -235,25 +235,25 @@ The channels you need for this procedure are:
 | Client Channel
 | Tools Channel
 
-| {redhat} 7
-| rhel7-pool-uyuni
+| {redhat} 10
+| rhel10-pool-uyuni
 | -
-| rhel7-uyuni-client
-
-| {redhat} 8
-| rhel8-pool-uyuni
-| -
-| rhel8-uyuni-client
+| rhel10-uyuni-client
 
 | {redhat} 9
 | rhel9-pool-uyuni
 | -
 | rhel9-uyuni-client
 
-| {redhat} 10
-| rhel10-pool-uyuni
+| {redhat} 8
+| rhel8-pool-uyuni
 | -
-| rhel10-uyuni-client
+| rhel8-uyuni-client
+
+| {redhat} 7
+| rhel7-pool-uyuni
+| -
+| rhel7-uyuni-client
 
 |===
 
@@ -306,10 +306,10 @@ ifeval::[{uyuni-content} == true]
 |===
 
 | OS Version  | Base Channel
-| {redhat} 7  | rhel7-pool-uyuni
-| {redhat} 8  | rhel8-pool-uyuni
-| {redhat} 9  | rhel9-pool-uyuni
 | {redhat} 10 | rhel10-pool-uyuni
+| {redhat} 9  | rhel9-pool-uyuni
+| {redhat} 8  | rhel8-pool-uyuni
+| {redhat} 7  | rhel7-pool-uyuni
 
 |===
 endif::[]
@@ -326,7 +326,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-For {redhat} 9 and {redhat} 8 clients, add both the Base and AppStream channels.
+For {redhat} 10, {redhat} 9 and {redhat} 8 clients, add both the Base and AppStream channels.
 You require packages from both channels.
 If you do not add both channels, you cannot create the bootstrap repository, due to missing packages.
 ====

--- a/en/modules/client-configuration/pages/supported-features-almalinux.adoc
+++ b/en/modules/client-configuration/pages/supported-features-almalinux.adoc
@@ -1,6 +1,6 @@
 [[supported-features-almalinux]]
 = Supported {almalinux} Features
-:revdate: 2024-09-30
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 
 
@@ -22,166 +22,203 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {almalinux} Operating Systems
 |===
-
 | Feature
+| {almalinux}{nbsp}10
 | {almalinux}{nbsp}9
 | {almalinux}{nbsp}8
 
 | Client
 | {check} (plain {almalinux})
 | {check} (plain {almalinux})
+| {check} (plain {almalinux})
 
 | System packages
+| {almalinux} Community
 | {almalinux} Community
 | {almalinux} Community
 
 | Registration
 | {check}
 | {check}
+| {check}
 
 | Install packages
+| {check}
 | {check}
 | {check}
 
 | Apply patches
 | {check}
 | {check}
+| {check}
 
 | Remote commands
+| {check}
 | {check}
 | {check}
 
 | System package states
 | {check}
 | {check}
+| {check}
 
 | System custom states
+| {check}
 | {check}
 | {check}
 
 | Group custom states
 | {check}
 | {check}
+| {check}
 
 | Organization custom states
+| {check}
 | {check}
 | {check}
 
 | System set manager (SSM)
 | {check}
 | {check}
+| {check}
 
 | Product migration {star}
+| {check}
 | {check}
 | {check}
 
 | System deployment (PXE/Kickstart)
 | {check}
 | {check}
+| {check}
 
 | System redeployment (Kickstart)
+| {check}
 | {check}
 | {check}
 
 | Contact methods
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
+| {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
+| {check}
 | {check}
 | {check}
 
 | Action chains
 | {check}
 | {check}
+| {check}
 
 | Staging (pre-download of packages)
+| {check}
 | {check}
 | {check}
 
 | Duplicate package reporting
 | {check}
 | {check}
+| {check}
 
 | CVE auditing
+| {check}
 | {check}
 | {check}
 
 | SCAP auditing
 | {check}
 | {check}
+| {check}
 
 | Package verification
+| {cross}
 | {cross}
 | {cross}
 
 | Package locking
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 
 | Maintenance Windows
 | {check}
 | {check}
+| {check}
 
 | System snapshot
+| {cross}
 | {cross}
 | {cross}
 
 | Configuration file management
 | {check}
 | {check}
+| {check}
 
 | Snapshots and profiles
+| {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 
 | Power management
 | {check}
 | {check}
+| {check}
 
 | Monitoring server
+| {cross}
 | {cross}
 | {cross}
 
 | Monitored clients
 | {check}
 | {check}
+| {check}
 
 | Docker buildhost
+| {cross}
 | {cross}
 | {cross}
 
 | Build Docker image with OS
 | {cross}
 | {cross}
+| {cross}
 
 | Kiwi buildhost
+| {cross}
 | {cross}
 | {cross}
 
 | Build Kiwi image with OS
 | {cross}
 | {cross}
+| {cross}
 
 | Recurring Actions
+| {check}
 | {check}
 | {check}
 
 | AppStreams
 | {check}
 | {check}
+| {check}
 
 | Yomi
 | N/A
 | N/A
-
+| N/A
 |===
 
 

--- a/en/modules/client-configuration/pages/supported-features-oracle.adoc
+++ b/en/modules/client-configuration/pages/supported-features-oracle.adoc
@@ -1,6 +1,6 @@
 [[supported-features-oracle]]
 = Supported Oracle Features
-:revdate: 2024-09-30
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 
 
@@ -23,153 +23,190 @@ The icons in this table indicate:
 .Supported Features on {oracle} Operating Systems
 |===
 | Feature
-| {oracle}{nbsp}8
-| {oracle}{nbsp}9
 | {oracle}{nbsp}10
+| {oracle}{nbsp}9
+| {oracle}{nbsp}8
+
 | Client
 | {check}
 | {check}
 | {check}
+
 | Operating system packages
 | {check}
 | {check}
 | {check}
+
 | Registration
 | {check}
 | {check}
 | {check}
+
 | Install packages
 | {check}
 | {check}
 | {check}
+
 | Apply patches (requires CVE ID)
 | {check}
 | {check}
 | {check}
+
 | Remote commands
 | {check}
 | {check}
 | {check}
+
 | System package states
 | {check}
 | {check}
 | {check}
+
 | System custom states
 | {check}
 | {check}
 | {check}
+
 | Group custom states
 | {check}
 | {check}
 | {check}
+
 | Organization custom states
 | {check}
 | {check}
 | {check}
+
 | System set manager (SSM)
 | {check}
 | {check}
 | {check}
+
 | Product migration {star}
 | {check}
 | {check}
 | {check}
+
 | System deployment (PXE/Kickstart)
 | {check}
 | {check}
 | {check}
+
 | System redeployment (Kickstart)
 | {check}
 | {check}
 | {check}
+
 | Contact methods
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
+
 | Works with {productname} Proxy
 | {check}
 | {check}
 | {check}
+
 | Action chains
 | {check}
 | {check}
 | {check}
+
 | Staging (pre-download of packages)
 | {check}
 | {check}
 | {check}
+
 | Duplicate package reporting
 | {check}
 | {check}
 | {check}
+
 | CVE auditing (requires CVE ID)
 | {check}
 | {check}
 | {check}
+
 | SCAP auditing
 | {check}
 | {check}
 | {check}
+
 | Package locking
 | {check}
 | {check}
 | {check}
+
 | System locking
 | {cross}
 | {cross}
 | {cross}
+
 | Maintenance Windows
 | {check}
 | {check}
 | {check}
+
 | System snapshot
 | {cross}
 | {cross}
 | {cross}
+
 | Configuration file management
 | {check}
 | {check}
 | {check}
+
 | Snapshots and profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
+
 | Power management
 | {check}
 | {check}
 | {check}
+
 | Monitoring server
 | {cross}
 | {cross}
 | {cross}
+
 | Monitored clients
 | {check}
 | {check}
 | {check}
+
 | Docker buildhost
 | {cross}
 | {cross}
 | {cross}
+
 | Build Docker image with OS
 | {cross}
 | {cross}
 | {cross}
+
 | Kiwi buildhost
 | {cross}
 | {cross}
 | {cross}
+
 | Build Kiwi image with OS
 | {cross}
 | {cross}
 | {cross}
+
 | Recurring Actions
 | {check}
 | {check}
 | {check}
+
 | AppStreams
 | {check}
 | {check}
 | {check}
+
 | Yomi
 | N/A
 | N/A

--- a/en/modules/client-configuration/pages/supported-features-rh.adoc
+++ b/en/modules/client-configuration/pages/supported-features-rh.adoc
@@ -1,6 +1,6 @@
 [[supported-features-rh]]
 = Supported {rhel} Features
-:revdate: 2025-02-06
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 
 ifeval::[{mlm-content} == true]
@@ -29,16 +29,17 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1,1,1", options="header"]
+[cols="1,1,1,1,1", options="header"]
 .Supported Features on {rhel} Operating Systems
 |===
-
 | Feature
-| {rhela}{nbsp}7
-| {rhela}{nbsp}8
+| {rhela}{nbsp}10
 | {rhela}{nbsp}9
+| {rhela}{nbsp}8
+| {rhela}{nbsp}7
 
 | Client
+| {check}
 | {check}
 | {check}
 | {check}
@@ -47,8 +48,10 @@ The icons in this table indicate:
 | {redhat}
 | {redhat}
 | {redhat}
+| {redhat}
 
 | Registration
+| {check}
 | {check}
 | {check}
 | {check}
@@ -57,8 +60,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 | {check}
@@ -67,8 +72,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 | {check}
@@ -77,8 +84,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 | {check}
@@ -87,8 +96,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 | {check}
@@ -97,8 +108,10 @@ The icons in this table indicate:
 | N/A
 | N/A
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {check}
 | {check}
 | {check}
 | {check}
@@ -107,8 +120,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
@@ -117,8 +132,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 | {check}
@@ -127,8 +144,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 | {check}
@@ -137,8 +156,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {check}
 | {check}
 | {check}
 | {check}
@@ -147,8 +168,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -157,8 +180,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System snapshot
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -167,8 +192,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Snapshots and profiles
+| {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
@@ -177,8 +204,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Monitoring server
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -187,8 +216,10 @@ The icons in this table indicate:
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Docker buildhost
+| {check}
 | {check}
 | {check}
 | {check}
@@ -197,8 +228,10 @@ The icons in this table indicate:
 | {question}
 | {question}
 | {question}
+| {question}
 
 | Kiwi buildhost
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -207,22 +240,25 @@ The icons in this table indicate:
 | {cross}
 | {cross}
 | {cross}
+| {cross}
 
 | Recurring Actions
 | {check}
 | {check}
 | {check}
+| {check}
 
 | AppStreams
+| {check}
+| {check}
+| {check}
 | N/A
-| {check}
-| {check}
 
 | Yomi
 | N/A
 | N/A
 | N/A
-
+| N/A
 |===
 
 {star} Product migration to matching {sll} version.

--- a/en/modules/client-configuration/pages/supported-features-rocky.adoc
+++ b/en/modules/client-configuration/pages/supported-features-rocky.adoc
@@ -1,6 +1,6 @@
 [[supported-features-rocky]]
 = Supported {rocky} Features
-:revdate: 2024-09-30
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 
 
@@ -21,178 +21,218 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {rocky} Operating Systems
 |===
-
 | Feature
-| {rocky}{nbsp}8
+| {rocky}{nbsp}10
 | {rocky}{nbsp}9
+| {rocky}{nbsp}8
 
 | Client
+| {check} (plain {rocky})
 | {check} (plain {rocky})
 | {check} (plain {rocky})
 
 | System packages
 | {rocky} Community
 | {rocky} Community
+| {rocky} Community
 
 | Registration
+| {check}
 | {check}
 | {check}
 
 | Install packages
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 
 | Remote commands
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 
 | System custom states
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 
 | Organization custom states
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 
 | Product migration {star}
 | {check}
 | {check}
+| {check}
 
 | Basic Virtual Guest Management {star}{star}
+| {check}
 | {check}
 | {check}
 
 | Advanced Virtual Guest Management {star}{star}
 | {check}
 | {check}
+| {check}
 
 | Virtual Guest Installation (Kickstart), as Host OS
+| {cross}
 | {cross}
 | {cross}
 
 | Virtual Guest Installation (image template), as Host OS
 | {check}
 | {check}
+| {check}
 
 | System deployment (PXE/Kickstart)
+| {check}
 | {check}
 | {check}
 
 | System redeployment (Kickstart)
 | {check}
 | {check}
+| {check}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 
 | Staging (pre-download of packages)
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 
 | CVE auditing
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {check}
 | {check}
 | {check}
 
 | Package locking
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 
 | Maintenance Windows
 | {check}
 | {check}
+| {check}
 
 | System snapshot
+| {cross}
 | {cross}
 | {cross}
 
 | Configuration file management
 | {check}
 | {check}
+| {check}
 
 | Snapshots and profiles
+| {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 
 | Power management
 | {check}
 | {check}
+| {check}
 
 | Monitoring server
+| {cross}
 | {cross}
 | {cross}
 
 | Monitored clients
 | {check}
 | {check}
+| {check}
 
 | Docker buildhost
+| {cross}
 | {cross}
 | {cross}
 
 | Build Docker image with OS
 | {cross}
 | {cross}
+| {cross}
 
 | Kiwi buildhost
+| {cross}
 | {cross}
 | {cross}
 
 | Build Kiwi image with OS
 | {cross}
 | {cross}
+| {cross}
 
 | Recurring Actions
+| {check}
 | {check}
 | {check}
 
 | AppStreams
 | {check}
 | {check}
+| {check}
 
 | Yomi
 | N/A
 | N/A
-
+| N/A
 |===
 
 

--- a/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
@@ -1,6 +1,6 @@
 [[supported-features-ubuntu]]
 = Supported {ubuntu} Features
-:revdate: 2025-03-13
+:revdate: 2026-05-21
 :page-revdate: {revdate}
 
 
@@ -24,10 +24,9 @@ ifeval::[{mlm-content} == true]
 [cols="1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
-
 | Feature
-| {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}22.04
 
 | Client
 | {check}
@@ -180,7 +179,6 @@ ifeval::[{mlm-content} == true]
 | Yomi
 | N/A
 | N/A
-
 |===
 
 endif::[]
@@ -189,13 +187,12 @@ endif::[]
 ifeval::[{uyuni-content} == true]
 
 
-[cols="1,1,1,1", options="header"]
+[cols="1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
-
 | Feature
-| {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}22.04
 
 | Client
 | {check}
@@ -244,7 +241,6 @@ ifeval::[{uyuni-content} == true]
 | Product migration
 | N/A
 | N/A
-| N/A
 
 | System deployment (PXE/Kickstart)
 | {cross}
@@ -287,6 +283,10 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 
 | Package locking
+| {check}
+| {check}
+
+| Maintenance Windows
 | {check}
 | {check}
 
@@ -341,7 +341,6 @@ ifeval::[{uyuni-content} == true]
 | Yomi
 | N/A
 | N/A
-
 |===
 
 endif::[]

--- a/en/modules/installation-and-upgrade/nav-installation-and-upgrade-guide.adoc
+++ b/en/modules/installation-and-upgrade/nav-installation-and-upgrade-guide.adoc
@@ -62,11 +62,9 @@ ifeval::[{uyuni-content} == true]
 *** Server
 **** xref:container-deployment/uyuni/migrate-uyuni-server-from-micro55-tumbleweed.adoc[Migrate the Server to openSUSE Tumbleweed]
 **** xref:container-deployment/uyuni/migrate-uyuni-to-a-container.adoc[Legacy Server Migration to Container]
-**** xref:container-management/updating-server-containers.adoc[Server Upgrade]
 *** Proxy
 **** xref:container-deployment/uyuni/migrate-uyuni-proxy-from-micro55-tumbleweed.adoc[Migrate the Proxy to openSUSE Tumbleweed]
 **** xref:container-deployment/uyuni/proxy-migration-uyuni.adoc[Legacy Proxy Migration to Container]
-**** xref:container-management/updating-proxy-containers.adoc[Proxy Upgrade]
 *** Clients
 **** xref:client-intro.adoc[Upgrading Clients]
 endif::[]

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
@@ -24,7 +24,8 @@ The recommended installation method is using the provided {productname} Virtual 
 
 For more information about installing {productname} Proxy Virtual Machine, see xref:container-deployment/mlm/proxy-deployment-vm-mlm.adoc[Deploy Proxy as a Virtual Machine].
 
-To upgrade {productname} Proxy, users should follow the procedures defined in xref:container-management/updating-proxy-containers.adoc[Proxy Upgrade].
+To upgrade {productname} Proxy, upgrade all packages on the host system, then run [command]``mgrpxy upgrade podman``.
+For air-gapped installations, upgrade the container RPM packages before running [command]``mgrpxy upgrade podman``.
 
 
 == Deploy {productname} on {sl-micro}
@@ -57,7 +58,8 @@ ____
 
 For more detailed information about installing {productname} Proxy on {sl-micro}, see xref:container-deployment/mlm/proxy-deployment-mlm.adoc[Deploy Proxy as a Virtual Machine].
 
-To upgrade {productname} Proxy, users should follow the procedures defined in xref:container-management/updating-proxy-containers.adoc[Proxy Upgrade].
+To upgrade {productname} Proxy, upgrade all packages on the host system, then run [command]``mgrpxy upgrade podman``.
+For air-gapped installations, upgrade the container RPM packages before running [command]``mgrpxy upgrade podman``.
 
 
 == Formula images

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -25,7 +25,8 @@ The recommended installation method is using the provided {productname} Virtual 
 
 For more information about installing {productname} Server Virtual Machine, see xref:container-deployment/mlm/server-deployment-vm-mlm.adoc[Deploy Server as a Virtual Machine].
 
-To upgrade {productname} Server, users should upgrade all packages in the system and follow the procedures defined in xref:container-management/updating-server-containers.adoc[Server Upgrade].
+To upgrade {productname} Server, upgrade all packages on the host system, then run [command]``mgradm upgrade podman``.
+For air-gapped installations, upgrade the container RPM packages before running [command]``mgradm upgrade podman``.
 
 
 === Deploy {productname} on {sl-micro}
@@ -64,7 +65,8 @@ ____
 
 For more detailed information about installing {productname} Server on {sl-micro}, see xref:container-deployment/mlm/server-deployment-mlm.adoc[Deploy Server as a Virtual Machine].
 
-To upgrade {productname} Server, users should upgrade all packages in the system and follow the procedures defined in xref:container-management/updating-server-containers.adoc[Server Upgrade].
+To upgrade {productname} Server, upgrade all packages on the host system, then run [command]``mgradm upgrade podman``.
+For air-gapped installations, upgrade the container RPM packages before running [command]``mgradm upgrade podman``.
 
 
 == PTFs

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -95,5 +95,6 @@ zypper install mgradm* mgrctl* uyuni-server*-image*
 
 For more detailed information about installing {productname} Server on {opensuse} {tumbleweed}, see xref:container-deployment/uyuni/server-deployment-uyuni.adoc[Server Deployment].
 
-To upgrade {productname} Server, users should upgrade all packages in the system and follow the procedures defined in xref:container-management/updating-server-containers.adoc[Server Upgrade].
+To upgrade {productname} Server, apply available host updates with [command]``transactional-update``, reboot if updates were applied, then run [command]``mgradm upgrade podman``.
+For air-gapped installations, upgrade the container RPM packages before running [command]``mgradm upgrade podman``.
 

--- a/l10n-weblate/installation-and-upgrade.cfg
+++ b/l10n-weblate/installation-and-upgrade.cfg
@@ -66,6 +66,7 @@
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-start-proxy.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-start-proxy.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-step-deploy-podman-certs.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-step-deploy-podman-certs.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-tag-containers.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-tag-containers.adoc
+[type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-third-party-ssl.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-third-party-ssl.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-transfer_proxy_config.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-version-number.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-version-number.adoc
 [type: asciidoc] en/modules/installation-and-upgrade/partials/snippet-warn-images-sl-micro.adoc $lang:translations/$lang/modules/installation-and-upgrade/partials/snippet-warn-images-sl-micro.adoc


### PR DESCRIPTION
Add EL 10 columns to per-OS supported-features tables with newest-first version ordering, fix the Ubuntu Uyuni table layout, remove stale upgrade nav xrefs after #5051, and inline air-gapped upgrade steps.
