### PR TITLE
manager-5.2 - Fix task validation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -518,21 +518,33 @@ tasks:
   # --------------------------------------------------------------------------
   validate:mlm:
     desc: "[Local] Antora xref validation — MLM"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: translations
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator mlm-dsc.site.yml
+          echo "==> Validating mlm-dsc / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product mlm -output mlm-dsc -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product mlm -lang {{.ITEM}}
+          mkdir -p translations/{{.ITEM}}/modules
+          cp -an en/modules/. translations/{{.ITEM}}/modules/ || true
+          npx antora --log-failure-level=warn --to-dir build/{{.ITEM}}/validate-mlm \
+            translations/{{.ITEM}}/mlm-dsc.site.yml
 
   validate:uyuni:
     desc: "[Local] Antora xref validation — Uyuni"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: translations
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator uyuni-website.site.yml
+          echo "==> Validating uyuni-website / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product uyuni -output uyuni-website -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product uyuni -lang {{.ITEM}}
+          mkdir -p translations/{{.ITEM}}/modules
+          cp -an en/modules/. translations/{{.ITEM}}/modules/ || true
+          npx antora --log-failure-level=warn --to-dir build/{{.ITEM}}/validate-uyuni \
+            translations/{{.ITEM}}/uyuni-website.site.yml
 
   # --------------------------------------------------------------------------
   # Translations
@@ -693,12 +705,12 @@ tasks:
   container:validate:mlm:
     desc: "[Container] Antora xref validation — MLM"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:uyuni:
     desc: "[Container] Antora xref validation — Uyuni"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # Translations
   container:translations:


### PR DESCRIPTION
# Description

`validate:{mlm,uyuni}` never worked because it `cd`'d into a `translations/` tree that nothing generated and invoked `--generator @antora/xref-validator` which is an unpublished, obsolete Antora 2.x plugin (that is also absent from the image).
Changed the command to run the same prep as the draft targets and validate via Antora's built-in `--log-failure-level=warn` instead of the missing generator.
As a bonus made it accept `LANGUAGES` arg like the other tasks.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5104
- 5.2 (this PR)
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5106
