### PR TITLE
5.2 - Added parameter description for large deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Documented apache2 parameter used for large deployments (bsc#1268673)
 - Documented Grafana reporting database automated setup and Hub Overview in Administration and Specialized Guides
 - Update the OpenSCAP packages table in the
   System Security with OpenSCAP article in the Administration guide (bsc#1269316)

--- a/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
+++ b/en/modules/specialized-guides/pages/large-deployments/tuning.adoc
@@ -173,6 +173,20 @@ This section contains information about the available parameters.
 | More information     | https://tomcat.apache.org/tomcat-9.0-doc/config/http.html
 |===
 
+[[limit-request-body]]
+=== `LimitRequestBody`
+
+[cols="1,1"]
+|===
+| Description          | This parameter specifies the number of bytes that are allowed in a request body.
+                         A value of 0 means unlimited.
+| Tune when            | When following message appears in the logs: "Request entity too large! 
+                         The POST method does not allow the data transmitted, or the data volume exceeds the capacity limit."
+| Value default        | 1GB
+| Location             |  Custom file `/etc/apache2/conf.d/maxrequestbody.conf` 
+| Example              | `LimitRequestBody 0`
+|===
+
 
 
 [[connectionTimeout]]


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

Parameter added with which allows configuration for uploading files larger than 1GB.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5122
- 5.2
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5120


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31035 / bug https://bugzilla.suse.com/show_bug.cgi?id=1268673.
