### PR TITLE
5.2 - Replacing certificate needed before rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added instruction for obtaining the certificate when renaming the server (bsc#1273853)
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added a common workflow for certificate setup and rotation with ACME
 - Added documentation support for Ubuntu 26.04 client systems

--- a/Makefile.en
+++ b/Makefile.en
@@ -1,0 +1,95 @@
+# Clean up build artifacts
+.PHONY: clean-en
+clean-en: clean-branding-en ## Remove build artifacts from output directory (Antora and PDF)
+	$(call clean-function,translations/en,en)
+
+.PHONY: clean-branding-en
+clean-branding-en:
+	$(call clean-branding,en)
+
+.PHONY: copy-branding-en
+copy-branding-en: copy-branding
+	$(call copy-branding,en)
+
+.PHONY: configure-suma-branding-dsc-en
+configure-suma-branding-dsc-en: configure-suma-branding-dsc
+	$(call configure-suma-branding-dsc,en)
+
+.PHONY: configure-suma-branding-webui-en
+configure-suma-branding-webui-en: configure-suma-branding-webui
+	$(call configure-suma-branding-webui,en)
+
+.PHONY: validate-suma-en
+validate-suma-en:
+	$(call validate-product,translations/en,suma-site.yml)
+
+.PHONY: pdf-tar-suma-en
+pdf-tar-suma-en:
+	$(call pdf-tar-product,en,susemanager-docs_en-pdf,$(current_dir)/build/en/pdf)
+
+.PHONY: set-html-language-selector-suma-en
+set-html-language-selector-suma-en: set-html-language-selector-suma
+	mkdir -p $(shell dirname translations/en/$(SUPPLEMENTAL_FILES_SUMA))
+	cp -a translations/$(SUPPLEMENTAL_FILES_SUMA) translations/en/$(SUPPLEMENTAL_FILES_SUMA)
+
+.PHONY: prepare-antora-suma-en
+prepare-antora-suma-en: copy-branding-en set-html-language-selector-suma-en
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/en && \
+	cp -a antora.yml translations/en/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/documentation\.suse\.com\/suma\/5\.0\/\)/\1en\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/en/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/en/;" site.yml > translations/en/suma-site.yml && \
+	find translations/en/branding/supplemental-ui -name "*.hbs" -exec sed -i 's/LANG_PLACEHOLDER/en/g' {} \; && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/en/{} \; && \
+	mkdir -p $(current_dir)/translations/en/modules/ROOT/pages/
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/en/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-suma-en
+antora-suma-en: configure-suma-branding-dsc-en prepare-antora-suma-en pdf-all-suma-en pdf-tar-suma-en
+	$(call antora-suma-function,translations/en,en)
+
+.PHONY: obs-packages-suma-en
+obs-packages-suma-en: configure-suma-branding-webui-en pdf-all-suma-en antora-suma-en ## Generate SUMA OBS tar files
+	$(call obs-packages-product,en,en/pdf,susemanager-docs_en,susemanager-docs_en-pdf)
+
+# UYUNI
+
+.PHONY: validate-uyuni-en
+validate-uyuni-en:
+	$(call validate-product,translations/en,uyuni-site.yml)
+
+.PHONY: pdf-tar-uyuni-en
+pdf-tar-uyuni-en:
+	$(call pdf-tar-product,en,uyuni-docs_en-pdf,$(current_dir)/build/en/pdf)
+
+.PHONY: set-html-language-selector-uyuni-en
+set-html-language-selector-uyuni-en: set-html-language-selector-uyuni
+	mkdir -p $(shell dirname translations/en/$(SUPPLEMENTAL_FILES_UYUNI))
+	cp -a translations/$(SUPPLEMENTAL_FILES_UYUNI) translations/en/$(SUPPLEMENTAL_FILES_UYUNI)
+
+.PHONY: prepare-antora-uyuni-en
+prepare-antora-uyuni-en: copy-branding-en set-html-language-selector-uyuni-en
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/en && \
+	cp antora.yml translations/en/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/www\.uyuni-project\.org\/uyuni-docs\/\)/\1en\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/en/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/en/;" site.yml > translations/en/uyuni-site.yml && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/en/{} \; && \
+	mkdir -p $(current_dir)/translations/en/modules/ROOT/pages/	
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/en/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-uyuni-en
+antora-uyuni-en: prepare-antora-uyuni-en pdf-all-uyuni-en pdf-tar-uyuni-en
+	$(call antora-uyuni-function,translations/en,en)
+
+.PHONY: obs-packages-uyuni-en
+obs-packages-uyuni-en: pdf-all-uyuni-en antora-uyuni-en ## Generate UYUNI OBS tar files
+	$(call obs-packages-product,en,en/pdf,uyuni-docs_en,uyuni-docs_en-pdf)

--- a/Makefile.ja
+++ b/Makefile.ja
@@ -1,0 +1,95 @@
+# Clean up build artifacts
+.PHONY: clean-ja
+clean-ja: clean-branding-ja ## Remove build artifacts from output directory (Antora and PDF)
+	$(call clean-function,translations/ja,ja)
+
+.PHONY: clean-branding-ja
+clean-branding-ja:
+	$(call clean-branding,ja)
+
+.PHONY: copy-branding-ja
+copy-branding-ja: copy-branding
+	$(call copy-branding,ja)
+
+.PHONY: configure-suma-branding-dsc-ja
+configure-suma-branding-dsc-ja: configure-suma-branding-dsc
+	$(call configure-suma-branding-dsc,ja)
+
+.PHONY: configure-suma-branding-webui-ja
+configure-suma-branding-webui-ja: configure-suma-branding-webui
+	$(call configure-suma-branding-webui,ja)
+
+.PHONY: validate-suma-ja
+validate-suma-ja:
+	$(call validate-product,translations/ja,suma-site.yml)
+
+.PHONY: pdf-tar-suma-ja
+pdf-tar-suma-ja:
+	$(call pdf-tar-product,ja,susemanager-docs_ja-pdf,$(current_dir)/build/ja/pdf)
+
+.PHONY: set-html-language-selector-suma-ja
+set-html-language-selector-suma-ja: set-html-language-selector-suma
+	mkdir -p $(shell dirname translations/ja/$(SUPPLEMENTAL_FILES_SUMA))
+	cp -a translations/$(SUPPLEMENTAL_FILES_SUMA) translations/ja/$(SUPPLEMENTAL_FILES_SUMA)
+
+.PHONY: prepare-antora-suma-ja
+prepare-antora-suma-ja: copy-branding-ja set-html-language-selector-suma-ja
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/ja && \
+	cp -a antora.yml translations/ja/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/documentation\.suse\.com\/suma\/5\.0\/\)/\1ja\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/ja/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/ja/;" site.yml > translations/ja/suma-site.yml && \
+	find translations/ja/branding/supplemental-ui -name "*.hbs" -exec sed -i 's/LANG_PLACEHOLDER/ja/g' {} \; && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/ja/{} \; && \
+	mkdir -p $(current_dir)/translations/ja/modules/ROOT/pages/
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/ja/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-suma-ja
+antora-suma-ja: configure-suma-branding-dsc-ja prepare-antora-suma-ja pdf-all-suma-ja pdf-tar-suma-ja
+	$(call antora-suma-function,translations/ja,ja)
+
+.PHONY: obs-packages-suma-ja
+obs-packages-suma-ja: configure-suma-branding-webui-ja pdf-all-suma-ja antora-suma-ja ## Generate SUMA OBS tar files
+	$(call obs-packages-product,ja,ja/pdf,susemanager-docs_ja,susemanager-docs_ja-pdf)
+
+# UYUNI
+
+.PHONY: validate-uyuni-ja
+validate-uyuni-ja:
+	$(call validate-product,translations/ja,uyuni-site.yml)
+
+.PHONY: pdf-tar-uyuni-ja
+pdf-tar-uyuni-ja:
+	$(call pdf-tar-product,ja,uyuni-docs_ja-pdf,$(current_dir)/build/ja/pdf)
+
+.PHONY: set-html-language-selector-uyuni-ja
+set-html-language-selector-uyuni-ja: set-html-language-selector-uyuni
+	mkdir -p $(shell dirname translations/ja/$(SUPPLEMENTAL_FILES_UYUNI))
+	cp -a translations/$(SUPPLEMENTAL_FILES_UYUNI) translations/ja/$(SUPPLEMENTAL_FILES_UYUNI)
+
+.PHONY: prepare-antora-uyuni-ja
+prepare-antora-uyuni-ja: copy-branding-ja set-html-language-selector-uyuni-ja
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/ja && \
+	cp antora.yml translations/ja/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/www\.uyuni-project\.org\/uyuni-docs\/\)/\1ja\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/ja/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/ja/;" site.yml > translations/ja/uyuni-site.yml && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/ja/{} \; && \
+	mkdir -p $(current_dir)/translations/ja/modules/ROOT/pages/	
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/ja/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-uyuni-ja
+antora-uyuni-ja: prepare-antora-uyuni-ja pdf-all-uyuni-ja pdf-tar-uyuni-ja
+	$(call antora-uyuni-function,translations/ja,ja)
+
+.PHONY: obs-packages-uyuni-ja
+obs-packages-uyuni-ja: pdf-all-uyuni-ja antora-uyuni-ja ## Generate UYUNI OBS tar files
+	$(call obs-packages-product,ja,ja/pdf,uyuni-docs_ja,uyuni-docs_ja-pdf)

--- a/Makefile.ko
+++ b/Makefile.ko
@@ -1,0 +1,95 @@
+# Clean up build artifacts
+.PHONY: clean-ko
+clean-ko: clean-branding-ko ## Remove build artifacts from output directory (Antora and PDF)
+	$(call clean-function,translations/ko,ko)
+
+.PHONY: clean-branding-ko
+clean-branding-ko:
+	$(call clean-branding,ko)
+
+.PHONY: copy-branding-ko
+copy-branding-ko: copy-branding
+	$(call copy-branding,ko)
+
+.PHONY: configure-suma-branding-dsc-ko
+configure-suma-branding-dsc-ko: configure-suma-branding-dsc
+	$(call configure-suma-branding-dsc,ko)
+
+.PHONY: configure-suma-branding-webui-ko
+configure-suma-branding-webui-ko: configure-suma-branding-webui
+	$(call configure-suma-branding-webui,ko)
+
+.PHONY: validate-suma-ko
+validate-suma-ko:
+	$(call validate-product,translations/ko,suma-site.yml)
+
+.PHONY: pdf-tar-suma-ko
+pdf-tar-suma-ko:
+	$(call pdf-tar-product,ko,susemanager-docs_ko-pdf,$(current_dir)/build/ko/pdf)
+
+.PHONY: set-html-language-selector-suma-ko
+set-html-language-selector-suma-ko: set-html-language-selector-suma
+	mkdir -p $(shell dirname translations/ko/$(SUPPLEMENTAL_FILES_SUMA))
+	cp -a translations/$(SUPPLEMENTAL_FILES_SUMA) translations/ko/$(SUPPLEMENTAL_FILES_SUMA)
+
+.PHONY: prepare-antora-suma-ko
+prepare-antora-suma-ko: copy-branding-ko set-html-language-selector-suma-ko
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/ko && \
+	cp -a antora.yml translations/ko/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/documentation\.suse\.com\/suma\/5\.0\/\)/\1ko\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/ko/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/ko/;" site.yml > translations/ko/suma-site.yml && \
+	find translations/ko/branding/supplemental-ui -name "*.hbs" -exec sed -i 's/LANG_PLACEHOLDER/ko/g' {} \; && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/ko/{} \; && \
+	mkdir -p $(current_dir)/translations/ko/modules/ROOT/pages/
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/ko/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-suma-ko
+antora-suma-ko: configure-suma-branding-dsc-ko prepare-antora-suma-ko pdf-all-suma-ko pdf-tar-suma-ko
+	$(call antora-suma-function,translations/ko,ko)
+
+.PHONY: obs-packages-suma-ko
+obs-packages-suma-ko: configure-suma-branding-webui-ko pdf-all-suma-ko antora-suma-ko ## Generate SUMA OBS tar files
+	$(call obs-packages-product,ko,ko/pdf,susemanager-docs_ko,susemanager-docs_ko-pdf)
+
+# UYUNI
+
+.PHONY: validate-uyuni-ko
+validate-uyuni-ko:
+	$(call validate-product,translations/ko,uyuni-site.yml)
+
+.PHONY: pdf-tar-uyuni-ko
+pdf-tar-uyuni-ko:
+	$(call pdf-tar-product,ko,uyuni-docs_ko-pdf,$(current_dir)/build/ko/pdf)
+
+.PHONY: set-html-language-selector-uyuni-ko
+set-html-language-selector-uyuni-ko: set-html-language-selector-uyuni
+	mkdir -p $(shell dirname translations/ko/$(SUPPLEMENTAL_FILES_UYUNI))
+	cp -a translations/$(SUPPLEMENTAL_FILES_UYUNI) translations/ko/$(SUPPLEMENTAL_FILES_UYUNI)
+
+.PHONY: prepare-antora-uyuni-ko
+prepare-antora-uyuni-ko: copy-branding-ko set-html-language-selector-uyuni-ko
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/ko && \
+	cp antora.yml translations/ko/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/www\.uyuni-project\.org\/uyuni-docs\/\)/\1ko\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/ko/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/ko/;" site.yml > translations/ko/uyuni-site.yml && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/ko/{} \; && \
+	mkdir -p $(current_dir)/translations/ko/modules/ROOT/pages/	
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/ko/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-uyuni-ko
+antora-uyuni-ko: prepare-antora-uyuni-ko pdf-all-uyuni-ko pdf-tar-uyuni-ko
+	$(call antora-uyuni-function,translations/ko,ko)
+
+.PHONY: obs-packages-uyuni-ko
+obs-packages-uyuni-ko: pdf-all-uyuni-ko antora-uyuni-ko ## Generate UYUNI OBS tar files
+	$(call obs-packages-product,ko,ko/pdf,uyuni-docs_ko,uyuni-docs_ko-pdf)

--- a/Makefile.lang
+++ b/Makefile.lang
@@ -1,0 +1,4 @@
+-include Makefile.en
+-include Makefile.ja
+-include Makefile.zh_CN
+-include Makefile.ko

--- a/Makefile.lang.target
+++ b/Makefile.lang.target
@@ -1,0 +1,41 @@
+.PHONY: validate-suma
+validate-suma: configure-suma validate-suma-en validate-suma-ja validate-suma-zh_CN validate-suma-ko  
+        
+
+.PHONY: pdf-tar-suma
+pdf-tar-suma: configure-suma pdf-tar-suma-en pdf-tar-suma-ja pdf-tar-suma-zh_CN pdf-tar-suma-ko  
+        
+
+.PHONY: antora-suma
+antora-suma: configure-suma copy-branding antora-suma-en antora-suma-ja antora-suma-zh_CN antora-suma-ko  
+        
+
+.PHONY: obs-packages-suma
+obs-packages-suma: configure-suma clean obs-packages-suma-en obs-packages-suma-ja obs-packages-suma-zh_CN obs-packages-suma-ko  
+        
+
+.PHONY: pdf-all-suma
+pdf-all-suma: configure-suma pdf-all-suma-en pdf-all-suma-ja pdf-all-suma-zh_CN pdf-all-suma-ko  
+        
+
+.PHONY: validate-uyuni
+validate-uyuni: configure-uyuni validate-uyuni-en validate-uyuni-ja validate-uyuni-zh_CN validate-uyuni-ko  
+        
+
+.PHONY: pdf-tar-uyuni
+pdf-tar-uyuni: configure-uyuni pdf-tar-uyuni-en pdf-tar-uyuni-ja pdf-tar-uyuni-zh_CN pdf-tar-uyuni-ko  
+        
+
+.PHONY: antora-uyuni
+antora-uyuni: configure-uyuni copy-branding antora-uyuni-en antora-uyuni-ja antora-uyuni-zh_CN antora-uyuni-ko  
+        
+
+.PHONY: obs-packages-uyuni
+obs-packages-uyuni: configure-uyuni clean obs-packages-uyuni-en obs-packages-uyuni-ja obs-packages-uyuni-zh_CN obs-packages-uyuni-ko  
+        
+
+.PHONY: pdf-all-uyuni
+pdf-all-uyuni: configure-uyuni pdf-all-uyuni-en pdf-all-uyuni-ja pdf-all-uyuni-zh_CN pdf-all-uyuni-ko  
+        
+
+

--- a/Makefile.section.functions
+++ b/Makefile.section.functions
@@ -1,0 +1,522 @@
+define pdf-installation-and-upgrade-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),installation-and-upgrade,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-installation-and-upgrade-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),installation-and-upgrade,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-installation-and-upgrade-index-en
+pdf-installation-and-upgrade-index-en:
+	$(call pdf-book-create-index,translations/en,installation-and-upgrade,en)
+
+.PHONY: pdf-installation-and-upgrade-suma-en
+pdf-installation-and-upgrade-suma-en: translations prepare-antora-suma-en pdf-installation-and-upgrade-index-en
+	$(call pdf-installation-and-upgrade-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-installation-and-upgrade-uyuni-en
+pdf-installation-and-upgrade-uyuni-en: translations prepare-antora-uyuni-en pdf-installation-and-upgrade-index-en
+	$(call pdf-installation-and-upgrade-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-installation-and-upgrade-index-ja
+pdf-installation-and-upgrade-index-ja:
+	$(call pdf-book-create-index,translations/ja,installation-and-upgrade,ja)
+
+.PHONY: pdf-installation-and-upgrade-suma-ja
+pdf-installation-and-upgrade-suma-ja: translations prepare-antora-suma-ja pdf-installation-and-upgrade-index-ja
+	$(call pdf-installation-and-upgrade-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-installation-and-upgrade-uyuni-ja
+pdf-installation-and-upgrade-uyuni-ja: translations prepare-antora-uyuni-ja pdf-installation-and-upgrade-index-ja
+	$(call pdf-installation-and-upgrade-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-installation-and-upgrade-index-zh_CN
+pdf-installation-and-upgrade-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,installation-and-upgrade,zh_CN)
+
+.PHONY: pdf-installation-and-upgrade-suma-zh_CN
+pdf-installation-and-upgrade-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-installation-and-upgrade-index-zh_CN
+	$(call pdf-installation-and-upgrade-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-installation-and-upgrade-uyuni-zh_CN
+pdf-installation-and-upgrade-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-installation-and-upgrade-index-zh_CN
+	$(call pdf-installation-and-upgrade-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-installation-and-upgrade-index-ko
+pdf-installation-and-upgrade-index-ko:
+	$(call pdf-book-create-index,translations/ko,installation-and-upgrade,ko)
+
+.PHONY: pdf-installation-and-upgrade-suma-ko
+pdf-installation-and-upgrade-suma-ko: translations prepare-antora-suma-ko pdf-installation-and-upgrade-index-ko
+	$(call pdf-installation-and-upgrade-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-installation-and-upgrade-uyuni-ko
+pdf-installation-and-upgrade-uyuni-ko: translations prepare-antora-uyuni-ko pdf-installation-and-upgrade-index-ko
+	$(call pdf-installation-and-upgrade-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-client-configuration-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),client-configuration,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-client-configuration-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),client-configuration,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-client-configuration-index-en
+pdf-client-configuration-index-en:
+	$(call pdf-book-create-index,translations/en,client-configuration,en)
+
+.PHONY: pdf-client-configuration-suma-en
+pdf-client-configuration-suma-en: translations prepare-antora-suma-en pdf-client-configuration-index-en
+	$(call pdf-client-configuration-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-client-configuration-uyuni-en
+pdf-client-configuration-uyuni-en: translations prepare-antora-uyuni-en pdf-client-configuration-index-en
+	$(call pdf-client-configuration-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-client-configuration-index-ja
+pdf-client-configuration-index-ja:
+	$(call pdf-book-create-index,translations/ja,client-configuration,ja)
+
+.PHONY: pdf-client-configuration-suma-ja
+pdf-client-configuration-suma-ja: translations prepare-antora-suma-ja pdf-client-configuration-index-ja
+	$(call pdf-client-configuration-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-client-configuration-uyuni-ja
+pdf-client-configuration-uyuni-ja: translations prepare-antora-uyuni-ja pdf-client-configuration-index-ja
+	$(call pdf-client-configuration-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-client-configuration-index-zh_CN
+pdf-client-configuration-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,client-configuration,zh_CN)
+
+.PHONY: pdf-client-configuration-suma-zh_CN
+pdf-client-configuration-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-client-configuration-index-zh_CN
+	$(call pdf-client-configuration-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-client-configuration-uyuni-zh_CN
+pdf-client-configuration-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-client-configuration-index-zh_CN
+	$(call pdf-client-configuration-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-client-configuration-index-ko
+pdf-client-configuration-index-ko:
+	$(call pdf-book-create-index,translations/ko,client-configuration,ko)
+
+.PHONY: pdf-client-configuration-suma-ko
+pdf-client-configuration-suma-ko: translations prepare-antora-suma-ko pdf-client-configuration-index-ko
+	$(call pdf-client-configuration-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-client-configuration-uyuni-ko
+pdf-client-configuration-uyuni-ko: translations prepare-antora-uyuni-ko pdf-client-configuration-index-ko
+	$(call pdf-client-configuration-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-administration-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),administration,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-administration-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),administration,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-administration-index-en
+pdf-administration-index-en:
+	$(call pdf-book-create-index,translations/en,administration,en)
+
+.PHONY: pdf-administration-suma-en
+pdf-administration-suma-en: translations prepare-antora-suma-en pdf-administration-index-en
+	$(call pdf-administration-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-administration-uyuni-en
+pdf-administration-uyuni-en: translations prepare-antora-uyuni-en pdf-administration-index-en
+	$(call pdf-administration-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-administration-index-ja
+pdf-administration-index-ja:
+	$(call pdf-book-create-index,translations/ja,administration,ja)
+
+.PHONY: pdf-administration-suma-ja
+pdf-administration-suma-ja: translations prepare-antora-suma-ja pdf-administration-index-ja
+	$(call pdf-administration-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-administration-uyuni-ja
+pdf-administration-uyuni-ja: translations prepare-antora-uyuni-ja pdf-administration-index-ja
+	$(call pdf-administration-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-administration-index-zh_CN
+pdf-administration-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,administration,zh_CN)
+
+.PHONY: pdf-administration-suma-zh_CN
+pdf-administration-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-administration-index-zh_CN
+	$(call pdf-administration-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-administration-uyuni-zh_CN
+pdf-administration-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-administration-index-zh_CN
+	$(call pdf-administration-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-administration-index-ko
+pdf-administration-index-ko:
+	$(call pdf-book-create-index,translations/ko,administration,ko)
+
+.PHONY: pdf-administration-suma-ko
+pdf-administration-suma-ko: translations prepare-antora-suma-ko pdf-administration-index-ko
+	$(call pdf-administration-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-administration-uyuni-ko
+pdf-administration-uyuni-ko: translations prepare-antora-uyuni-ko pdf-administration-index-ko
+	$(call pdf-administration-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-reference-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),reference,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-reference-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),reference,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-reference-index-en
+pdf-reference-index-en:
+	$(call pdf-book-create-index,translations/en,reference,en)
+
+.PHONY: pdf-reference-suma-en
+pdf-reference-suma-en: translations prepare-antora-suma-en pdf-reference-index-en
+	$(call pdf-reference-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-reference-uyuni-en
+pdf-reference-uyuni-en: translations prepare-antora-uyuni-en pdf-reference-index-en
+	$(call pdf-reference-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-reference-index-ja
+pdf-reference-index-ja:
+	$(call pdf-book-create-index,translations/ja,reference,ja)
+
+.PHONY: pdf-reference-suma-ja
+pdf-reference-suma-ja: translations prepare-antora-suma-ja pdf-reference-index-ja
+	$(call pdf-reference-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-reference-uyuni-ja
+pdf-reference-uyuni-ja: translations prepare-antora-uyuni-ja pdf-reference-index-ja
+	$(call pdf-reference-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-reference-index-zh_CN
+pdf-reference-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,reference,zh_CN)
+
+.PHONY: pdf-reference-suma-zh_CN
+pdf-reference-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-reference-index-zh_CN
+	$(call pdf-reference-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-reference-uyuni-zh_CN
+pdf-reference-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-reference-index-zh_CN
+	$(call pdf-reference-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-reference-index-ko
+pdf-reference-index-ko:
+	$(call pdf-book-create-index,translations/ko,reference,ko)
+
+.PHONY: pdf-reference-suma-ko
+pdf-reference-suma-ko: translations prepare-antora-suma-ko pdf-reference-index-ko
+	$(call pdf-reference-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-reference-uyuni-ko
+pdf-reference-uyuni-ko: translations prepare-antora-uyuni-ko pdf-reference-index-ko
+	$(call pdf-reference-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-retail-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),retail,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-retail-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),retail,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-retail-index-en
+pdf-retail-index-en:
+	$(call pdf-book-create-index,translations/en,retail,en)
+
+.PHONY: pdf-retail-suma-en
+pdf-retail-suma-en: translations prepare-antora-suma-en pdf-retail-index-en
+	$(call pdf-retail-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-retail-uyuni-en
+pdf-retail-uyuni-en: translations prepare-antora-uyuni-en pdf-retail-index-en
+	$(call pdf-retail-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-retail-index-ja
+pdf-retail-index-ja:
+	$(call pdf-book-create-index,translations/ja,retail,ja)
+
+.PHONY: pdf-retail-suma-ja
+pdf-retail-suma-ja: translations prepare-antora-suma-ja pdf-retail-index-ja
+	$(call pdf-retail-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-retail-uyuni-ja
+pdf-retail-uyuni-ja: translations prepare-antora-uyuni-ja pdf-retail-index-ja
+	$(call pdf-retail-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-retail-index-zh_CN
+pdf-retail-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,retail,zh_CN)
+
+.PHONY: pdf-retail-suma-zh_CN
+pdf-retail-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-retail-index-zh_CN
+	$(call pdf-retail-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-retail-uyuni-zh_CN
+pdf-retail-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-retail-index-zh_CN
+	$(call pdf-retail-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-retail-index-ko
+pdf-retail-index-ko:
+	$(call pdf-book-create-index,translations/ko,retail,ko)
+
+.PHONY: pdf-retail-suma-ko
+pdf-retail-suma-ko: translations prepare-antora-suma-ko pdf-retail-index-ko
+	$(call pdf-retail-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-retail-uyuni-ko
+pdf-retail-uyuni-ko: translations prepare-antora-uyuni-ko pdf-retail-index-ko
+	$(call pdf-retail-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-common-workflows-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),common-workflows,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-common-workflows-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),common-workflows,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-common-workflows-index-en
+pdf-common-workflows-index-en:
+	$(call pdf-book-create-index,translations/en,common-workflows,en)
+
+.PHONY: pdf-common-workflows-suma-en
+pdf-common-workflows-suma-en: translations prepare-antora-suma-en pdf-common-workflows-index-en
+	$(call pdf-common-workflows-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-common-workflows-uyuni-en
+pdf-common-workflows-uyuni-en: translations prepare-antora-uyuni-en pdf-common-workflows-index-en
+	$(call pdf-common-workflows-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-common-workflows-index-ja
+pdf-common-workflows-index-ja:
+	$(call pdf-book-create-index,translations/ja,common-workflows,ja)
+
+.PHONY: pdf-common-workflows-suma-ja
+pdf-common-workflows-suma-ja: translations prepare-antora-suma-ja pdf-common-workflows-index-ja
+	$(call pdf-common-workflows-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-common-workflows-uyuni-ja
+pdf-common-workflows-uyuni-ja: translations prepare-antora-uyuni-ja pdf-common-workflows-index-ja
+	$(call pdf-common-workflows-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-common-workflows-index-zh_CN
+pdf-common-workflows-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,common-workflows,zh_CN)
+
+.PHONY: pdf-common-workflows-suma-zh_CN
+pdf-common-workflows-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-common-workflows-index-zh_CN
+	$(call pdf-common-workflows-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-common-workflows-uyuni-zh_CN
+pdf-common-workflows-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-common-workflows-index-zh_CN
+	$(call pdf-common-workflows-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-common-workflows-index-ko
+pdf-common-workflows-index-ko:
+	$(call pdf-book-create-index,translations/ko,common-workflows,ko)
+
+.PHONY: pdf-common-workflows-suma-ko
+pdf-common-workflows-suma-ko: translations prepare-antora-suma-ko pdf-common-workflows-index-ko
+	$(call pdf-common-workflows-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-common-workflows-uyuni-ko
+pdf-common-workflows-uyuni-ko: translations prepare-antora-uyuni-ko pdf-common-workflows-index-ko
+	$(call pdf-common-workflows-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-specialized-guides-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),specialized-guides,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-specialized-guides-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),specialized-guides,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-specialized-guides-index-en
+pdf-specialized-guides-index-en:
+	$(call pdf-book-create-index,translations/en,specialized-guides,en)
+
+.PHONY: pdf-specialized-guides-suma-en
+pdf-specialized-guides-suma-en: translations prepare-antora-suma-en pdf-specialized-guides-index-en
+	$(call pdf-specialized-guides-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-specialized-guides-uyuni-en
+pdf-specialized-guides-uyuni-en: translations prepare-antora-uyuni-en pdf-specialized-guides-index-en
+	$(call pdf-specialized-guides-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-specialized-guides-index-ja
+pdf-specialized-guides-index-ja:
+	$(call pdf-book-create-index,translations/ja,specialized-guides,ja)
+
+.PHONY: pdf-specialized-guides-suma-ja
+pdf-specialized-guides-suma-ja: translations prepare-antora-suma-ja pdf-specialized-guides-index-ja
+	$(call pdf-specialized-guides-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-specialized-guides-uyuni-ja
+pdf-specialized-guides-uyuni-ja: translations prepare-antora-uyuni-ja pdf-specialized-guides-index-ja
+	$(call pdf-specialized-guides-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-specialized-guides-index-zh_CN
+pdf-specialized-guides-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,specialized-guides,zh_CN)
+
+.PHONY: pdf-specialized-guides-suma-zh_CN
+pdf-specialized-guides-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-specialized-guides-index-zh_CN
+	$(call pdf-specialized-guides-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-specialized-guides-uyuni-zh_CN
+pdf-specialized-guides-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-specialized-guides-index-zh_CN
+	$(call pdf-specialized-guides-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-specialized-guides-index-ko
+pdf-specialized-guides-index-ko:
+	$(call pdf-book-create-index,translations/ko,specialized-guides,ko)
+
+.PHONY: pdf-specialized-guides-suma-ko
+pdf-specialized-guides-suma-ko: translations prepare-antora-suma-ko pdf-specialized-guides-index-ko
+	$(call pdf-specialized-guides-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-specialized-guides-uyuni-ko
+pdf-specialized-guides-uyuni-ko: translations prepare-antora-uyuni-ko pdf-specialized-guides-index-ko
+	$(call pdf-specialized-guides-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+define pdf-legal-product
+	cd $(current_dir)
+	$(call pdf-book-create,$(1),$(2),$(3),$(4),$(5),legal,$(6),$(7),$(8),$(9),$(10))
+endef
+
+define pdf-legal-product-uyuni
+	cd $(current_dir)
+	$(call pdf-book-create-uyuni,$(1),$(2),$(3),$(4),$(5),legal,$(6),$(7),$(8),$(9),$(10))
+endef
+
+.PHONY: pdf-legal-index-en
+pdf-legal-index-en:
+	$(call pdf-book-create-index,translations/en,legal,en)
+
+.PHONY: pdf-legal-suma-en
+pdf-legal-suma-en: translations prepare-antora-suma-en pdf-legal-index-en
+	$(call pdf-legal-product,translations/en,suse,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+.PHONY: pdf-legal-uyuni-en
+pdf-legal-uyuni-en: translations prepare-antora-uyuni-en pdf-legal-index-en
+	$(call pdf-legal-product-uyuni,translations/en,uyuni,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/en/pdf,en,en_US.utf8,%B %d %Y,)
+
+
+.PHONY: pdf-legal-index-ja
+pdf-legal-index-ja:
+	$(call pdf-book-create-index,translations/ja,legal,ja)
+
+.PHONY: pdf-legal-suma-ja
+pdf-legal-suma-ja: translations prepare-antora-suma-ja pdf-legal-index-ja
+	$(call pdf-legal-product,translations/ja,suse-jp,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-legal-uyuni-ja
+pdf-legal-uyuni-ja: translations prepare-antora-uyuni-ja pdf-legal-index-ja
+	$(call pdf-legal-product-uyuni,translations/ja,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ja/pdf,ja,ja_JP.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-legal-index-zh_CN
+pdf-legal-index-zh_CN:
+	$(call pdf-book-create-index,translations/zh_CN,legal,zh_CN)
+
+.PHONY: pdf-legal-suma-zh_CN
+pdf-legal-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-legal-index-zh_CN
+	$(call pdf-legal-product,translations/zh_CN,suse-sc,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+.PHONY: pdf-legal-uyuni-zh_CN
+pdf-legal-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-legal-index-zh_CN
+	$(call pdf-legal-product-uyuni,translations/zh_CN,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/zh_CN/pdf,zh_CN,zh_CN.UTF-8,%Y年%m月%e日,-a scripts=cjk)
+
+
+.PHONY: pdf-legal-index-ko
+pdf-legal-index-ko:
+	$(call pdf-book-create-index,translations/ko,legal,ko)
+
+.PHONY: pdf-legal-suma-ko
+pdf-legal-suma-ko: translations prepare-antora-suma-ko pdf-legal-index-ko
+	$(call pdf-legal-product,translations/ko,suse-ko,$(PRODUCTNAME_SUMA),$(SUMA_CONTENT),$(FILENAME_SUMA),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+.PHONY: pdf-legal-uyuni-ko
+pdf-legal-uyuni-ko: translations prepare-antora-uyuni-ko pdf-legal-index-ko
+	$(call pdf-legal-product-uyuni,translations/ko,uyuni-cjk,$(PRODUCTNAME_UYUNI),$(UYUNI_CONTENT),$(FILENAME_UYUNI),$(current_dir)/build/ko/pdf,ko,ko_KR.UTF-8,%Y년%m월%e일,-a scripts=cjk)
+
+
+
+# Generate PDF versions of all SUMA books
+.PHONY: pdf-all-suma-en
+pdf-all-suma-en: translations prepare-antora-suma-en pdf-installation-and-upgrade-suma-en pdf-client-configuration-suma-en pdf-administration-suma-en pdf-reference-suma-en pdf-retail-suma-en pdf-common-workflows-suma-en pdf-specialized-guides-suma-en pdf-legal-suma-en 
+# Generate PDF versions of all UYUNI books
+.PHONY: pdf-all-uyuni-en
+pdf-all-uyuni-en: translations prepare-antora-uyuni-en pdf-installation-and-upgrade-uyuni-en pdf-client-configuration-uyuni-en pdf-administration-uyuni-en pdf-reference-uyuni-en pdf-retail-uyuni-en pdf-common-workflows-uyuni-en pdf-specialized-guides-uyuni-en pdf-legal-uyuni-en 
+# Generate PDF versions of all SUMA books
+.PHONY: pdf-all-suma-ja
+pdf-all-suma-ja: translations prepare-antora-suma-ja pdf-installation-and-upgrade-suma-ja pdf-client-configuration-suma-ja pdf-administration-suma-ja pdf-reference-suma-ja pdf-retail-suma-ja pdf-common-workflows-suma-ja pdf-specialized-guides-suma-ja pdf-legal-suma-ja 
+# Generate PDF versions of all UYUNI books
+.PHONY: pdf-all-uyuni-ja
+pdf-all-uyuni-ja: translations prepare-antora-uyuni-ja pdf-installation-and-upgrade-uyuni-ja pdf-client-configuration-uyuni-ja pdf-administration-uyuni-ja pdf-reference-uyuni-ja pdf-retail-uyuni-ja pdf-common-workflows-uyuni-ja pdf-specialized-guides-uyuni-ja pdf-legal-uyuni-ja 
+# Generate PDF versions of all SUMA books
+.PHONY: pdf-all-suma-zh_CN
+pdf-all-suma-zh_CN: translations prepare-antora-suma-zh_CN pdf-installation-and-upgrade-suma-zh_CN pdf-client-configuration-suma-zh_CN pdf-administration-suma-zh_CN pdf-reference-suma-zh_CN pdf-retail-suma-zh_CN pdf-common-workflows-suma-zh_CN pdf-specialized-guides-suma-zh_CN pdf-legal-suma-zh_CN 
+# Generate PDF versions of all UYUNI books
+.PHONY: pdf-all-uyuni-zh_CN
+pdf-all-uyuni-zh_CN: translations prepare-antora-uyuni-zh_CN pdf-installation-and-upgrade-uyuni-zh_CN pdf-client-configuration-uyuni-zh_CN pdf-administration-uyuni-zh_CN pdf-reference-uyuni-zh_CN pdf-retail-uyuni-zh_CN pdf-common-workflows-uyuni-zh_CN pdf-specialized-guides-uyuni-zh_CN pdf-legal-uyuni-zh_CN 
+# Generate PDF versions of all SUMA books
+.PHONY: pdf-all-suma-ko
+pdf-all-suma-ko: translations prepare-antora-suma-ko pdf-installation-and-upgrade-suma-ko pdf-client-configuration-suma-ko pdf-administration-suma-ko pdf-reference-suma-ko pdf-retail-suma-ko pdf-common-workflows-suma-ko pdf-specialized-guides-suma-ko pdf-legal-suma-ko 
+# Generate PDF versions of all UYUNI books
+.PHONY: pdf-all-uyuni-ko
+pdf-all-uyuni-ko: translations prepare-antora-uyuni-ko pdf-installation-and-upgrade-uyuni-ko pdf-client-configuration-uyuni-ko pdf-administration-uyuni-ko pdf-reference-uyuni-ko pdf-retail-uyuni-ko pdf-common-workflows-uyuni-ko pdf-specialized-guides-uyuni-ko pdf-legal-uyuni-ko 
+

--- a/Makefile.zh_CN
+++ b/Makefile.zh_CN
@@ -1,0 +1,95 @@
+# Clean up build artifacts
+.PHONY: clean-zh_CN
+clean-zh_CN: clean-branding-zh_CN ## Remove build artifacts from output directory (Antora and PDF)
+	$(call clean-function,translations/zh_CN,zh_CN)
+
+.PHONY: clean-branding-zh_CN
+clean-branding-zh_CN:
+	$(call clean-branding,zh_CN)
+
+.PHONY: copy-branding-zh_CN
+copy-branding-zh_CN: copy-branding
+	$(call copy-branding,zh_CN)
+
+.PHONY: configure-suma-branding-dsc-zh_CN
+configure-suma-branding-dsc-zh_CN: configure-suma-branding-dsc
+	$(call configure-suma-branding-dsc,zh_CN)
+
+.PHONY: configure-suma-branding-webui-zh_CN
+configure-suma-branding-webui-zh_CN: configure-suma-branding-webui
+	$(call configure-suma-branding-webui,zh_CN)
+
+.PHONY: validate-suma-zh_CN
+validate-suma-zh_CN:
+	$(call validate-product,translations/zh_CN,suma-site.yml)
+
+.PHONY: pdf-tar-suma-zh_CN
+pdf-tar-suma-zh_CN:
+	$(call pdf-tar-product,zh_CN,susemanager-docs_zh_CN-pdf,$(current_dir)/build/zh_CN/pdf)
+
+.PHONY: set-html-language-selector-suma-zh_CN
+set-html-language-selector-suma-zh_CN: set-html-language-selector-suma
+	mkdir -p $(shell dirname translations/zh_CN/$(SUPPLEMENTAL_FILES_SUMA))
+	cp -a translations/$(SUPPLEMENTAL_FILES_SUMA) translations/zh_CN/$(SUPPLEMENTAL_FILES_SUMA)
+
+.PHONY: prepare-antora-suma-zh_CN
+prepare-antora-suma-zh_CN: copy-branding-zh_CN set-html-language-selector-suma-zh_CN
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/zh_CN && \
+	cp -a antora.yml translations/zh_CN/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/documentation\.suse\.com\/suma\/5\.0\/\)/\1zh_CN\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/zh_CN/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/zh_CN/;" site.yml > translations/zh_CN/suma-site.yml && \
+	find translations/zh_CN/branding/supplemental-ui -name "*.hbs" -exec sed -i 's/LANG_PLACEHOLDER/zh_CN/g' {} \; && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/zh_CN/{} \; && \
+	mkdir -p $(current_dir)/translations/zh_CN/modules/ROOT/pages/
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/zh_CN/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-suma-zh_CN
+antora-suma-zh_CN: configure-suma-branding-dsc-zh_CN prepare-antora-suma-zh_CN pdf-all-suma-zh_CN pdf-tar-suma-zh_CN
+	$(call antora-suma-function,translations/zh_CN,zh_CN)
+
+.PHONY: obs-packages-suma-zh_CN
+obs-packages-suma-zh_CN: configure-suma-branding-webui-zh_CN pdf-all-suma-zh_CN antora-suma-zh_CN ## Generate SUMA OBS tar files
+	$(call obs-packages-product,zh_CN,zh_CN/pdf,susemanager-docs_zh_CN,susemanager-docs_zh_CN-pdf)
+
+# UYUNI
+
+.PHONY: validate-uyuni-zh_CN
+validate-uyuni-zh_CN:
+	$(call validate-product,translations/zh_CN,uyuni-site.yml)
+
+.PHONY: pdf-tar-uyuni-zh_CN
+pdf-tar-uyuni-zh_CN:
+	$(call pdf-tar-product,zh_CN,uyuni-docs_zh_CN-pdf,$(current_dir)/build/zh_CN/pdf)
+
+.PHONY: set-html-language-selector-uyuni-zh_CN
+set-html-language-selector-uyuni-zh_CN: set-html-language-selector-uyuni
+	mkdir -p $(shell dirname translations/zh_CN/$(SUPPLEMENTAL_FILES_UYUNI))
+	cp -a translations/$(SUPPLEMENTAL_FILES_UYUNI) translations/zh_CN/$(SUPPLEMENTAL_FILES_UYUNI)
+
+.PHONY: prepare-antora-uyuni-zh_CN
+prepare-antora-uyuni-zh_CN: copy-branding-zh_CN set-html-language-selector-uyuni-zh_CN
+	cd $(current_dir)
+	mkdir -p $(current_dir)/translations/zh_CN && \
+	cp antora.yml translations/zh_CN/antora.yml && \
+	sed "s/\(url\:\ https\:\/\/www\.uyuni-project\.org\/uyuni-docs\/\)/\1zh_CN\//;\
+	s/\-\ url\:\ \./\-\ url\:\ \.\.\/\.\.\//;\
+	s/start_path\:\ \./\start_path\:\ translations\/zh_CN/;\
+	s/dir:\ \.\/build\/en/dir:\ \.\.\/\.\.\/build\/zh_CN/;" site.yml > translations/zh_CN/uyuni-site.yml && \
+	cp -a $(current_dir)/modules $(current_dir)/translations/en/
+	find modules/ -maxdepth 1 -name "*" -type d -exec mkdir -p $(current_dir)/translations/zh_CN/{} \; && \
+	mkdir -p $(current_dir)/translations/zh_CN/modules/ROOT/pages/	
+	cp -a $(current_dir)/modules/ROOT/pages/common_gfdl1.2_i.adoc $(current_dir)/translations/zh_CN/modules/ROOT/pages/	
+	cd $(current_dir)
+
+.PHONY: antora-uyuni-zh_CN
+antora-uyuni-zh_CN: prepare-antora-uyuni-zh_CN pdf-all-uyuni-zh_CN pdf-tar-uyuni-zh_CN
+	$(call antora-uyuni-function,translations/zh_CN,zh_CN)
+
+.PHONY: obs-packages-uyuni-zh_CN
+obs-packages-uyuni-zh_CN: pdf-all-uyuni-zh_CN antora-uyuni-zh_CN ## Generate UYUNI OBS tar files
+	$(call obs-packages-product,zh_CN,zh_CN/pdf,uyuni-docs_zh_CN,uyuni-docs_zh_CN-pdf)

--- a/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
@@ -1,6 +1,6 @@
 [[tshoot-hostname-rename]]
 = Troubleshooting Renaming {productname} Server
-:revdate: 2025-02-18
+:revdate: 2026-08-06
 :page-revdate: {revdate}
 
 ////

--- a/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
@@ -40,6 +40,11 @@ This is because the changes have not been made in the database, which prevents t
 If you need to change the hostname of the {productname} Server, you can do so using the `mgradm server rename` command.
 This command updates the settings in the {postgresql} database and the internal structures of {productname}.
 
+[IMPORTANT]
+====
+If your system uses a certificate signed by an external or third-party certificate authority, the new certificate containing the new hostname must be obtained before beginning the renaming process.
+To replace active certificates with your external certificates, see xref:administration:ssl-certs-imported.adoc#ssl-certs-import-replace[Replace certificates].
+====
 
 
 === Server configuration

--- a/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
+++ b/en/modules/administration/pages/troubleshooting/tshoot-hostname-rename.adoc
@@ -21,15 +21,6 @@ If more detailed instructions are required, put them in a "Resolving" procedure:
 . Last step
 ////
 
-////
-Showing my working. --LKB 2020-06-22
-
-Cause: Renaming the hostname
-Consequence: Changes not picked up by db, clients and proxies
-Fix: Use the `spacewalk-hostname-rename` script to update the settings in the PostgreSQL database and the internal structures of {productname}.
-Result: Renaming is successfully propagated
-////
-
 If you change the hostname of the {productname} Server locally, your {productname} installation ceases to work properly.
 This is because the changes have not been made in the database, which prevents the changes from propagating out your clients and any proxies.
 


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

The customer needs to do replace certificate before triggering the rename command.


# Target branches

<!--
* Which product version this PR applies to (Uyuni, MLM-5.X-MU-A.B.C, or MLM development version).  This information can be helpful if `ifeval` statements are needed to publish it for certain products only.
* Does this PR need to be backported? If yes, make sure you list all the branches below. Docs squad will take care of backporting.
* Whenever possible, cross-reference each backport PR here, so that all backports can be easily accessed from the description.

# Wait for code
In cases when the documentation PR is ready before the corresponding code is merged, you can use label Wait-for-code to signal this specific status.
-->

- master https://github.com/uyuni-project/uyuni-docs/pull/5180
- 5.2
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5182

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31568 / https://bugzilla.suse.com/show_bug.cgi?id=1273853.