### PR TITLE
Fix Traefik setup doc for rke2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fix Traefik installation documentation
 - Removed legacy mgradm and mgrpxy commands
 - Documented apache2 parameter used for large deployments (bsc#1268673)
 - Documented Grafana reporting database automated setup and Hub Overview in Administration and Specialized Guides

--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -491,37 +491,14 @@ RKE2 ships with nginx as the default ingress controller.
 The `server-helm` chart requires Traefik, so nginx must be disabled and Traefik installed before proceeding.
 This is a task for the {kube} cluster administrator.
 
-Disable the nginx ingress controller by adding the following to `/etc/rancher/rke2/config.yaml` on each RKE2 server node (create the file if it does not exist):
+Set the ingress controller to be Traefik by adding the following to `/etc/rancher/rke2/config.yaml` on each RKE2 server node (create the file if it does not exist):
 
 [source,yaml]
 ----
-disable:
-  - rke2-ingress-nginx
+ingress-controller: traefik
 ----
 
-Install Traefik by creating `/var/lib/rancher/rke2/server/manifests/traefik.yaml` on the RKE2 server node with the following content:
-
-[source,yaml]
-----
-apiVersion: helm.cattle.io/v1
-kind: HelmChart
-metadata:
-  name: traefik
-  namespace: kube-system
-spec:
-  chart: traefik
-  repo: https://traefik.github.io/charts
-  targetNamespace: kube-system
-----
-
-[IMPORTANT]
-====
-The `metadata.name` must be `traefik`.
-The `server-helm` chart creates Ingress resources with `ingressClassName: traefik`, which must match the IngressClass name created by the Helm release.
-Using a different name (such as `rke2-traefik`) causes Traefik to silently ignore all {productname} ingresses, resulting in 404 responses even when all pods are running.
-====
-
-Restart RKE2 to apply both changes:
+Restart RKE2 to apply the changes:
 
 [source,shell]
 ----
@@ -554,7 +531,7 @@ Traefik takes a few seconds to be reconfigured after the file is saved.
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
-  name: traefik
+  name: rke2-traefik
   namespace: kube-system
 spec:
   valuesContent: |-


### PR DESCRIPTION
# Description

I don't know where the Traefik installation were coming from, but what is documented in the [RKE2 doc](https://docs.rke2.io/networking/networking_services#ingress-controller) is simpler and works fine.

# Target branches

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5140


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
