### PR TITLE
Fixed incorrect 6.1 references

### DIFF
--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
@@ -20,7 +20,7 @@ Only the following operating systems are currently supported for proxy conversio
 
 * {sles} 15 SP7
 
-* {sl-micro} 6.1
+* {sl-micro} 6.2
 
 === Client Must Be
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
@@ -35,9 +35,9 @@ endif::[]
 
 [NOTE]
 ====
-For more information on preparing raw images, see https://documentation.suse.com/sle-micro/6.1/html/Micro-deployment-raw-images-virtual-machines/index.html#deployment-preparing-configuration-device[].
+For more information on preparing raw images, see https://documentation.suse.com/sle-micro/6.2/html/Micro-deployment-raw-images-virtual-machines/index.html#deployment-preparing-configuration-device[].
 
-For additional information on the self install images, see https://documentation.suse.com/sle-micro/6.1/html/Micro-deployment-selfinstall-images/index.html
+For additional information on the self install images, see https://documentation.suse.com/sle-micro/6.2/html/Micro-deployment-selfinstall-images/index.html
 ====
 
 // FIXME more archs supported?

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
@@ -34,11 +34,11 @@ endif::[]
 
 [NOTE]
 ====
-For more information on preparing raw images, see https://documentation.suse.com/sle-micro/6.1/html/Micro-deployment-raw-images-virtual-machines/index.html#deployment-preparing-configuration-device[].
+For more information on preparing raw images, see https://documentation.suse.com/sle-micro/6.2/html/Micro-deployment-raw-images-virtual-machines/index.html#deployment-preparing-configuration-device[].
 // For the 5.0 backport:
 // For more information on preparing raw images, see link:https://documentation.suse.com/en-us/sle-micro/5.5/single-html/SLE-Micro-deployment/#sec-raw-preparation[].
 
-For additional information on the self install images, see https://documentation.suse.com/sle-micro/6.1/html/Micro-deployment-selfinstall-images/index.html
+For additional information on the self install images, see https://documentation.suse.com/sle-micro/6.2/html/Micro-deployment-selfinstall-images/index.html
 ====
 
 .Available Server Images


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

See https://suse.slack.com/archives/C02D12QAXV1/p1783346231799869,  thanks to @nodeg 

The first 3 errors reported in the chat were fixed, the other issues (broken links) work when docs are built.

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master



# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
