### PR TITLE
5.2 - Add --set tag={productversion} to helm commnands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add the --set tag parameter to helm install/upgrade commands as a workaround (bsc#1271902)
+- Added the --set tag parameter to helm install/upgrade commands as a workaround (bsc#1271902)
 - Documented apache2 parameter used for large deployments (bsc#1268673)
 - Documented Grafana reporting database automated setup and Hub Overview in Administration and Specialized Guides
 - Update the OpenSCAP packages table in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add the --set tag parameter to helm install/upgrade commands as a workaround (bsc#1271902)
 - Documented apache2 parameter used for large deployments (bsc#1268673)
 - Documented Grafana reporting database automated setup and Hub Overview in Administration and Specialized Guides
 - Update the OpenSCAP packages table in the

--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
@@ -427,6 +427,8 @@ helm install smlm-proxy \
     --set-file global.config=path/to/config.yaml \
     --set-file global.ssh=path/to/ssh.yaml \
     --set-file global.httpd=path/to/httpd.yaml \
+    --set tag={productchartversion} \
+    --version {productchartversion}
 ----
 endif::[]
 
@@ -442,6 +444,8 @@ helm install uyuni-proxy \
     --set-file global.config=path/to/config.yaml \
     --set-file global.ssh=path/to/ssh.yaml \
     --set-file global.httpd=path/to/httpd.yaml \
+    --set tag={productnumber} \
+    --version {productchartversion}
 ----
 endif::[]
 

--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-upgrade.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-upgrade.adoc
@@ -23,6 +23,7 @@ ifeval::[{mlm-content} == true]
 helm upgrade uyuni-proxy \
     oci://registry.suse.com/suse/multi-linux-manager/{productnumber}/proxy-helm \
     --version {productchartversion} \
+    --set tag={productchartversion} \
     --namespace uyuni-proxy \
     --reuse-values
 ----
@@ -38,6 +39,7 @@ ifeval::[{uyuni-content} == true]
 helm upgrade uyuni-proxy \
     oci://registry.opensuse.org/uyuni/proxy-helm \
     --version {productchartversion} \
+    --set tag={productnumber} \
     --namespace uyuni-proxy \
     --reuse-values
 ----

--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -680,6 +680,7 @@ helm install smlm-server \
      --set "global.fqdn=the.server.fqdn" \
      --set "registrySecret=scc-credentials" \
      --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/"
+     --set tag={productchartversion} \
      --version {productchartversion}
 ----
 endif::[]
@@ -692,6 +693,7 @@ helm install uyuni-server \
      -n $NAMESPACE \
      --description "Server installation" \
      --set "global.fqdn=the.server.fqdn" \
+     --set tag={productnumber} \
      --version {productchartversion}
 ----
 endif::[]


### PR DESCRIPTION

# Description

`latest` being the default tag value can lead to troubles, especially on MLM where latest is no longer added to the images. There is a code change to change the default tag to the chart's appVersion but this will be merged for the next releases. In the mean time, document to set the tag value. (bsc#1271902)

# Target branches

- master - [#5128](https://github.com/uyuni-project/uyuni-docs/pull/5128)
- 5.2

**This PR should be reverted once https://github.com/uyuni-project/uyuni/pull/12283 and https://github.com/SUSE/spacewalk/pull/31286 are merged.**

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31281
