### PR TITLE
master - Fix build caching

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -542,9 +542,11 @@ tasks:
     sources:
       - l10n-weblate/**/*.po
       - l10n-weblate/**/*.cfg
+      - en/modules/**/*
     generates:
       - translations/**/*.adoc
     cmds:
+      - rm -rf translations
       - bash scripts/use_po.sh
 
   pot:


### PR DESCRIPTION
Fixes #5109.

The new toolchain dropped the old Makefile's per-build rm -rf translations/{lang} (Makefile lines 81-82). English source reaches the build only via cp -an (no-clobber) into a persistent translations/ tree, and the translations task's sources: watched only l10n-weblate/**. So editing en/modules/** neither invalidated the task nor overwrote the already-copied stale file — only task clean fixed it.

# Target branches

- master (this PR)
- 5.2
- 5.1
- 5.0
