### PR TITLE
Allow diskcheck env vars into containers (bsc#1270033) (#5071)

### DIFF
--- a/en/modules/administration/pages/space-management.adoc
+++ b/en/modules/administration/pages/space-management.adoc
@@ -1,7 +1,7 @@
 [[space-management]]
 = Disk Space Management
 :description: Configure disk space monitoring and alert settings in SUSE Multi-Linux Manager to ensure timely warnings and notifications for low disk space
-:revdate: 2026-03-10
+:revdate: 2026-07-01
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -26,7 +26,7 @@ By default, the {productname} Server container monitors these directories:
 * `/var/cache`
 * `/srv`
 
-You can change which directories are monitored by setting the `DISKCHECKDIRS` environment variable in the server container systemd service.
+You can change which directories are monitored by setting the `PODMAN_EXTRA_ENV_VAR` environment variable in the server container systemd service override file, which passes `DISKCHECKDIRS` to the container.
 You can specify multiple directories by separating them with a space.
 
 [NOTE]
@@ -47,7 +47,7 @@ mkdir -p /etc/systemd/system/uyuni-server.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
 EOF
 ----
 
@@ -79,14 +79,12 @@ mkdir -p /etc/systemd/system/uyuni-db.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=90"
-Environment="DISKTHRESHOLD=95"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=90 --env DISKTHRESHOLD=95"
 EOF
 
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=90"
-Environment="DISKTHRESHOLD=95"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=90 --env DISKTHRESHOLD=95"
 EOF
 ----
 
@@ -136,14 +134,12 @@ To effectively disable disk space monitoring, set the threshold values to 99 (pe
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=99"
-Environment="DISKTHRESHOLD=99"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=99 --env DISKTHRESHOLD=99"
 EOF
 
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=99"
-Environment="DISKTHRESHOLD=99"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=99 --env DISKTHRESHOLD=99"
 EOF
 ----
 

--- a/en/modules/administration/pages/troubleshooting/tshoot-diskspace.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-diskspace.adoc
@@ -81,8 +81,8 @@ A common configuration included `/var/lib/pgsql` to monitor database disk space.
 
 In containerized deployments:
 
-* The `spacecheck_dirs` parameter in `/etc/rhn/rhn.conf` is still read, but is overridden by the `DISKCHECKDIRS` environment variable if set
-* If `DISKCHECKDIRS` is not set, the system falls back to `spacecheck_dirs` from the configuration file
+* The `PODMAN_EXTRA_ENV_VAR` environment variable is the recommended way to pass `DISKCHECKDIRS`, `DISKCHECKALERT`, and `DISKTHRESHOLD` into the container
+* The legacy `spacecheck_dirs` parameter in `/etc/rhn/rhn.conf` is only used as a fallback when the corresponding environment variable is not set
 * The database runs in a separate container and has its own dedicated disk check
 
 
@@ -103,7 +103,7 @@ cat /etc/systemd/system/uyuni-server.service.d/diskcheck.conf
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKDIRS=/var/spacewalk /var/cache /srv"
 EOF
 ----
 

--- a/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
+++ b/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
@@ -1,7 +1,7 @@
 [[lsd-tuning]]
 = Tuning Large Scale Deployments
 :description: Learn how to optimize SUSE Multi-Linux Manager performance by following the steps outlined in this document for adequate hardware sizing and parameter tuning
-:revdate: 2026-06-29
+:revdate: 2026-07-01
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -789,8 +789,7 @@ mkdir -p /etc/systemd/system/uyuni-db.service.d/
 ----
 cat > /etc/systemd/system/uyuni-server.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=95"
-Environment="DISKTHRESHOLD=98"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=95 --env DISKTHRESHOLD=98"
 EOF
 ----
 
@@ -799,8 +798,7 @@ EOF
 ----
 cat > /etc/systemd/system/uyuni-db.service.d/diskcheck.conf << 'EOF'
 [Service]
-Environment="DISKCHECKALERT=95"
-Environment="DISKTHRESHOLD=98"
+Environment="PODMAN_EXTRA_ENV_VAR=--env DISKCHECKALERT=95 --env DISKTHRESHOLD=98"
 EOF
 ----
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description

as title

# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5053
- 5.1
  

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31099
- Related development https://github.com/uyuni-project/uyuni/pull/12193