### PR TITLE
Document SLES 15 SP7 to SLES 16.0 major upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Document SLES 15 SP7 to SLES 16.0 major upgrade via product migration in Client Configuration Guide
 - Document the repository value for helm charts on MLM (bsc#1269667)
 - Removed unsupported {raspberrypios} 12 from Client Configuration Guide
 - Added a common workflow to setup crypto policies in the server container (bsc#1253505)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Document SLES 15 SP7 to SLES 16.0 major upgrade via product migration in Client Configuration Guide
+- Documented SLES 15 SP7 to SLES 16.0 major upgrade via product migration in Client Configuration Guide
 - Document the repository value for helm charts on MLM (bsc#1269667)
 - Removed unsupported {raspberrypios} 12 from Client Configuration Guide
 - Added a common workflow to setup crypto policies in the server container (bsc#1253505)

--- a/en/modules/client-configuration/pages/client-upgrades-major.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-major.adoc
@@ -1,12 +1,20 @@
 [[client-upgrades-major]]
 = Major Version Upgrade
-:revdate: 2024-06-12
+:revdate: 2026-07-08
 :page-revdate: {revdate}
+
+This method covers major version upgrades such as {sles}{nbsp}12 to {sles}{nbsp}15.
+The upgrade is controlled by {yast} and {ay}, it does not use Zypper.
 
 The clients must have the latest available service pack (SP) for the installed operating system, with all the latest updates applied.
 Before you start, ensure that the system is up to date and all updates have been installed successfully.
 
-The upgrade is controlled by {yast} and {ay}, it does not use Zypper.
+[IMPORTANT]
+====
+This method does not apply to the upgrade from {sles}{nbsp}15 to {sles}{nbsp}16.
+To upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0, use product migration instead.
+For more information, see xref:client-configuration:client-upgrades-product-migration.adoc[].
+====
 
 
 

--- a/en/modules/client-configuration/pages/client-upgrades-product-migration.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-product-migration.adoc
@@ -1,42 +1,75 @@
 [[client-upgrades-spmigration]]
 = Product Migration
-:revdate: 2025-03-10
+:revdate: 2026-07-08
 :page-revdate: {revdate}
 
 == Introduction
 
 
-Product migration allows you to upgrade SLE-based client systems from an Service Pack (SP) level to a later one.
-For example, you can migrate {sles}{nbsp}15{nbsp}SP5 to {sles}{nbsp}15{nbsp}SP6.
-You can also upgrade clients such as {rhel} or {centos} to {sll}.
+Product migration lets you upgrade SLE-based client systems to a newer supported product version directly from the {webui}.
+This includes upgrading to a later Service Pack (SP) within the same major version, for example {sles}{nbsp}15{nbsp}SP5 to {sles}{nbsp}15{nbsp}SP6, as well as the major version upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0.
+
+You can also use it to upgrade clients such as {rhel} or {centos} to {sll}.
 
 [IMPORTANT]
 ====
 Product migration requires that all repositories which are enabled on the client and which should be migrated must be valid, otherwise the migration will abort.
 ====
 
-{productname} supports the following migration paths:
+{productname} supports the following migration paths using the product migration feature:
 
-=== Migration within the same major version
+[cols="1,1", options="header"]
+|===
+| Migration path | Example
 
-Product migration is for upgrading within the same major version.
+| Service Pack (SP) upgrade within the same major version
+| {sles}{nbsp}15{nbsp}SP5 to {sles}{nbsp}15{nbsp}SP6
+
+| {leap} to a later minor version
+| {leap}{nbsp}15.5 to {leap}{nbsp}15.6
+
+| {leap} to the corresponding {sles} SP
+| {leap}{nbsp}15.6 to {sles}{nbsp}15{nbsp}SP6
+
+| {sles} to the corresponding {slesforsap} SP
+| {sles}{nbsp}15{nbsp}SP5 to {slesforsap}{nbsp}15{nbsp}SP5
+
+| Major version upgrade to {sles}{nbsp}16.0
+| {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0
+
+| {rhel} or {centos} to {sll}
+| {rhel} to {sll}
+|===
+
+[NOTE]
+====
 You cannot use product migration to migrate from {sles}{nbsp}12 to {sles}{nbsp}15.
-For more information about major upgrades, see xref:client-configuration:client-upgrades-major.adoc[].
+To upgrade from {sles}{nbsp}12 to {sles}{nbsp}15, see xref:client-configuration:client-upgrades-major.adoc[].
+====
 
 
-=== Migration of {leap} to a later minor version or to the corresponding {sles} SP
+=== Major version upgrade to {sles}{nbsp}16.0
 
-You can also migrate {leap} to a later minor version or to the corresponding {sles} SP level, for example:
+The following applies specifically to the major version upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0.
 
-* {leap} 15.5 to 15.6
-* {leap} 15.6 to {sles} 15 SP6
+[IMPORTANT]
+====
+* The upgrade to {sles}{nbsp}16.0 is supported from {sles}{nbsp}15{nbsp}SP7 only.
+  Bring the client up to {sles}{nbsp}15{nbsp}SP7, with all the latest updates applied, before you migrate.
 
+* The migration is currently supported for regular (Salt) minions only.
+  Clients managed with Salt SSH cannot yet be migrated.
 
-=== Migration of {sles} to the corresponding {slesforsap} SP
+* The dry run option is not available when migrating from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0.
+====
 
-You can also migrate {sles} to the corresponding {slesforsap} SP level, for example:
+The migration to {sles}{nbsp}16.0 happens in two steps:
 
-* {sles} 15 SP5 to {slesforsap} 15 SP5
+. The migration action performs the actual product migration on the client.
+. Once the migration action has finished, whether it passed or failed, the system is rebooted automatically.
+  After the reboot, when the Salt minion connects to the {productname} Server again, the verification step starts automatically.
+
+To perform this upgrade, use the standard product migration procedures described in this page: the `Single System Migration` procedure for a single client, or the `Product Mass Migration` procedure for many clients at once.
 
 
 In {sles}{nbsp}12 and later, {suse} supports service pack skipping if {scclongform} provides it.

--- a/en/modules/client-configuration/pages/client-upgrades-product-migration.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-product-migration.adoc
@@ -69,7 +69,7 @@ The migration to {sles}{nbsp}16.0 happens in two steps:
 . Once the migration action has finished, whether it passed or failed, the system is rebooted automatically.
   After the reboot, when the Salt minion connects to the {productname} Server again, the verification step starts automatically.
 
-To perform this upgrade, use the standard product migration procedures described in this page: the `Single System Migration` procedure for a single client, or the `Product Mass Migration` procedure for many clients at once.
+To perform this upgrade, use the standard product migration procedures described in this page: the <<single-system-migration>> procedure for a single client, or the <<product-mass-migration>> procedure for many clients at once.
 
 
 In {sles}{nbsp}12 and later, {suse} supports service pack skipping if {scclongform} provides it.
@@ -86,7 +86,7 @@ For supported {sles} upgrade paths, see link:https://documentation.suse.com/en-u
 ====
 
 
-
+[[single-system-migration]]
 == Single System Migration
 
 Before starting the product migration:
@@ -118,7 +118,7 @@ To migrate openSUSE Leap to {sles}, you must check the `Allow Vendor Change` opt
 . Click btn:[Schedule Migration] when your channels have been configured properly.
 ____
 
-
+[[product-mass-migration]]
 == Product Mass Migration
 
 If you want to migrate a large number of clients to the next SP version, you can use {productname} API calls or System Set Manager (SSM).

--- a/en/modules/client-configuration/pages/client-upgrades.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades.adoc
@@ -14,9 +14,9 @@ For more information, see xref:client-configuration:client-upgrades-major.adoc[]
 You can also automate client upgrades using the content lifecycle manager.
 For more information, see xref:client-configuration:client-upgrades-lifecycle.adoc[].
 
-For more information about product migration such as service pack upgrades, the major version upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0, openSUSE Leap minor version upgrades, or openSUSE Leap to {sle} migrations, see xref:client-configuration:client-upgrades-product-migration.adoc[].
+For more information about product migration such as service pack upgrades, the major version upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0, {leap} minor version upgrades, or {leap} to {sle} migrations, see xref:client-configuration:client-upgrades-product-migration.adoc[].
 
 ifeval::[{uyuni-content} == true]
 
-For more information about upgrading unregistered openSUSE Leap clients, see xref:client-configuration:client-upgrades-uyuni.adoc[].
+For more information about upgrading unregistered {leap} clients, see xref:client-configuration:client-upgrades-uyuni.adoc[].
 endif::[]

--- a/en/modules/client-configuration/pages/client-upgrades.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades.adoc
@@ -1,6 +1,6 @@
 [[client-upgrades]]
 = Client Upgrades
-:revdate: 2024-11-29
+:revdate: 2026-07-08
 :page-revdate: {revdate}
 
 Clients use the versioning system of their underlying operating system, and require regular upgrades.
@@ -14,7 +14,7 @@ For more information, see xref:client-configuration:client-upgrades-major.adoc[]
 You can also automate client upgrades using the content lifecycle manager.
 For more information, see xref:client-configuration:client-upgrades-lifecycle.adoc[].
 
-For more information about product migration such as service pack upgrades, openSUSE Leap minor version upgrades, or openSUSE Leap to {sle} migrations, see xref:client-configuration:client-upgrades-product-migration.adoc[].
+For more information about product migration such as service pack upgrades, the major version upgrade from {sles}{nbsp}15{nbsp}SP7 to {sles}{nbsp}16.0, openSUSE Leap minor version upgrades, or openSUSE Leap to {sle} migrations, see xref:client-configuration:client-upgrades-product-migration.adoc[].
 
 ifeval::[{uyuni-content} == true]
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!
In the `manager-4.3`, the hidden `.changelog` file with a leading dot is still in use.

Add description, target branches, and related links to the section below.

-->


# Description



Document SLES 15 SP7 to SLES 16.0 major upgrade via product migration in Client Configuration Guide


# Target branches

<!--
* Which product version this PR applies to (Uyuni, SUMA 4.3.X, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, create an issue for tracking it and add the link to this PR.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.
-->

- master
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5085



# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
