### PR TITLE
manager-5.2 - Update storage locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Update data file storage locations for Uyuni in Installation and Upgrade Guide
 - Documented SLES 15 SP7 to SLES 16.0 major upgrade via product migration in Client Configuration Guide
 - Document the repository value for helm charts on MLM (bsc#1269667)
 - Removed unsupported {raspberrypios} 12 from Client Configuration Guide

--- a/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
@@ -15,6 +15,7 @@ Do not use NFS for storage because it does not support SELinux file labeling.
 ====
 
 // In this table, replace `version` with the version of the product you are using.
+[[server-hardware-requirements]]
 == Server Requirements
 
 
@@ -47,11 +48,15 @@ Do not use NFS for storage because it does not support SELinux file labeling.
 | Minimum 40{nbsp}GB
 
 |
-| `/var/lib/pgsql`
+| `/var/lib/containers/storage/volumes`
+| Minimum 150{nbsp}GB (depending on the number of products)
+
+|
+| `/var/lib/containers/storage/volumes/var-pgsql`
 | Minimum 50{nbsp}GB
 
 |
-| `/var/spacewalk`
+| `/var/lib/containers/storage/volumes/var-spacewalk`
 | Minimum storage required: 100{nbsp}GB (this will be verified by the implemented check)
 
 * 50{nbsp}GB for each {suse} product and Package Hub
@@ -59,7 +64,7 @@ Do not use NFS for storage because it does not support SELinux file labeling.
 * 360{nbsp}GB for each {redhat} product
 
 |
-| `/var/cache`
+| `/var/lib/containers/storage/volumes/var-cache`
 | Minimum 10{nbsp}GB.
 Add 100{nbsp}MB per {suse} product, 1{nbsp}GB per {redhat} or other product.
 Double the space if the server is an ISS Master.
@@ -101,23 +106,19 @@ Double the space if the server is an ISS Master.
 | Minimum 40{nbsp}GB
 
 |
-| `/srv`
-| Minimum 100{nbsp}GB
-
-|
-| `/var/cache` (Squid)
+| `/var/lib/containers/storage/volumes`
 | Minimum 100{nbsp}GB
 |===
 
 
-{productname} Proxy caches packages in the `/var/cache/` directory.
-If there is not enough space available in `/var/cache/`, the proxy will remove old, unused packages and replace them with newer packages.
+{productname} Proxy caches packages in the `/var/lib/containers/storage/volumes/uyuni-proxy-squid-cache/` directory.
+If there is not enough space available in `/var/lib/containers/storage/volumes/uyuni-proxy-squid-cache/`, the proxy will remove old, unused packages and replace them with newer packages.
 
 As a result of this behavior:
 
-* The larger `/var/cache/` directory is on the proxy, the less traffic there will be between it and the {productname} Server.
+* The larger `/var/lib/containers/storage/volumes/uyuni-proxy-squid-cache/` directory is on the proxy, the less traffic there will be between it and the {productname} Server.
 
-* By making the `/var/cache/` directory on the proxy the same size as `/var/spacewalk/` on the {productname} Server, you avoid a large amount of traffic after the first synchronization.
+* By making the `/var/lib/containers/storage/volumes/uyuni-proxy-squid-cache/` directory on the proxy the same size as `/var/lib/containers/storage/volumes/var-spacewalk/` on the {productname} Server, you avoid a large amount of traffic after the first synchronization.
 
-* The `/var/cache/` directory can be small on the {productname} Server compared to the proxy.
+* The `/var/lib/containers/storage/volumes/uyuni-proxy-squid-cache/` directory can be small on the {productname} Server compared to the proxy.
     For a guide to size estimation, see the <<server-hardware-requirements>> section.


### PR DESCRIPTION
# Description

From the issue:
```
The locations of the data files specified for non-containerised deployment and different than the locations in SUMA 5 docs,

Update data locations for Uyuni to match those of suma.
```

Information taken from https://documentation.suse.com/multi-linux-manager/5.1/en/docs/installation-and-upgrade/hardware-requirements.html

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5092
- 5.2 (this PR)
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5093

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/25707
