### PR TITLE
Fix validate tasks to use Antora 3 built-in xref checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Fixed `task validate:mlm` and `task validate:uyuni` to use Antora 3 built-in xref
+  checking (`stage-content`, `gen-site`, `gen-antora`, `--log-failure-level=error`)
+  instead of the obsolete Antora 2.x `@antora/xref-validator` plugin, which was not
+  shipped in the builder image
 - Documented Grafana reporting database automated setup and Hub Overview in Administration and Specialized Guides
 - Update the OpenSCAP packages table in the
   System Security with OpenSCAP article in the Administration guide (bsc#1269316)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -518,21 +518,29 @@ tasks:
   # --------------------------------------------------------------------------
   validate:mlm:
     desc: "[Local] Antora xref validation — MLM"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: stage-content
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator mlm-dsc.site.yml
+          echo "==> Validating mlm-dsc / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product mlm -output mlm-dsc -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product mlm -lang {{.ITEM}}
+          npx antora --log-failure-level=error --to-dir build/{{.ITEM}}/validate-mlm \
+            translations/{{.ITEM}}/mlm-dsc.site.yml
 
   validate:uyuni:
     desc: "[Local] Antora xref validation — Uyuni"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: stage-content
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator uyuni-website.site.yml
+          echo "==> Validating uyuni-website / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product uyuni -output uyuni-website -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product uyuni -lang {{.ITEM}}
+          npx antora --log-failure-level=error --to-dir build/{{.ITEM}}/validate-uyuni \
+            translations/{{.ITEM}}/uyuni-website.site.yml
 
   # --------------------------------------------------------------------------
   # Translations
@@ -695,12 +703,12 @@ tasks:
   container:validate:mlm:
     desc: "[Container] Antora xref validation — MLM"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:uyuni:
     desc: "[Container] Antora xref validation — Uyuni"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # Translations
   container:translations:


### PR DESCRIPTION
## Summary

- Replace broken `@antora/xref-validator` validate tasks with Antora 3 site generation and `--log-failure-level=error`
- Align validate prep with draft builds: `stage-content`, `gen-site`, `gen-antora`
- Pass `LANGUAGES` through container validate wrappers

## ⚠️ Do not merge until #5103 is backported to `manager-5.2`
This PR calls `task: stage-content`, which is introduced by the AI localization toolchain in #5103.

**Merge order:**
1. Backport #5103 → `master`
2. Merge this PR → `master`
Supersedes Lukáš's validate PR #5105 for `master`.

## Test plan
- [ ] After #5103 lands on `master`: `task validate:mlm LANGUAGES=en`
- [ ] After #5103 lands on `master`: `task validate:uyuni LANGUAGES=en`