### PR TITLE
Adjust rke2 server doc to the new way to expose the reportdb (bsc#127…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Removed unsupported {raspberrypios} 12 from Client Configuration Guide
 - Added a common workflow to setup crypto policies in the server container (bsc#1253505)
 - Document Ansible Playbook variable editing (bsc#1260396)
+- Adjust to the new way to expose the report database (bsc#1270038)
 - Convert broken `[role]``text`` double-backtick literals in `en/modules`
   to standard single-backtick literals for Weblate AI translation
   compatibility

--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -559,14 +559,6 @@ metadata:
 spec:
   valuesContent: |-
     ports:
-      reportdb-pgsql:
-        port: 5432
-        expose:
-          default: true
-        exposedPort: 5432
-        protocol: TCP
-        hostPort: 5432
-        containerPort: 5432
       salt-publish:
         port: 4505
         expose:
@@ -593,6 +585,16 @@ This means that there are only two possible ways to use the TFTP server:
 * using a load balancer compatible with TFTP,
 
 * using the host network for the TFTP pod. This can be achieved by setting the `tftp.hostNetwork` helm chart value to `true`.
+
+[IMPORTANT]
+====
+Exposing the report database externally requires configuring the [literal]``reportdb`` service as a [literal]``NodePort`` or [literal]``LoadBalancer`` (via the [literal]``services.reportdb`` value).
+
+Be aware of a critical security behavior: external database connections require SSL, whereas internal cluster connections do not.
+However, Traefik ingress TCP routes mask client IPs, causing PostgreSQL to view external traffic as internal.
+
+If you expose the database using a Traefik ingress TCP route and endpoint, you risk allowing clients to establish unencrypted, insecure connections.
+====
 
 [[security-framework-setup]]
 === Security framework setup


### PR DESCRIPTION
…0038) (#5057)

DO NOT MERGE UNTIL CODE IS IN

## Description

With https://github.com/uyuni-project/uyuni/pull/12194 the reportdb can no longer be exposed using Traefik TCP routes.
Document this change and the possible security issue if still trying to expose it this way
Target branches

    - master
    - 5.2

Links

    This PR tracks issue 

https://github.com/SUSE/spacewalk/issues/31100
Related development PR
https://github.com/uyuni-project/uyuni/pull/12194