### PR TITLE
5.2 - Added the missing TFTP image in airgap install command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added the missing TFTP image in airgap install command
 - Corrected verification step order in MLM 5.0 to 5.2 upgrade guide for SL-Micro (bsc#1271678)
 - Extended configuration instructions for Saline formula in Specialized Guides
   (bsc#1268587)

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -1,5 +1,5 @@
 = {productname} Server Air-gapped Deployment
-:revdate: 2026-04-29
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
@@ -52,7 +52,9 @@ ____
 
 [source,shell]
 ----
-transactional-update pkg install mgradm* mgrctl* suse-multi-linux-manager-5.2-$ARCH$-server-*
+transactional-update pkg install mgradm* mgrctl* \
+     suse-multi-linux-manager-5.2-$ARCH$-server-* \
+     suse-multi-linux-manager-5.2-$ARCH$-proxy-tftpd-image
 ----
 
 +


### PR DESCRIPTION
# Description

The server now needs a tftp image named proxy-tftpd: this needs to be added for airgap install

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5152
- 5.2


# Links
- This PR tracks issue #<insert spacewalk issue, if any>
- Related development PR #<insert PR link, if any>
