### PR TITLE
manager-5.2 - Clarify availability of Salt's "virt" module in the Salt Bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Clarified availability of Salt's "virt" module in the Salt Bundle (bsc#1270694)
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added a common workflow for certificate setup and rotation with ACME
 - Added documentation support for Ubuntu 26.04 client systems

--- a/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
+++ b/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
@@ -1,6 +1,6 @@
 [[contact-methods-saltbundle]]
 = Salt Bundle
-:revdate: 2025-07-14
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 
 == What is Salt Bundle?
@@ -52,7 +52,8 @@ The {salt} state `util.mgr_switch_to_venv_minion` is available to switch from `s
 It is recommended to switch to `venv-salt-minion` in two steps to avoid trouble with shifting processes:
 
 .Procedure: Switching with `util.mgr_switch_to_venv_minion` state to `venv-salt-minion`
-
+[role=procedure]
+_____
 . Apply `util.mgr_switch_to_venv_minion` with no pillar specified first.
   This will result in the switch to `venv-salt-minion` with copying configuration files etc.
   It will not clean up the original `salt-minion` configurations and its packages.
@@ -60,12 +61,14 @@ It is recommended to switch to `venv-salt-minion` in two steps to avoid trouble 
 ----
 salt <minion_id> state.apply util.mgr_switch_to_venv_minion
 ----
+
 . Apply `util.mgr_switch_to_venv_minion` with `mgr_purge_non_venv_salt` set to `True` to remove `salt-minion` and with `mgr_purge_non_venv_salt_files` set to `True` to remove all the files related to `salt-minion`.
 This second step ensures the first step was processed, and then removes the old configuration files and the now obsolete `salt-minion` package.
 +
 ----
 salt <minion_id> state.apply util.mgr_switch_to_venv_minion pillar='{"mgr_purge_non_venv_salt_files": True, "mgr_purge_non_venv_salt": True}'
 ----
+_____
 
 
 === Additional Concerns
@@ -132,3 +135,26 @@ Environment=VENV_PIP_TARGET=/new/path/local/venv-salt-minion/pip
 The Python packages installed through `pip` are not changing on updating the Salt Bundle.
 To ensure that such packages are available and functional after an update, it is recommended to install them with a {salt} state that is applied after Salt Bundle updates.
 ====
+
+
+[[contact-methods-saltbundle-virt]]
+== Availability of Salt's "virt" module inside the Salt Bundle
+
+The Salt `virt` module is not available by default inside the Salt Bundle (`venv-salt-minion`) because it requires Python `libvirt` bindings, which are not included in the bundle.
+
+If you need to use the `virt` module (for example, on physical virtual hosts or hypervisors like KVM), you have two options:
+
+* Install the classic `salt-minion` package instead of the Salt Bundle.
+* Or, if you want to keep using the Salt Bundle (`venv-salt-minion`), you must manually install the `libvirt-libs` system library on the managed host system, and then install the `libvirt-python` package in the `venv-salt-minion` environment using `pip`:
++
+[role=procedure]
+_____
+. Install the `libvirt-libs` package on the managed host system using the system's package manager.
+
+. Install the `libvirt-python` package inside the Salt Bundle environment:
++
+[source,bash]
+----
+salt <minion_id> pip.install libvirt-python
+----
+_____

--- a/en/modules/client-configuration/pages/system-types.adoc
+++ b/en/modules/client-configuration/pages/system-types.adoc
@@ -1,6 +1,6 @@
 [[system-types]]
 = System Types
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 
 Clients are categorized by system type.
@@ -11,13 +11,21 @@ Base system type is `Salt` for all clients.
 Add-on system types include:
 
 * `Virtualization Host`: Assigned to clients that operate as physical virtual hosts/hypervisors (such as KVM). Setting this system type is required to allow the daily Taskomatic job to query the system directly (via `libvirt`) and inventory its running virtual machines for display under menu:Systems[System List > Virtual Systems] and for subscription matching.
++
+[NOTE]
+====
+If the physical virtualization host is managed using the Salt Bundle (`venv-salt-minion`), you must manually install the `libvirt-libs` system library on the host and install the `libvirt-python` package in the `venv-salt-minion` environment. For more information, see xref:client-configuration:contact-methods-saltbundle.adoc#contact-methods-saltbundle-virt[Availability of Salt's "virt" module inside the Salt Bundle].
+====
 * `Container Build Host`: Assigned to clients that operate as a build host.
 
 .Adjust the add-on system type
-[role="procedure"]
+[role=procedure]
 _____
 . In the {productname} {webui}, navigate to menu:Systems[System List > System Types].
+
 . Check the clients you want to change the add-on system type for.
+
 . Select the `Add-On System Type`.
+
 . Click either btn:[Add System Type] or btn:[Remove System Type].
 _____

--- a/en/modules/client-configuration/pages/vhm.adoc
+++ b/en/modules/client-configuration/pages/vhm.adoc
@@ -1,6 +1,6 @@
 [[virt-vhm]]
 = Virtual Host Managers
-:revdate: 2026-08-03
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 
 Virtual Host Managers (VHMs) are used to gather information from a range of client types.
@@ -22,5 +22,10 @@ You can also use a VHM to manage clusters created with {kube}.
 == Direct Hypervisor Querying
 
 Registered physical Linux clients acting as hypervisors (such as KVM) do not require a Virtual Host Manager (VHM) configuration. Instead, if a registered physical host has the `Virtualization Host` add-on system type assigned, {productname} queries the system directly using `libvirt` to gather virtual machine data.
+
+[NOTE]
+====
+If the hypervisor is managed using the Salt Bundle (`venv-salt-minion`), see xref:client-configuration:contact-methods-saltbundle.adoc#contact-methods-saltbundle-virt[Availability of Salt's "virt" module inside the Salt Bundle] for the required setup.
+====
 
 For more information, see xref:client-configuration:system-types.adoc[].


### PR DESCRIPTION
# Description

This PR documents the availability of Salt's "virt" module inside the Salt Bundle (`venv-salt-minion`) and the required setup steps.

Specifically:
- Updates `contact-methods-saltbundle.adoc` to add a new section clarifying that the Salt `virt` module is not available inside the Salt Bundle by default, and explains the options (using classic `salt-minion` or installing `libvirt-libs` and `libvirt-python` using pip).
- Updates `system-types.adoc` and `vhm.adoc` to add `[NOTE]` blocks pointing to the Salt Bundle considerations when physical virtualization hosts are managed with `venv-salt-minion`.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5177
- manager-5.2 (this PR)
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5179

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31166
- Addresses Bugzilla issue https://bugzilla.suse.com/show_bug.cgi?id=1270694
