### PR TITLE
Added procedure for recovery from a failed migration

### DIFF
--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
@@ -261,13 +261,13 @@ endif::[]
 
 === Recover from a failed upgrade
 
-If the database migration fails during mgradm upgrade (for example due to "No space left on device", or an unexpected container exit), the original {postgresql} database should remain untouched and safe. 
+If the database upgrade fails during mgradm upgrade (for example, due to `No space left on device`, or an unexpected container exit), the original {postgresql} database should remain untouched and safe. 
 Use the following procedure to clean up the environment and retry the upgrade:
 
 .Procedure: Recovering from a failed upgrade
 [role=procedure]
 ____
-. Stop and remove any residual migration containers (e.g., `uyuni-upgrade-pgsql`):
+. Stop and remove any residual containers (e.g., `uyuni-upgrade-pgsql`):
 
 +
 
@@ -291,9 +291,9 @@ podman volume rm var-pgsql-migration-target
 +
 
 . Ensure the underlying host filesystem has sufficient capacity.
-  Ideally at least double the capacity of the current database volume plus a safety buffershould be available to accommodate the copy-based upgrade.
+  Ideally at least double the capacity of the current database volume plus a safety buffer should be available to accommodate the copy-based upgrade.
 
-. Once storage space is resolved, re-initiate the migration: 
+. Once storage space is resolved, re-initiate the upgrade: 
 
 +
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
@@ -258,6 +258,53 @@ include::../../../../../partials/snippet-database-backup-volume.adoc[leveloffset
 endif::[]
 
 
+
+=== Recover from a failed upgrade
+
+If the database migration fails during mgradm upgrade (for example due to "No space left on device", or an unexpected container exit), the original {postgresql} database should remain untouched and safe. 
+Use the following procedure to clean up the environment and retry the upgrade:
+
+.Procedure: Recovering from a failed upgrade
+[role=procedure]
+____
+. Stop and remove any residual migration containers (e.g., `uyuni-upgrade-pgsql`):
+
++
+
+[source,bash]
+---- 
+podman stop uyuni−upgrade−pgsql
+podman rm uyuni-upgrade-pgsql 
+----
+
++
+
+. Remove the partial, incomplete target volume created during the failed attempt (e.g., `var-pgsql-migration-target`): 
+
++
+
+[source,bash]
+---- 
+podman volume rm var-pgsql-migration-target 
+----
+
++
+
+. Ensure the underlying host filesystem has sufficient capacity.
+  Ideally at least double the capacity of the current database volume plus a safety buffershould be available to accommodate the copy-based upgrade.
+
+. Once storage space is resolved, re-initiate the migration: 
+
++
+
+[source,bash]
+----
+mgradm upgrade 
+----
+
+____
+
+
 == {sles} 15 SP7
 
 This document provides the procedure to upgrade a {sles} 15 SP7 host deployed with {productname} 5.1 Server to {productname} {productnumber}.


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

From bug:
"If an administrator runs `mgradm upgrade` and the containerized database migration fails (for example, due to a "No space left on device" error), there is currently no documentation explaining how to recover. This leads to customer panic, uncleared storage volumes, and preventable support tickets"


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master
- 5.2



# Links
- This PR tracks bug https://bugzilla.suse.com/show_bug.cgi?id=1271596.