### PR TITLE
manager-5.1 - Document Virtualization Host requirement for VM gathering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Extended configuration instructions for Saline formula in Specialized Guides
   (bsc#1268587)
 - Enhanced instructions for Liberate formula and reactivation key in Specialized

--- a/en/modules/client-configuration/pages/system-types.adoc
+++ b/en/modules/client-configuration/pages/system-types.adoc
@@ -1,7 +1,7 @@
 [[system-types]]
 = System Types
 :description: Configure your clients systems by assigning a base system type and adding virtualization or container build host capabilities
-:revdate: 2023-11-23
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -11,10 +11,18 @@
 Clients are categorized by system type.
 Every client can have both a base system type, and an add-on system type assigned.
 
-Base system type is `Salt` for all clients.
+Base system type is `Salt` for all clients.
 
-Add-on system types include `Virtualization Host`, for clients that operate as virtual hosts, 
-and `Container Build Host` for clients that operate as a build host.
+Add-on system types include:
 
-You can adjust the add-on system type by navigating to menu:Systems[System List > System Types].
-Check the clients you want to change the add-on system type for, select the `Add-On System Type`, and click either btn:[Add System Type] or btn:[Remove System Type].
+* `Virtualization Host`: Assigned to clients that operate as physical virtual hosts/hypervisors (such as KVM). Setting this system type is required to allow the daily Taskomatic job to query the system directly (via `libvirt`) and inventory its running virtual machines for display under menu:Systems[System List > Virtual Systems] and for subscription matching.
+* `Container Build Host`: Assigned to clients that operate as a build host.
+
+.Adjust the add-on system type
+[role="procedure"]
+_____
+. In the {productname} {webui}, navigate to menu:Systems[System List > System Types].
+. Check the clients you want to change the add-on system type for.
+. Select the `Add-On System Type`.
+. Click either btn:[Add System Type] or btn:[Remove System Type].
+_____

--- a/en/modules/client-configuration/pages/vhm.adoc
+++ b/en/modules/client-configuration/pages/vhm.adoc
@@ -1,7 +1,7 @@
 [[virt-vhm]]
 = Virtual Host Managers
 :description: Configure virtualized clients using Virtual Host Managers to collect data displayed in the SUSE Multi-Linux Manager Web UI
-:revdate: 2025-04-15
+:revdate: 2026-08-03
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -17,9 +17,15 @@ VHMs also allow you to use subscription matching on your virtualized clients.
 You can create a VHM on your {productname} Server, and use it to inventory available public cloud instances.
 You can also use a VHM to manage clusters created with {kube}.
 
-* For more information on using a VHM with Amazon Web Services, see xref:client-configuration:vhm-aws.adoc[].
+* For more information on using a VHM with Amazon Web Services, see xref:client-configuration:vhm-aws.adoc[].
 * For more information on using a VHM with Microsoft Azure, see xref:client-configuration:vhm-azure.adoc[].
 * For more information on using a VHM with Nutanix, see xref:client-configuration:vhm-nutanix.adoc[].
 * For more information on using a VHM with VMWare vSphere, see xref:client-configuration:vhm-vmware.adoc[].
 * For more information on using a VHM with other hosts, see xref:client-configuration:vhm-file.adoc[].
 
+
+== Direct Hypervisor Querying
+
+Registered physical Linux clients acting as hypervisors (such as KVM) do not require a Virtual Host Manager (VHM) configuration. Instead, if a registered physical host has the `Virtualization Host` add-on system type assigned, {productname} queries the system directly using `libvirt` to gather virtual machine data.
+
+For more information, see xref:client-configuration:system-types.adoc[].


### PR DESCRIPTION
# Description

This is a backport of https://github.com/uyuni-project/uyuni-docs/pull/5172 to the `manager-5.1` branch.

This PR documents the new Virtualization Host requirement for direct virtual machine data gathering (libvirt polling).

Specifically:
- Updates `system-types.adoc` to expand the `Virtualization Host` add-on system type, explaining that registered physical hypervisors must have this type assigned to be queried directly by Taskomatic.
- Reformats the add-on system type adjustment procedure in `system-types.adoc` to use the standard `[role="procedure"]` and sidebar delimiters (`_____`), in compliance with project instructions.
- Updates `vhm.adoc` to add a dedicated section clarifying direct hypervisor querying for local hypervisors (without the need for VHMs).
- Prepend a changelog entry to `CHANGELOG.md` referencing `bsc#1273073`.
- Updates all edited file headers with today's date (`2026-08-03`).

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5172
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5170
- manager-5.1 (this PR)

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31468