### PR TITLE
fix ordering and add raspberry pi os 13

### DIFF
--- a/en/modules/client-configuration/pages/supported-features-almalinux.adoc
+++ b/en/modules/client-configuration/pages/supported-features-almalinux.adoc
@@ -26,9 +26,9 @@ The icons in this table indicate:
 .Supported Features on {almalinux} Operating Systems
 |===
 | Feature
-| {almalinux}{nbsp}10
-| {almalinux}{nbsp}9
 | {almalinux}{nbsp}8
+| {almalinux}{nbsp}9
+| {almalinux}{nbsp}10
 
 | Client
 | {check} (plain {almalinux})

--- a/en/modules/client-configuration/pages/supported-features-oes.adoc
+++ b/en/modules/client-configuration/pages/supported-features-oes.adoc
@@ -24,9 +24,9 @@ The icons in this table indicate:
 |===
 
 | Feature
-| {oes}{nbsp}25.4
-| {oes}{nbsp}24.4
 | {oes}{nbsp}23.4
+| {oes}{nbsp}24.4
+| {oes}{nbsp}25.4
 
 | Client
 | {check}

--- a/en/modules/client-configuration/pages/supported-features-oracle.adoc
+++ b/en/modules/client-configuration/pages/supported-features-oracle.adoc
@@ -23,9 +23,9 @@ The icons in this table indicate:
 .Supported Features on {oracle} Operating Systems
 |===
 | Feature
-| {oracle}{nbsp}10
-| {oracle}{nbsp}9
 | {oracle}{nbsp}8
+| {oracle}{nbsp}9
+| {oracle}{nbsp}10
 
 | Client
 | {check}

--- a/en/modules/client-configuration/pages/supported-features-raspberrypios.adoc
+++ b/en/modules/client-configuration/pages/supported-features-raspberrypios.adoc
@@ -18,119 +18,156 @@ The icons in this table indicate:
 * {question} the feature is under consideration, and may or may not be made available at a later date
 
 ifeval::[{mlm-content} == true]
-[cols="1,1", options="header"]
+[cols="1,1,1", options="header"]
 .Supported Features on {raspberrypios} Operating Systems
 |===
 
 | Feature
 | {raspberrypios}{nbsp}12
+| {raspberrypios}{nbsp}13
 
 | Client
+| {check}
 | {check}
 
 | System packages
 | {raspberrypios} Community
+| {raspberrypios} Community
 
 | Registration
+| {check}
 | {check}
 
 | Install packages
 | {check}
+| {check}
 
 | Apply patches
+| {question}
 | {question}
 
 | Remote commands
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 
 | System custom states
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 
 | Organization custom states
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 
 | Product migration
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {cross}
 | {cross}
 
 | System redeployment (Kickstart)
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Action chains
 | {check}
+| {check}
 
 | Staging (pre-download of packages)
+| {check}
 | {check}
 
 | Duplicate package reporting
 | {check}
+| {check}
 
 | CVE auditing
+| {question}
 | {question}
 
 | SCAP auditing
 | {question}
+| {question}
 
 | Package locking
+| {check}
 | {check}
 
 | System locking
 | {cross}
+| {cross}
 
 | Maintenance Windows
+| {check}
 | {check}
 
 | System snapshot
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 
 | Monitoring server
 | {cross}
+| {cross}
 
 | Monitoring clients
+| {check}
 | {check}
 
 | Docker buildhost
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {check}
 | {check}
 
 | Kiwi buildhost
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 
 | Recurring Actions
 | {check}
+| {check}
 
 | AppStreams
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 
 |===

--- a/en/modules/client-configuration/pages/supported-features-rh.adoc
+++ b/en/modules/client-configuration/pages/supported-features-rh.adoc
@@ -33,10 +33,10 @@ The icons in this table indicate:
 .Supported Features on {rhel} Operating Systems
 |===
 | Feature
-| {rhela}{nbsp}10
-| {rhela}{nbsp}9
-| {rhela}{nbsp}8
 | {rhela}{nbsp}7
+| {rhela}{nbsp}8
+| {rhela}{nbsp}9
+| {rhela}{nbsp}10
 
 | Client
 | {check}
@@ -249,10 +249,10 @@ The icons in this table indicate:
 | {check}
 
 | AppStreams
-| {check}
-| {check}
-| {check}
 | N/A
+| {check}
+| {check}
+| {check}
 
 | Yomi
 | N/A

--- a/en/modules/client-configuration/pages/supported-features-rocky.adoc
+++ b/en/modules/client-configuration/pages/supported-features-rocky.adoc
@@ -25,9 +25,9 @@ The icons in this table indicate:
 .Supported Features on {rocky} Operating Systems
 |===
 | Feature
-| {rocky}{nbsp}10
-| {rocky}{nbsp}9
 | {rocky}{nbsp}8
+| {rocky}{nbsp}9
+| {rocky}{nbsp}10
 
 | Client
 | {check} (plain {rocky})

--- a/en/modules/client-configuration/pages/supported-features-sl-micro.adoc
+++ b/en/modules/client-configuration/pages/supported-features-sl-micro.adoc
@@ -26,9 +26,9 @@ The icons in this table indicate:
 .Supported Features on {sl-micro} Operating Systems
 |===
 | Feature
-| {sl-micro}{nbsp}6.2
-| {sl-micro}{nbsp}6.1
 | {sl-micro}{nbsp}6.0
+| {sl-micro}{nbsp}6.1
+| {sl-micro}{nbsp}6.2
 | Client
 | {check}
 | {check}

--- a/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
@@ -25,8 +25,8 @@ ifeval::[{mlm-content} == true]
 .Supported Features on {ubuntu} Operating Systems
 |===
 | Feature
-| {ubuntu}{nbsp}24.04
 | {ubuntu}{nbsp}22.04
+| {ubuntu}{nbsp}24.04
 
 | Client
 | {check}
@@ -191,8 +191,8 @@ ifeval::[{uyuni-content} == true]
 .Supported Features on {ubuntu} Operating Systems
 |===
 | Feature
-| {ubuntu}{nbsp}24.04
 | {ubuntu}{nbsp}22.04
+| {ubuntu}{nbsp}24.04
 
 | Client
 | {check}

--- a/en/modules/client-configuration/pages/supported-features.adoc
+++ b/en/modules/client-configuration/pages/supported-features.adoc
@@ -42,13 +42,13 @@ ifeval::[{mlm-content} == true]
 | {ibmz}
 | {aarch64}
 
-| {sle} 16, 15, 12
+| {sle} 12, 15, 16
 | {check}
 | {check}
 | {check}
 | {check}
 
-| {sles} for SAP 16, 15, 12
+| {sles} for SAP 12, 15, 16
 | {check}
 | {check}
 | {cross}
@@ -60,7 +60,7 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {check}
 
-| {sl-micro} 6.2, 6.1, 6.0
+| {sl-micro} 6.0, 6.1, 6.2
 | {check}
 | {cross}
 | {cross}
@@ -78,25 +78,25 @@ ifeval::[{mlm-content} == true]
 | {check}
 | {check}
 
-| {sll} 10, 9.6 EMS, 9, 8, 7
+| {sll} 7, 8, 9, 9.6 EMS, 10
 | {check}
 | {cross}
 | {cross}
 | {cross}
 
-| {sles} ES 8, 7
+| {sles} ES 7, 8
 | {check}
 | {cross}
 | {cross}
 | {cross}
 
-| {almalinux} 10, 9, 8
+| {almalinux} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {check}
 
-| {amazon} 2023, 2
+| {amazon} 2, 2023
 | {check}
 | {cross}
 | {cross}
@@ -114,31 +114,31 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {cross}
 
-| {oes} 24.4, 23.4
+| {oes} 23.4, 24.4, 25.4
 | {check}
 | {cross}
 | {cross}
 | {cross}
 
-| {oracle} 10, 9, 8
+| {oracle} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {check}
 
-| {rhel} 10, 9, 8, 7
+| {rhel} 7, 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {cross}
 
-| {rocky} 10, 9, 8
+| {rocky} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {check}
 
-| {ubuntu} 24.04, 22.04 (*)
+| {ubuntu} 22.04, 24.04 (*)
 | {check}
 | {cross}
 | {cross}
@@ -162,14 +162,14 @@ ifeval::[{uyuni-content} == true]
 | {aarch64}
 | {arm64} / {armhf}
 
-| {sle} 16, 15, 12
+| {sle} 12, 15, 16
 | {check}
 | {check}
 | {check}
 | {check}
 | {cross}
 
-| {sles} for SAP 16, 15, 12
+| {sles} for SAP 12, 15, 16
 | {check}
 | {check}
 | {cross}
@@ -183,7 +183,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {sl-micro} 6.2, 6.1, 6.0
+| {sl-micro} 6.0, 6.1, 6.2
 | {check}
 | {cross}
 | {cross}
@@ -225,14 +225,14 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {almalinux} 10, 9, 8
+| {almalinux} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {check}
 | {cross}
 
-| {amazon} 2003, 2
+| {amazon} 2, 2023
 | {check}
 | {cross}
 | {cross}
@@ -260,14 +260,14 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 
-| {oes} 24.4, 23.4
+| {oes} 23.4, 24.4, 25.4
 | {check}
 | {cross}
 | {cross}
 | {cross}
 | {cross}
 
-| {oracle} 10, 9, 8
+| {oracle} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
@@ -281,21 +281,21 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {check}
 
-| {rhel} 10, 9, 8, 7
+| {rhel} 7, 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {cross}
 | {cross}
 
-| {rocky} 10, 9, 8
+| {rocky} 8, 9, 10
 | {check}
 | {cross}
 | {cross}
 | {check}
 | {cross}
 
-| {ubuntu} 24.04, 22.04
+| {ubuntu} 22.04, 24.04
 | {check}
 | {cross}
 | {cross}


### PR DESCRIPTION
Updates supported features tables with correct version left to right ordering. 