### PR TITLE
DOC: Allow diskcheck env vars into containers (bsc#1270033) (#5053)

### DIFF
--- a/en/modules/administration/pages/space-management.adoc
+++ b/en/modules/administration/pages/space-management.adoc
@@ -1,6 +1,6 @@
 [[space-management]]
 = Disk Space Management
-:revdate: 2026-03-10
+:revdate: 2026-07-01
 :page-revdate: {revdate}
 
 Running out of disk space can have a severe impact on the {productname} database and file structure which, in some cases, is not recoverable.
@@ -21,7 +21,7 @@ By default, the {productname} Server container monitors these directories:
 * `/var/cache`
 * `/srv`
 
-You can change which directories are monitored by setting the `DISKCHECKDIRS` environment variable in the server container systemd service.
+You can change which directories are monitored by setting the `PODMAN_EXTRA_ENV_VAR` environment variable in the server container systemd service override file, which passes `DISKCHECKDIRS` to the container.
 You can specify multiple directories by separating them with a space.
 
 [NOTE]
@@ -42,7 +42,7 @@ mkdir -p /etc/systemd/system/uyuni-server.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
 EOF
 ----
 
@@ -74,14 +74,12 @@ mkdir -p /etc/systemd/system/uyuni-db.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=90"
-Environment="DISKTHRESHOLD=95"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=90 --env DISKTHRESHOLD=95"
 EOF
 
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=90"
-Environment="DISKTHRESHOLD=95"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=90 --env DISKTHRESHOLD=95"
 EOF
 ----
 
@@ -131,14 +129,12 @@ To effectively disable disk space monitoring, set the threshold values to 99 (pe
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=99"
-Environment="DISKTHRESHOLD=99"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=99 --env DISKTHRESHOLD=99"
 EOF
 
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=99"
-Environment="DISKTHRESHOLD=99"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=99 --env DISKTHRESHOLD=99"
 EOF
 ----
 

--- a/en/modules/administration/pages/troubleshooting/tshoot-diskspace.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-diskspace.adoc
@@ -1,6 +1,6 @@
 [[troubleshooting-disk-space]]
 = Troubleshooting Disk Space
-:revdate: 2024-06-19
+:revdate: 2026-07-01
 :page-revdate: {revdate}
 
 ////
@@ -76,8 +76,8 @@ A common configuration included `/var/lib/pgsql` to monitor database disk space.
 
 In containerized deployments:
 
-* The `spacecheck_dirs` parameter in `/etc/rhn/rhn.conf` is still read, but is overridden by the `DISKCHECKDIRS` environment variable if set
-* If `DISKCHECKDIRS` is not set, the system falls back to `spacecheck_dirs` from the configuration file
+* The `PODMAN_EXTRA_ENV_VAR` environment variable is the recommended way to pass `DISKCHECKDIRS`, `DISKCHECKALERT`, and `DISKTHRESHOLD` into the container
+* The legacy `spacecheck_dirs` parameter in `/etc/rhn/rhn.conf` is only used as a fallback when the corresponding environment variable is not set
 * The database runs in a separate container and has its own dedicated disk check
 
 
@@ -98,7 +98,7 @@ cat /etc/systemd/system/uyuni-server.service.d/diskcheck.conf
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
 EOF
 ----
 

--- a/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
+++ b/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
@@ -1,6 +1,6 @@
 [[lsd-tuning]]
 = Tuning Large Scale Deployments
-:revdate: 2026-05-26
+:revdate: 2026-07-01
 :page-revdate: {revdate}
 
 {productname} is designed by default to work on small and medium scale installations.
@@ -768,8 +768,7 @@ mkdir -p /etc/systemd/system/uyuni-db.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=95"
-Environment="DISKTHRESHOLD=98"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=95 --env DISKTHRESHOLD=98"
 EOF
 ----
 
@@ -778,8 +777,7 @@ EOF
 ----
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=95"
-Environment="DISKTHRESHOLD=98"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=95 --env DISKTHRESHOLD=98"
 EOF
 ----
 


### PR DESCRIPTION
* Allow diskcheck env vars into containers (bsc#1270033)

<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

as title

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5071

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31099
- Related development https://github.com/uyuni-project/uyuni/pull/12193
