### PR TITLE
manager-5.1 - Consolidate multiple activation key procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Consolidated multiple duplicated activation key creation procedures into a single reusable partial snippet
 - Documented apache2 parameter used for large deployments (bsc#1268673)
 - Fixed `task validate:mlm` and `task validate:uyuni` to use Antora 3 built-in xref
   checking (`stage-content`, `gen-site`, `gen-antora`, `--log-failure-level=error`)

--- a/en/modules/administration/pages/image-management.adoc
+++ b/en/modules/administration/pages/image-management.adoc
@@ -1,7 +1,7 @@
 [[image-management]]
 = Image Building and Management
 :description: Configure system builds and manage container deployments with SUSE Multi-Linux Managers intuitive tools for efficient management
-:revdate: 2025-02-25
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -130,20 +130,13 @@ This section guides you through creating an ad-hoc activation key for this purpo
 To build a container, you need an activation key that is associated with a channel other than `SUSE Manager Default`.
 ====
 
-.Procedure: Creating an activation key
-[role=procedure]
-_____
+ifndef::backend-pdf[]
+include::client-configuration:partial$snippet-creating-activation-key.adoc[]
+endif::[]
 
-. Select menu:Systems[Activation Keys].
-
-. Click btn:[Create Key].
-
-. Enter a `Description` and a `Key` name.
-  Use the drop-down menu to select the `Base Channel` to associate with this key.
-
-. Confirm with btn:[Create Activation Key].
-
-_____
+ifdef::backend-pdf[]
+include::../../client-configuration/partials/snippet-creating-activation-key.adoc[]
+endif::[]
 
 For more information, see xref:client-configuration:activation-keys.adoc[].
 
@@ -695,19 +688,13 @@ Activation keys are mandatory for OS Image building.
 To build OS Images, you need an activation key that is associated with a channel other than `Default` activation key.
 ====
 
-.Procedure: Creating an activation key
-[role=procedure]
-_____
+ifndef::backend-pdf[]
+include::client-configuration:partial$snippet-creating-activation-key.adoc[]
+endif::[]
 
-. In the {webui}, select menu:Systems[Activation Keys].
-
-. Click `Create Key`.
-
-. Enter a `Description`, a `Key` name, and use the drop-down box to select a `Base Channel` to associate with the key.
-
-. Confirm with btn:[Create Activation Key].
-
-_____
+ifdef::backend-pdf[]
+include::../../client-configuration/partials/snippet-creating-activation-key.adoc[]
+endif::[]
 
 For more information, see xref:client-configuration:activation-keys.adoc[].
 

--- a/en/modules/client-configuration/pages/activation-keys.adoc
+++ b/en/modules/client-configuration/pages/activation-keys.adoc
@@ -1,7 +1,7 @@
 [[activation-keys]]
 = Activation Keys
 :description: Configure and manage clients software entitlements by creating and applying activation keys in SUSE Multi-Linux Manager
-:revdate: 2025-02-11
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -34,36 +34,13 @@ image::provision-config-keys.png[scaledwidth=80%]
 
 
 
-.Procedure: Creating an Activation Key
-. In the {productname} {webui}, as an administrator, navigate to menu:Systems[Activation Keys].
-. Click the btn:[Create Key] button.
-. On the `Activation Key Details` page, in the `Description` field, enter a description of the activation key.
-. In the `Key` field, enter a name for the activation key.
-  For example, `SLES15-{sp-version}` for {sles}{nbsp}15{nbsp}{sp-version}.
-+
-[IMPORTANT]
-====
-* Do not use commas or double quotes in the `Key` field for any {suse} products.
-However, you *must* use commas for Red Hat Products.
+ifndef::backend-pdf[]
+include::client-configuration:partial$snippet-creating-activation-key.adoc[]
+endif::[]
 
-* All other characters are allowed, but `<> (){}` (this includes the space) are removed automatically.
-
-* If the field is left empty, a random string is generated.
-====
-+
-. In the `Usage` add number of times the key can be used, or leave it blank for unlimited usage.
-. In the `Base Channels` drop-down box, select the appropriate base software channel, and allow the relevant child channels to populate.
-  For more information, see xref:reference:admin/setup-wizard.adoc[] and xref:administration:custom-channels.adoc[].
-. Select the `Child Channels` you need (for example, the mandatory {susemgr} tools and updates channels).
-. Check the `Add-On System Types` checkbox if you need to enable any of the options. 
-  For more information about system types, see xref:client-configuration:system-types.adoc[].
-. We recommend you leave the `Contact Method` set to `Default`.
-  For more information about contact methds, see xref:client-configuration:contact-methods-intro.adoc[].
-. We recommend you leave the `Universal Default` setting unchecked.
-. Click btn:[Create Activation Key] to create the activation key.
-. After the activation key is created, the page shows additional checkbox `Configuration File Deployment` below the list of `Add-On System Types`.
-  To enable deploying configuration files to systems on registration, select this checkbox.
-. Click btn:[Update Activation Key] to save the change.
+ifdef::backend-pdf[]
+include::../partials/snippet-creating-activation-key.adoc[]
+endif::[]
 
 When the activation key creation is completed, additional tabs appear at the top of the page.
 Use them to check and set additional features. 

--- a/en/modules/client-configuration/pages/client-upgrades-major.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-major.adoc
@@ -1,7 +1,7 @@
 [[client-upgrades-major]]
 = Major Version Upgrade
 :description: Learn how to successfully migrate clients from SLE12 to SLE15 by preparing installation media using YaST tools, declaring an autoinstallation distribution
-:revdate: 2026-07-08
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -38,6 +38,8 @@ Before you can migrate your client from SLE{nbsp}12 to SLE{nbsp}15, you need to:
 === Prepare Installation Media
 
 .Procedure: Preparing Installation Media
+[role="procedure"]
+_____
 . On the container host, download an ISO image with the installation sources.
 
 . Use `mgradm` to import the installation data from the ISO image:
@@ -48,6 +50,7 @@ mgradm distribution copy <image_name>.iso <image_name>
 
 . Take a note of the distribution path reported by `mgradm`.
   You will need it when you declare the distribution to {productname}.
+_____
 
 
 [NOTE]
@@ -62,6 +65,8 @@ For more information, see xref:client-configuration:autoinst-distributions.adoc[
 === Declare an Autoinstallation Distribution
 
 .Procedure: Declaring an Autoinstallation Distribution
+[role="procedure"]
+_____
 . In the {productname} {webui}, navigate to menu:Systems[Autoinstallation > Distributions].
 . Click `Create  Distribution` , and complete these fields:
 +
@@ -76,6 +81,7 @@ In the `Distribution Label` field, enter a name to identify your autoinstallatio
   There are multiple ways to provide kernel options.
   Only add options here that are generic for the distribution.
 . Click btn:[Create Autoinstallable Distribution].
+_____
 
 
 === Create an Activation Key
@@ -83,17 +89,13 @@ In the `Distribution Label` field, enter a name to identify your autoinstallatio
 For example, to switch from the old SLE{nbsp}12 base channel to the new SLE{nbsp}15 channel, you need an activation key.
 
 
-.Procedure: Creating an Activation Key
-. In the {productname} Server {webui}, navigate to menu:Systems[Activation Keys] and click `Create Key`.
-. Enter a description for your key.
-. Enter a key or leave it blank to generate an automatic key.
-. OPTIONAL: If you want to limit the usage, enter your value in the `Usage` text field.
-. Select the `SLE-Product-SLES15-SP6-Pool for x86_64` base channel.
-. OPTIONAL: Select any `Add-On System Types`.
-    For more information, see {sles-base-os-documentation}/article-modules.html.
-. Click btn:[Create Activation Key].
-. Click the `Child Channels` tab and select the required channels.
-. Click btn:[Update Key].
+ifndef::backend-pdf[]
+include::client-configuration:partial$snippet-creating-activation-key.adoc[]
+endif::[]
+
+ifdef::backend-pdf[]
+include::../partials/snippet-creating-activation-key.adoc[]
+endif::[]
 
 
 
@@ -107,6 +109,8 @@ For valid {ay} upgrade settings, see https://doc.opensuse.org/projects/autoyast/
 
 
 .Procedure: Creating an Autoinstallation Profile
+[role="procedure"]
+_____
 . In the {productname} {webui}, navigate to menu:Systems[Autoinstallation > Profiles] and upload your autoinstallation profile script.
 +
 For example scripts that you can use as a starting point, see:
@@ -133,6 +137,7 @@ Specify the required variables, using this format:
 ----
 <key>=<value>
 ----
+_____
 
 
 
@@ -144,10 +149,13 @@ You can monitor the mirroring progress in `/var/log/rhn/reposync/<channel-label>
 
 
 .Procedure: Migrating
+[role="procedure"]
+_____
 . In the {productname} Server {webui}, navigate to `Systems` and select the client to be upgraded.
 . Navigate to the `Provisioning` tab, and select the autoinstallation profile you uploaded.
 . Click btn:[Schedule Autoinstallation and Finish].
   The system downloads the required files, change the bootloader entries, reboot, and start the upgrade.
+_____
 
 
 Next time the client synchronizes with the {productname} Server, it receives a re-installation job.

--- a/en/modules/client-configuration/partials/snippet-creating-activation-key.adoc
+++ b/en/modules/client-configuration/partials/snippet-creating-activation-key.adoc
@@ -1,0 +1,34 @@
+// This snippet is reusable across multiple guides.
+.Procedure: Creating an Activation Key
+[role="procedure"]
+_____
+. In the {productname} {webui}, as an administrator, navigate to menu:Systems[Activation Keys].
+. Click the btn:[Create Key] button.
+. On the `Activation Key Details` page, in the `Description` field, enter a description of the activation key.
+. In the `Key` field, enter a name for the activation key.
+  For example, `SLES15-{sp-version}` for {sles}{nbsp}15{nbsp}{sp-version}.
++
+[IMPORTANT]
+====
+* Do not use commas or double quotes in the `Key` field for any {suse} products.
+However, you *must* use commas for Red Hat Products.
+
+* All other characters are allowed, but `<> (){}` (this includes the space) are removed automatically.
+
+* If the field is left empty, a random string is generated.
+====
++
+. In the `Usage` add number of times the key can be used, or leave it blank for unlimited usage.
+. In the `Base Channels` drop-down box, select the appropriate base software channel, and allow the relevant child channels to populate.
+  For more information, see xref:reference:admin/setup-wizard.adoc[] and xref:administration:custom-channels.adoc[].
+. Select the `Child Channels` you need (for example, the mandatory {susemgr} tools and updates channels).
+. Check the `Add-On System Types` checkbox if you need to enable any of the options.
+  For more information about system types, see xref:client-configuration:system-types.adoc[].
+. We recommend you leave the `Contact Method` set to `Default`.
+  For more information about contact methods, see xref:client-configuration:contact-methods-intro.adoc[].
+. We recommend you leave the `Universal Default` setting unchecked.
+. Click btn:[Create Activation Key] to create the activation key.
+. After the activation key is created, the page shows additional checkbox `Configuration File Deployment` below the list of `Add-On System Types`.
+  To enable deploying configuration files to systems on registration, select this checkbox.
+. Click btn:[Update Activation Key] to save the change.
+_____


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

Consolidates the various duplicated and simplified activation key creation procedures scattered across the documentation codebase into a single, high-quality, reusable partial snippet (`snippet-creating-activation-key.adoc`), and replaces the duplicates with clean includes.

This avoids text duplication and drift, ensuring high quality and consistency across:
- `activation-keys.adoc` (main Client Configuration guide page)
- `client-upgrades-major.adoc` (major client upgrades section)
- `image-management.adoc` (image management container/OS image build sections)


# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5129
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5131
- manager-5.1 (this PR)


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/22966