### PR TITLE
Add tftp image to airgap install commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add the missing TFTP image in airgap install command
+- Added the missing TFTP image in airgap install command
 - Enhanced instructions for Liberate formula and reactivation key in Specialized
   Guides (bsc#1268473)
 - Fixed missing line end escapes in kubernetes helm install commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add the missing TFTP image in airgap install command
 - Enhanced instructions for Liberate formula and reactivation key in Specialized
   Guides (bsc#1268473)
 - Fixed missing line end escapes in kubernetes helm install commands

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -52,7 +52,9 @@ ____
 
 [source,shell]
 ----
-transactional-update pkg install mgradm* mgrctl* suse-multi-linux-manager-5.2-$ARCH$-server-*
+transactional-update pkg install mgradm* mgrctl* \
+     suse-multi-linux-manager-5.2-$ARCH$-server-* \
+     suse-multi-linux-manager-5.2-$ARCH$-proxy-tftpd-image
 ----
 
 +

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -85,8 +85,11 @@ User should make the needed RPM available on the internal network. That can be d
 
 [source,shell]
 ----
-zypper install mgradm* mgrctl* uyuni-server*-image*
+zypper install mgradm* mgrctl* uyuni-server*-image* uyuni-server-proxy-tftpd-image*
 ----
+
+The TFTPD image is now the same than on the proxy.
+If TFTPD is disabled on the server this image is not needed.
 
 +
 


### PR DESCRIPTION
# Description

The server now needs a tftp image named proxy-tftpd: this needs to be added for airgap install

# Target branches

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5160


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
