### PR TITLE
5.2 - Fixed the snippet to reflect the correct product version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed the snippet to reflect the correct produst version (bsc#1272538)
 - Extended configuration instructions for Saline formula in Specialized Guides
   (bsc#1268587)
 - Enhanced instructions for Liberate formula and reactivation key in Specialized

--- a/en/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc
+++ b/en/modules/installation-and-upgrade/partials/snippet-ensure-proxy-prerequisites.adoc
@@ -20,7 +20,7 @@ _____
 
 +
 
-For example, for version 5.2 and architecture of x86_64, the package name would be `suse-multi-linux-manager-5.1-x86_64-proxy-httpd-image`.
+For example, for version 5.2 and architecture of x86_64, the package name would be `suse-multi-linux-manager-5.2-x86_64-proxy-httpd-image`.
 
 +
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

5.1 was shown instead of 5.2. 


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5154
- 5.2



# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1272538