### PR TITLE
5.1 - Added instructions for enabling reporting dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added instructions for enabling reporting dashboards in Specialized Guides
+  (bsc#1268228)
 - Documented apache2 parameter used for large deployments (bsc#1268673)
 - Fixed `task validate:mlm` and `task validate:uyuni` to use Antora 3 built-in xref
   checking (`stage-content`, `gen-site`, `gen-antora`, `--log-failure-level=error`)

--- a/en/modules/specialized-guides/pages/large-deployments/hub-reporting.adoc
+++ b/en/modules/specialized-guides/pages/large-deployments/hub-reporting.adoc
@@ -1,7 +1,7 @@
 [[lsd-hub-reporting]]
 = Hub Reporting
 :description: Configure Hub Reporting to collect and aggregate data from SUSE Multi-Linux Manager servers for combined reporting
-:revdate: 2026-07-14
+:revdate: 2026-07-21
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -12,7 +12,8 @@ Hub Reporting extends the xref:administration:reporting-database.adoc[Reporting 
 
 For general reporting database setup, user creation, schema documentation, and Grafana dashboard integration, see xref:administration:reporting-database.adoc[].
 
-== Hub Architecture
+
+== Hub architecture
 
 In a hub deployment:
 
@@ -29,12 +30,28 @@ For more information, see xref:specialized-guides:large-deployments/hub-online-s
 Hub Reporting and central Report DB aggregation depend entirely on active Hub Online Synchronization (ISS v3) registration. During any Hub upgrade or migration, ensure that all peripheral servers are successfully migrated or registered under Hub Online Synchronization (ISS v3) for reporting data aggregation to continue working.
 ====
 
-== Hub Data Aggregation
+== Enable reporting dashboards in Grafana
+
+To make hub reporting dashboards available in Grafana, the reporting database data source must be enabled in the Grafana formula on the monitoring server.
+
+.Procedure: Enabling reporting dashboards in Grafana
+[role=procedure]
+____
+. Navigate to menu:Systems[(monitoring server) > Formulas > Grafana].
+. Expand Datasources > Report database.
+. Check `Enable Reporting Dashboards`.
+. Click button `Save Formula`.
+. Apply the highstate.
+____
+
+
+== Hub data aggregation
 
 The `update-reporting-hub-default` schedule fetches and aggregates reporting data from all registered peripheral servers.
 For a description of both taskomatic reporting schedules, see xref:administration:reporting-database.adoc[].
 
 If peripheral servers are in different timezones, align all `update-reporting-default` schedules so that every peripheral server has finished its local job before `update-reporting-hub-default` runs on the Hub.
+
 
 == Tuning
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

 Hub Reporting documentation did not mention the prerequisite of enabling Report DB / Enable Reporting Dashboards. This has now been resolved by creating a procedure for it.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5135
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5136
- 5.1


# Links
- This PR tracks issue  https://github.com/SUSE/spacewalk/issues/30986