### PR TITLE
master - Correct verification step order in MLM 5.0 to 5.2 upgrade guide (bsc#1271678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Corrected verification step order in MLM 5.0 to 5.2 upgrade guide for SL-Micro (bsc#1271678)
 - Enhanced instructions for Liberate formula and reactivation key in Specialized
   Guides (bsc#1268473)
 - Fixed missing line end escapes in kubernetes helm install commands

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
@@ -1,5 +1,5 @@
 = Server Upgrade from 5.0 to 5.2
-:revdate: 2026-06-30
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 
@@ -41,8 +41,8 @@ This document provides the tested procedure to upgrade a {sle-micro} 5.5 host de
 === Distribution upgrade and server migration
 
 .Procedure: Migration from {productname} 5.0 to {productname} {productnumber}
-[role=procedure]
-____
+[role="procedure"]
+_____
 
 . Verify current product status.
 
@@ -161,24 +161,6 @@ Expected output:
 
 +
 
-. Verify PostgreSQL database version.
-
-+
-
-[source,console]
-----
-podman ps
-----
-
-+
-
-Expected output:
-
-* `server:5.2.0` or higher
-* `server-postgresql:5.2.0` or higher
-
-+
-
 . Upgrade server containers.
 
 +
@@ -230,7 +212,7 @@ Follow the prompts to pull and configure the new 5.2.x containers.
 
 +
 
-. Verify running containers:
+. Verify running containers.
 
 +
 
@@ -241,7 +223,12 @@ podman ps
 
 +
 
-You should see all the expected server containers are up and running.
+Expected output:
+
+* `server:5.2.0` or higher
+* `server-postgresql:5.2.0` or higher
+
++
 
 . Clean up the unused container images to free disk space:
 
@@ -261,7 +248,7 @@ ifdef::backend-pdf[]
 include::../../../../../partials/snippet-check-rpmnew-rpmsave.adoc[]
 endif::[]
 
-____
+_____
 
 
 === Migration complete
@@ -295,8 +282,8 @@ This document provides the procedure to upgrade a {sles} 15 SP6 host deployed wi
 === Distribution upgrade and server migration
 
 .Procedure: Upgrade and Migrate {productname} on {sles} 15 SP6
-[role=procedure]
-____
+[role="procedure"]
+_____
 
 . Verify current product status.
 
@@ -448,7 +435,7 @@ Expected output:
 * `server:5.2.0` or higher
 * `server-postgresql:5.2.0` or higher
 
-____
+_____
 
 
 === Migration complete


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

This PR corrects the verification step order in the MLM 5.0 to 5.2 upgrade guide for SL-Micro.
The premature database verification step (which was placed before container upgrades) was removed, and correct verification details were added to the post-upgrade verification step.
Additionally, both procedures in `server-mlm-50-52.adoc` were updated to use standard quoted role attributes and five-underscore sidebar delimiters per project conventions, and the file header's revision date was updated to today's date.


# Target branches

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5157


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31362 / https://bugzilla.suse.com/show_bug.cgi?id=1271678
