### PR TITLE
master - Document Ubuntu 26.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added documentation support for Ubuntu 26.04 client systems
 - Enhanced instructions for Liberate formula and reactivation key in Specialized
   Guides (bsc#1268473)
 - Fixed missing line end escapes in kubernetes helm install commands

--- a/en/modules/administration/pages/auditing.adoc
+++ b/en/modules/administration/pages/auditing.adoc
@@ -1,6 +1,6 @@
 [[auditing]]
 = Auditing
-:revdate: 2026-05-18
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 In {productname}, you can keep track of your clients through a series of auditing tasks.
@@ -225,6 +225,7 @@ Debian 13 +
 Raspberry Pi OS
 | Ubuntu | https://security-metadata.canonical.com/oval
 a|
+Ubuntu 26.04 +
 Ubuntu 24.04 +
 Ubuntu 22.04
 | AlmaLinux | https://security.almalinux.org/oval

--- a/en/modules/administration/pages/openscap.adoc
+++ b/en/modules/administration/pages/openscap.adoc
@@ -1,6 +1,6 @@
 [[ch-openscap]]
 = System Security with OpenSCAP
-:revdate: 2025-06-17
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 
@@ -70,11 +70,12 @@ The table below lists the packages you need:
 | Debian | 13 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debian` can be used at your own risk.]
 | Ubuntu | 22.04 | `libopenscap8` | `scap-security-guide-ubuntu`
 | Ubuntu | 24.04 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debderived` can be used at your own risk.]
+| Ubuntu | 26.04 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debderived` can be used at your own risk.]
 |===
 
 [NOTE]
 ====
-For Debian 13 and Ubuntu 24.04, {suse} does not provide custom security guide packages.
+For Debian 13, Ubuntu 24.04, and Ubuntu 26.04, {suse} does not provide custom security guide packages.
 To perform scans on these clients, you must install the upstream packages (`ssg-debian` and `ssg-debderived` respectively) from their respective community repositories.
 Please note that these upstream guides are not officially supported by {suse}.
 ====

--- a/en/modules/administration/partials/install_scap_security_guide_package.adoc
+++ b/en/modules/administration/partials/install_scap_security_guide_package.adoc
@@ -1,15 +1,14 @@
 For executing remediations you need to install the SCAP security guide package on the Ansible control node.
 
 .Procedure: Installing the SCAP security guide package
-[role=procedure]
-
+[role="procedure"]
+_____
 . From menu:Systems[Overview], select the client.
   Then click menu:Software[Packages > Install].
 
 . Search for `scap-security-guide` and install the package suitable for your system.
   See the following table for package distribution requirements:
 +
-
 [cols="1,1", options="header"]
 .SCAP security guide package requirements
 |===
@@ -30,10 +29,11 @@ For executing remediations you need to install the SCAP security guide package o
 | Ubuntu 22.04
 
 |===
+_____
 
 [NOTE]
 ====
-For Debian 13 and Ubuntu 24.04, {suse} does not provide custom security guide packages.
+For Debian 13, Ubuntu 24.04, and Ubuntu 26.04, {suse} does not provide custom security guide packages.
 You must use upstream packages (`ssg-debian` and `ssg-debderived` respectively) from their respective community repositories.
 Please note that these upstream guides are not officially supported by {suse}.
 ====

--- a/en/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -1,6 +1,6 @@
 [[clients-ubuntu]]
 = Registering {ubuntu} Clients
-:revdate: 2025-03-13
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 This section contains information about registering clients running {ubuntu} operating systems.
@@ -17,7 +17,7 @@ endif::[]
 
 ifeval::[{mlm-content} == true]
 
-{productname} supports {ubuntu} 22.04 LTS and 24.04 LTS clients using {salt}.
+{productname} supports {ubuntu} 22.04 LTS, 24.04 LTS, and 26.04 LTS clients using {salt}.
 endif::[]
 
 Bootstrapping is supported for starting {ubuntu} clients and performing initial state runs such as setting repositories and performing profile updates.
@@ -51,6 +51,7 @@ The products you need for this procedure are:
 |===
 
 | OS Version     | Product Name
+| {ubuntu} 26.04 | Ubuntu 26.04
 | {ubuntu} 24.04 | Ubuntu 24.04
 | {ubuntu} 22.04 | Ubuntu 22.04
 |===
@@ -72,6 +73,7 @@ The channels you need for this procedure are:
 |===
 
 | OS Version     | Base Channel
+| {ubuntu} 26.04 | ubuntu-2604-amd64-main-amd64
 | {ubuntu} 24.04 | ubuntu-2404-amd64-main-amd64
 | {ubuntu} 22.04 | ubuntu-2204-amd64-main-amd64
 |===
@@ -97,6 +99,7 @@ The channels you need for this procedure are:
 
 | OS Version | Base Channel | Main Channel | Updates Channel | Security Channel | Client Channel
 
+| {ubuntu} 26.04 | ubuntu-2604-pool-amd64-uyuni | ubuntu-2604-amd64-main-uyuni | ubuntu-2604-amd64-main-updates-uyuni | ubuntu-2604-amd64-main-security-uyuni | ubuntu-2604-amd64-uyuni-client
 | {ubuntu} 24.04 | ubuntu-2404-pool-amd64-uyuni | ubuntu-2404-amd64-main-uyuni | ubuntu-2404-amd64-main-updates-uyuni | ubuntu-2404-amd64-main-security-uyuni | ubuntu-2404-amd64-uyuni-client
 | {ubuntu} 22.04 | ubuntu-2204-pool-amd64-uyuni | ubuntu-2204-amd64-main-uyuni | ubuntu-2204-amd64-main-updates-uyuni | ubuntu-2204-amd64-main-security-uyuni | ubuntu-2204-amd64-uyuni-client
 |===
@@ -176,7 +179,7 @@ Replace `<token>` with your personal Bearer Token. Also, `arch` and `release` mu
 |===
 
 | Architectures | Releases
-| `amd64`, `arm64`, `armel`, `armhf`, `i386`, `powerpc`, `ppc64el`, `s390x` | `bionic`, `focal`, `jammy`, `noble`, `trusty`, `xenial`
+| `amd64`, `arm64`, `armel`, `armhf`, `i386`, `powerpc`, `ppc64el`, `s390x` | `bionic`, `focal`, `jammy`, `noble`, `resolute`, `trusty`, `xenial`
 |===
 
 In order for {productname} to synchronize the repositories, the corresponding GPG keys (`ubuntu-advantage-esm-infra-trusty.gpg`, `ubuntu-advantage-esm-apps.gpg`) must be imported. These are located on a system registered with Ubuntu Pro under `/etc/apt/trusted.gpg.d`. Copy these files to the {productname} system and import them as follows:
@@ -269,7 +272,8 @@ With cloud instances this does not happen because `cloud-init` automatically cre
 === Grant Root User Access
 
 .Procedure: Granting Root User Access
-
+[role="procedure"]
+_____
 . On the client, edit the `sudoers` file:
 +
 ----
@@ -282,6 +286,7 @@ Replace `<user>` with the name of the user that is bootstrapping the client in t
 ----
 <user>  ALL=NOPASSWD: /usr/bin/python, /usr/bin/python2, /usr/bin/python3, /var/tmp/venv-salt-minion/bin/python
 ----
+_____
 
 [NOTE]
 ====
@@ -298,21 +303,21 @@ To bootstrap an Ubuntu client via SSH you must add the install-created user to t
 Then run the bootstrap script from the client.
 
 .Procedure: Adding Install-created User to sudo Group and Bootstrapping via SSH
-
+[role="procedure"]
+_____
 . On the client, as root, run from the command line (replace `<username>` with the name of the install-created user):
 +
-
 ----
 sudo usermod -aG sudo <username>
 ----
 
 . Bootstrap the client system from its command line (replace `<SERVER_FQDN>` with the fully qualified domain name of the {productname} Server):
 +
-
 ----
 sudo su -
 curl -Sks https://<SERVER_FQDN>/pub/bootstrap/bootstrap-script.sh | /bin/bash
 ----
+_____
 
 [IMPORTANT]
 ====

--- a/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
@@ -1,6 +1,6 @@
 [[supported-features-ubuntu]]
 = Supported {ubuntu} Features
-:revdate: 2026-05-21
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 
@@ -21,162 +21,201 @@ The icons in this table indicate:
 ifeval::[{mlm-content} == true]
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
 | Feature
 | {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}26.04
 
 | Client
+| {check}
 | {check}
 | {check}
 
 | System packages
 | {ubuntu} Community
 | {ubuntu} Community
+| {ubuntu} Community
 
 | Registration
+| {check}
 | {check}
 | {check}
 
 | Install packages
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 
 | Remote commands
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 
 | System custom states
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 
 | Organization custom states
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 
 | Product migration
 | N/A
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {cross}
 | {cross}
 | {cross}
 
 | System redeployment (Kickstart)
 | {cross}
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 
 | Staging (pre-download of packages)
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 
 | CVE auditing
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {question}
 | {question}
 | {question}
 
 | Package verification
 | {cross}
 | {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 | {check}
 
 | Maintenance Windows
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 
 | System snapshot
 | {cross}
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 | {check}
 
 | Monitoring server
 | {cross}
 | {cross}
+| {cross}
 
 | Monitored clients
+| {check}
 | {check}
 | {check}
 
 | Docker buildhost
 | {question}
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {check}
 | {check}
 | {check}
 
 | Kiwi buildhost
 | {cross}
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 | {cross}
 
 | Recurring Actions
 | {check}
 | {check}
+| {check}
 
 | AppStreams
 | N/A
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 | N/A
 |===
@@ -187,158 +226,196 @@ endif::[]
 ifeval::[{uyuni-content} == true]
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
 | Feature
 | {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}26.04
 
 | Client
+| {check}
 | {check}
 | {check}
 
 | System packages
 | Canonical
 | Canonical
+| Canonical
 
 | Registration
+| {check}
 | {check}
 | {check}
 
 | Install packages
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 
 | Remote commands
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 
 | System custom states
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 
 | Organization custom states
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 
 | Product migration
 | N/A
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {cross}
 | {cross}
 | {cross}
 
 | System redeployment (Kickstart)
 | {cross}
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 
 | Staging (pre-download of packages)
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 
 | CVE auditing
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {question}
 | {question}
 | {question}
 
 | Package verification
 | {cross}
 | {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 | {check}
 
 | Maintenance Windows
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 
 | System snapshot
 | {cross}
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 | {check}
 
 | Monitoring
 | {check}
 | {check}
+| {check}
 
 | Docker buildhost
+| {question}
 | {question}
 | {question}
 
 | Build Docker image with OS
 | {check}
 | {check}
+| {check}
 
 | Kiwi buildhost
+| {cross}
 | {cross}
 | {cross}
 
 | Build Kiwi image with OS
 | {cross}
 | {cross}
+| {cross}
 
 | Recurring Actions
+| {check}
 | {check}
 | {check}
 
 | AppStreams
 | N/A
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 | N/A
 |===

--- a/en/modules/client-configuration/pages/supported-features.adoc
+++ b/en/modules/client-configuration/pages/supported-features.adoc
@@ -1,6 +1,6 @@
 [[supported-features]]
 = Supported Clients and Features
-:revdate: 2026-05-21
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 
 {productname} is compatible with a range of client technologies.
@@ -138,7 +138,7 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {check}
 
-| {ubuntu} 22.04, 24.04 (*)
+| {ubuntu} 22.04, 24.04, 26.04 (*)
 | {check}
 | {cross}
 | {cross}
@@ -295,7 +295,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {ubuntu} 22.04, 24.04
+| {ubuntu} 22.04, 24.04, 26.04
 | {check}
 | {cross}
 | {cross}


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

This PR adds documentation support for Ubuntu 26.04 (Resolute Raccoon) client systems across the client configuration and administration guides.
Additionally, legacy procedures in `clients-ubuntu.adoc` and `install_scap_security_guide_package.adoc` have been updated to use the project's standard quoted role attributes and five-underscore sidebar delimiters, and all modified files' headers have been updated to today's date.


# Target branches

- master (this PR)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5162
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5163


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30346