### PR TITLE
manager-5.1 - Document Ubuntu 26.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added documentation support for Ubuntu 26.04 client systems
 - Extended configuration instructions for Saline formula in Specialized Guides
   (bsc#1268587)
 - Enhanced instructions for Liberate formula and reactivation key in Specialized

--- a/en/modules/administration/pages/auditing.adoc
+++ b/en/modules/administration/pages/auditing.adoc
@@ -1,7 +1,7 @@
 [[auditing]]
 = Auditing
 :description: Manage client relationships effectively by auditing tasks within SUSE Multi-Linux Manager, such as checking for security patches and ensuring compliance
-:revdate: 2026-06-24
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -223,6 +223,7 @@ Debian 13 +
 Raspberry Pi OS
 | Ubuntu | https://security-metadata.canonical.com/oval
 a|
+Ubuntu 26.04 +
 Ubuntu 24.04 +
 Ubuntu 22.04
 | AlmaLinux | https://security.almalinux.org/oval

--- a/en/modules/administration/pages/openscap.adoc
+++ b/en/modules/administration/pages/openscap.adoc
@@ -1,7 +1,7 @@
 [[ch-openscap]]
 = System Security with OpenSCAP
 :description: Configure system security with OpenSCAP through the SUSE Multi-Linux Manager, which enables scheduling and viewing of compliance scans for clients
-:revdate: 2026-05-12
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -69,11 +69,12 @@ The table below lists the packages you need:
 | Debian | 13 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debian` can be used at your own risk.]
 | Ubuntu | 22.04 | `libopenscap8` | `scap-security-guide-ubuntu`
 | Ubuntu | 24.04 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debderived` can be used at your own risk.]
+| Ubuntu | 26.04 | `openscap-scanner` | Not officially supported footnote:[This package is community-provided and not officially supported by {suse}. Upstream `ssg-debderived` can be used at your own risk.]
 |===
 
 [NOTE]
 ====
-For Debian 13 and Ubuntu 24.04, {suse} does not provide custom security guide packages.
+For Debian 13, Ubuntu 24.04, and Ubuntu 26.04, {suse} does not provide custom security guide packages.
 To perform scans on these clients, you must install the upstream packages (`ssg-debian` and `ssg-debderived` respectively) from their respective community repositories.
 Please note that these upstream guides are not officially supported by {suse}.
 ====

--- a/en/modules/administration/partials/install_scap_security_guide_package.adoc
+++ b/en/modules/administration/partials/install_scap_security_guide_package.adoc
@@ -4,7 +4,7 @@
 For executing remediations you need to install the SCAP security guide package on the Ansible control node.
 
 .Procedure: Installing the SCAP security guide package
-[role=procedure]
+[role="procedure"]
 _____
 . From menu:Systems[Overview], select the client.
   Then click menu:Software[Packages > Install].
@@ -36,7 +36,7 @@ _____
 
 [NOTE]
 ====
-For Debian 13 and Ubuntu 24.04, {suse} does not provide custom security guide packages.
+For Debian 13, Ubuntu 24.04, and Ubuntu 26.04, {suse} does not provide custom security guide packages.
 You must use upstream packages (`ssg-debian` and `ssg-debderived` respectively) from their respective community repositories.
 Please note that these upstream guides are not officially supported by {suse}.
 ====

--- a/en/modules/client-configuration/pages/clients-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/clients-ubuntu.adoc
@@ -1,7 +1,7 @@
 [[clients-ubuntu]]
 = Registering {ubuntu} Clients
 :description: Configure Ubuntu clients with your SUSE Multi-Linux Manager Server by adding required software channels, synchronizing them, and managing supported products
-:revdate: 2025-03-13
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -22,7 +22,7 @@ endif::[]
 
 ifeval::[{mlm-content} == true]
 
-{productname} supports {ubuntu} 22.04 LTS and 24.04 LTS clients using {salt}.
+{productname} supports {ubuntu} 22.04 LTS, 24.04 LTS, and 26.04 LTS clients using {salt}.
 endif::[]
 
 Bootstrapping is supported for starting {ubuntu} clients and performing initial state runs such as setting repositories and performing profile updates.
@@ -56,6 +56,7 @@ The products you need for this procedure are:
 |===
 
 | OS Version     | Product Name
+| {ubuntu} 26.04 | Ubuntu 26.04
 | {ubuntu} 24.04 | Ubuntu 24.04
 | {ubuntu} 22.04 | Ubuntu 22.04
 |===
@@ -77,6 +78,7 @@ The channels you need for this procedure are:
 |===
 
 | OS Version     | Base Channel
+| {ubuntu} 26.04 | ubuntu-2604-amd64-main-amd64
 | {ubuntu} 24.04 | ubuntu-2404-amd64-main-amd64
 | {ubuntu} 22.04 | ubuntu-2204-amd64-main-amd64
 |===
@@ -102,6 +104,7 @@ The channels you need for this procedure are:
 
 | OS Version | Base Channel | Main Channel | Updates Channel | Security Channel | Client Channel
 
+| {ubuntu} 26.04 | ubuntu-2604-pool-amd64-uyuni | ubuntu-2604-amd64-main-uyuni | ubuntu-2604-amd64-main-updates-uyuni | ubuntu-2604-amd64-main-security-uyuni | ubuntu-2604-amd64-uyuni-client
 | {ubuntu} 24.04 | ubuntu-2404-pool-amd64-uyuni | ubuntu-2404-amd64-main-uyuni | ubuntu-2404-amd64-main-updates-uyuni | ubuntu-2404-amd64-main-security-uyuni | ubuntu-2404-amd64-uyuni-client
 | {ubuntu} 22.04 | ubuntu-2204-pool-amd64-uyuni | ubuntu-2204-amd64-main-uyuni | ubuntu-2204-amd64-main-updates-uyuni | ubuntu-2204-amd64-main-security-uyuni | ubuntu-2204-amd64-uyuni-client
 | {ubuntu} 20.04 | ubuntu-2004-pool-amd64-uyuni | ubuntu-2004-amd64-main-uyuni | ubuntu-2004-amd64-main-updates-uyuni | ubuntu-2004-amd64-main-security-uyuni | ubuntu-2004-amd64-uyuni-client
@@ -195,7 +198,7 @@ Replace `<token>` with your personal Bearer Token. Also, `arch` and `release` mu
 |===
 
 | Architectures | Releases
-| `amd64`, `arm64`, `armel`, `armhf`, `i386`, `powerpc`, `ppc64el`, `s390x` | `bionic`, `focal`, `jammy`, `noble`, `trusty`, `xenial`
+| `amd64`, `arm64`, `armel`, `armhf`, `i386`, `powerpc`, `ppc64el`, `s390x` | `bionic`, `focal`, `jammy`, `noble`, `resolute`, `trusty`, `xenial`
 |===
 
 In order for {productname} to synchronize the repositories, the corresponding GPG keys (`ubuntu-advantage-esm-infra-trusty.gpg`, `ubuntu-advantage-esm-apps.gpg`) must be imported. These are located on a system registered with Ubuntu Pro under `/etc/apt/trusted.gpg.d`. Copy these files to the {productname} system and import them as follows:
@@ -286,7 +289,8 @@ With cloud instances this does not happen because `cloud-init` automatically cre
 === Grant Root User Access
 
 .Procedure: Granting Root User Access
-
+[role="procedure"]
+_____
 . On the client, edit the `sudoers` file:
 +
 ----
@@ -299,6 +303,7 @@ Replace `<user>` with the name of the user that is bootstrapping the client in t
 ----
 <user>  ALL=NOPASSWD: /usr/bin/python, /usr/bin/python2, /usr/bin/python3, /var/tmp/venv-salt-minion/bin/python
 ----
+_____
 
 [NOTE]
 ====
@@ -315,21 +320,21 @@ To bootstrap an Ubuntu client via SSH you must add the install-created user to t
 Then run the bootstrap script from the client.
 
 .Procedure: Adding Install-created User to sudo Group and Bootstrapping via SSH
-
+[role="procedure"]
+_____
 . On the client, as root, run from the command line (replace `<username>` with the name of the install-created user):
 +
-
 ----
 sudo usermod -aG sudo <username>
 ----
 
 . Bootstrap the client system from its command line (replace `<SERVER_FQDN>` with the fully qualified domain name of the {productname} Server):
 +
-
 ----
 sudo su -
 curl -Sks https://<SERVER_FQDN>/pub/bootstrap/bootstrap-script.sh | /bin/bash
 ----
+_____
 
 [IMPORTANT]
 ====

--- a/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
+++ b/en/modules/client-configuration/pages/supported-features-ubuntu.adoc
@@ -1,7 +1,7 @@
 [[supported-features-ubuntu]]
 = Supported {ubuntu} Features
 :description: Learn about the various features supported by Canonical for Ubuntu clients, including registration, package installation, remote commands, system package
-:revdate: 2025-03-13
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -26,163 +26,202 @@ The icons in this table indicate:
 ifeval::[{mlm-content} == true]
 
 
-[cols="1,1,1", options="header"]
+[cols="1,1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
 
 | Feature
 | {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}26.04
 
 | Client
+| {check}
 | {check}
 | {check}
 
 | System packages
 | {ubuntu} Community
 | {ubuntu} Community
+| {ubuntu} Community
 
 | Registration
+| {check}
 | {check}
 | {check}
 
 | Install packages
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 
 | Remote commands
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 
 | System custom states
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 
 | Organization custom states
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 
 | Product migration
 | N/A
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {cross}
 | {cross}
 | {cross}
 
 | System redeployment (Kickstart)
 | {cross}
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 
 | Works with {productname} Proxy
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 
 | Staging (pre-download of packages)
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 
 | CVE auditing
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {question}
 | {question}
 | {question}
 
 | Package verification
 | {cross}
 | {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 | {check}
 
 | Maintenance Windows
 | {check}
 | {check}
+| {check}
 
 | System locking
+| {cross}
 | {cross}
 | {cross}
 
 | System snapshot
 | {cross}
 | {cross}
+| {cross}
 
 | Configuration file management
+| {check}
 | {check}
 | {check}
 
 | Package profiles
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
+| {check} Profiles supported, Sync not supported
 
 | Power management
+| {check}
 | {check}
 | {check}
 
 | Monitoring server
 | {cross}
 | {cross}
+| {cross}
 
 | Monitored clients
+| {check}
 | {check}
 | {check}
 
 | Docker buildhost
 | {question}
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {check}
 | {check}
 | {check}
 
 | Kiwi buildhost
 | {cross}
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 | {cross}
 
 | Recurring Actions
 | {check}
 | {check}
+| {check}
 
 | AppStreams
 | N/A
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 | N/A
 
@@ -194,7 +233,7 @@ endif::[]
 ifeval::[{uyuni-content} == true]
 
 
-[cols="1,1,1,1", options="header"]
+[cols="1,1,1,1,1", options="header"]
 .Supported Features on {ubuntu} Operating Systems
 |===
 
@@ -202,8 +241,10 @@ ifeval::[{uyuni-content} == true]
 | {ubuntu}{nbsp}20.04
 | {ubuntu}{nbsp}22.04
 | {ubuntu}{nbsp}24.04
+| {ubuntu}{nbsp}26.04
 
 | Client
+| {check}
 | {check}
 | {check}
 | {check}
@@ -212,8 +253,10 @@ ifeval::[{uyuni-content} == true]
 | Canonical
 | Canonical
 | Canonical
+| Canonical
 
 | Registration
+| {check}
 | {check}
 | {check}
 | {check}
@@ -222,8 +265,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Apply patches
+| {check}
 | {check}
 | {check}
 | {check}
@@ -232,8 +277,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System package states
+| {check}
 | {check}
 | {check}
 | {check}
@@ -242,8 +289,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Group custom states
+| {check}
 | {check}
 | {check}
 | {check}
@@ -252,8 +301,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | System set manager (SSM)
+| {check}
 | {check}
 | {check}
 | {check}
@@ -262,8 +313,10 @@ ifeval::[{uyuni-content} == true]
 | N/A
 | N/A
 | N/A
+| N/A
 
 | System deployment (PXE/Kickstart)
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -272,8 +325,10 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 | {cross}
+| {cross}
 
 | Contact methods
+| {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
 | {check} ZeroMQ, Salt-SSH
@@ -282,8 +337,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Action chains
+| {check}
 | {check}
 | {check}
 | {check}
@@ -292,8 +349,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Duplicate package reporting
+| {check}
 | {check}
 | {check}
 | {check}
@@ -302,8 +361,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | SCAP auditing
+| {question}
 | {question}
 | {question}
 | {question}
@@ -312,8 +373,10 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 | {cross}
+| {cross}
 
 | Package locking
+| {check}
 | {check}
 | {check}
 | {check}
@@ -322,8 +385,10 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 | {cross}
+| {cross}
 
 | System snapshot
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -332,8 +397,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Package profiles
+| {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
 | {check} Profiles supported, Sync not supported
@@ -342,8 +409,10 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | Monitoring
+| {check}
 | {check}
 | {check}
 | {check}
@@ -352,8 +421,10 @@ ifeval::[{uyuni-content} == true]
 | {question}
 | {question}
 | {question}
+| {question}
 
 | Build Docker image with OS
+| {check}
 | {check}
 | {check}
 | {check}
@@ -362,8 +433,10 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 | {cross}
+| {cross}
 
 | Build Kiwi image with OS
+| {cross}
 | {cross}
 | {cross}
 | {cross}
@@ -372,13 +445,16 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {check}
 | {check}
+| {check}
 
 | AppStreams
 | N/A
 | N/A
 | N/A
+| N/A
 
 | Yomi
+| N/A
 | N/A
 | N/A
 | N/A

--- a/en/modules/client-configuration/pages/supported-features.adoc
+++ b/en/modules/client-configuration/pages/supported-features.adoc
@@ -1,7 +1,7 @@
 [[supported-features]]
 = Supported Clients and Features
 :description: Configure and manage a wide range of Linux operating systems including SUSE Linux Enterprise Server for SAP, AlmaLinux, CentOS, Debian, Oracle Linux, Red Hat
-:revdate: 2026-05-21
+:revdate: 2026-07-27
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -143,7 +143,7 @@ ifeval::[{mlm-content} == true]
 | {cross}
 | {check}
 
-| {ubuntu} 22.04, 24.04 (*)
+| {ubuntu} 22.04, 24.04, 26.04 (*)
 | {check}
 | {cross}
 | {cross}
@@ -300,7 +300,7 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {ubuntu} 22.04, 24.04
+| {ubuntu} 22.04, 24.04, 26.04
 | {check}
 | {cross}
 | {cross}


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

This is a backport of https://github.com/uyuni-project/uyuni-docs/pull/5161 to the `manager-5.1` branch.

This PR adds documentation support for Ubuntu 26.04 (Resolute Raccoon) client systems across the client configuration and administration guides.
Additionally, legacy procedures in `clients-ubuntu.adoc` and `install_scap_security_guide_package.adoc` have been updated to use the project's standard quoted role attributes and five-underscore sidebar delimiters, and all modified files' headers have been updated to today's date.


# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5161
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5162
- manager-5.1 (this PR)


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/30346