### PR TITLE
5.2 - Link to API docs fixed

### DIFF
--- a/en/modules/client-configuration/pages/clients-sleses.adoc
+++ b/en/modules/client-configuration/pages/clients-sleses.adoc
@@ -427,7 +427,7 @@ If an Enterprise Linux (EL) client such as {rhel} and {centos} is already regist
 For more information about re-activation keys, see xref:client-configuration:activation-keys.adoc#activation-keys-reactivation[].
 
 The re-activation key is per minion, and can be generated with the {webui} or using the API.
-For more information, see https://documentation.suse.com/multi-linux-manager/5.1/api/suse-manager/api/system.html#apidoc-system-obtainReactivationKey-loggedInUser-sid.
+For more information, see https://documentation.suse.com/multi-linux-manager/5.2/api/docs/api/system.html#apidoc-system-obtainReactivationKey-loggedInUser-sid.
 
 To re-activate a client, the user can run the bootstrap script on the client and pass the re-activation key as an environment variable.
 Example:


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

Broken link to API document has been fixed.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5118
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5114


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/31206.