### PR TITLE
5.2 - Fix missing line end escapes in helm install commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed missing line end escapes in kubernetes helm install commands
 - Consolidated multiple duplicated activation key creation procedures into a single reusable partial snippet
 - Fixed Traefik installation documentation in Specialized Guides
 - Clarified CA certificate migration requirements (bsc#1271841)

--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
@@ -423,7 +423,7 @@ helm install smlm-proxy \
     -n uyuni-proxy \
     --description "Proxy installation" \
     --set "registrySecret=the-scc-secret" \
-    --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/"
+    --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/" \
     --set-file global.config=path/to/config.yaml \
     --set-file global.ssh=path/to/ssh.yaml \
     --set-file global.httpd=path/to/httpd.yaml \

--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -656,7 +656,7 @@ helm install smlm-server \
      --description "Server installation" \
      --set "global.fqdn=the.server.fqdn" \
      --set "registrySecret=scc-credentials" \
-     --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/"
+     --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/" \
      --set tag={productchartversion} \
      --version {productchartversion}
 ----


### PR DESCRIPTION
Restore trailing backslashes on repository= lines that were lost when the --set tag workaround was backported, so multi-line helm commands parse correctly in the shell.
