### PR TITLE
Replacing certificate needed before rename (bsc#1273853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added instruction for obtaining the certificate when renaming the server (bsc#1273853)
 - Added a common workflow for certificate setup and rotation with ACME
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added documentation support for Ubuntu 26.04 client systems

--- a/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
@@ -1,6 +1,6 @@
 [[tshoot-hostname-rename]]
 = Troubleshooting Renaming {productname} Server
-:revdate: 2025-02-18
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 
 ////
@@ -21,15 +21,6 @@ If more detailed instructions are required, put them in a "Resolving" procedure:
 . Last step
 ////
 
-////
-Showing my working. --LKB 2020-06-22
-
-Cause: Renaming the hostname
-Consequence: Changes not picked up by db, clients and proxies
-Fix: Use the `spacewalk-hostname-rename` script to update the settings in the PostgreSQL database and the internal structures of {productname}.
-Result: Renaming is successfully propagated
-////
-
 If you change the hostname of the {productname} Server locally, your {productname} installation ceases to work properly.
 This is because the changes have not been made in the database, which prevents the changes from propagating out your clients and any proxies.
 
@@ -40,6 +31,11 @@ This is because the changes have not been made in the database, which prevents t
 If you need to change the hostname of the {productname} Server, you can do so using the `mgradm server rename` command.
 This command updates the settings in the {postgresql} database and the internal structures of {productname}.
 
+[IMPORTANT]
+====
+If your system uses a certificate signed by an external or third-party certificate authority, the new certificate containing the new hostname must be obtained before beginning the renaming process. 
+To replace active certificates with your external certificates, see xref:administration:ssl-certs-imported.adoc#ssl-certs-import-replace[Replace certificates].
+====
 
 
 === Server configuration


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

The customer needs to do replace certificate before triggering the rename command.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5181
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5182


# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31568 / https://bugzilla.suse.com/show_bug.cgi?id=1273853.