### PR TITLE
manager-5.1 - Clarify Salt virt module requirements on SUSE and non-SUSE hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-- Refined clarification of Salt's "virt" module availability in the Salt Bundle (bsc#1270694)
 - Clarified availability of Salt's "virt" module in the Salt Bundle (bsc#1270694)
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added a common workflow for certificate setup and rotation with ACME

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Refined clarification of Salt's "virt" module availability in the Salt Bundle (bsc#1270694)
 - Clarified availability of Salt's "virt" module in the Salt Bundle (bsc#1270694)
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added a common workflow for certificate setup and rotation with ACME

--- a/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
+++ b/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
@@ -1,7 +1,7 @@
 [[contact-methods-saltbundle]]
 = Salt Bundle
 :description: Learn how to deploy and configure the Salt Bundle, a single binary package that simplifies Salt Minion installation by including Python 3, its required modules
-:revdate: 2026-08-06
+:revdate: 2026-08-10
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -145,36 +145,13 @@ To ensure that such packages are available and functional after an update, it is
 [[contact-methods-saltbundle-virt]]
 == Availability of Salt's "virt" module inside the Salt Bundle
 
-The Salt `virt` module is not available by default inside the Salt Bundle (`venv-salt-minion`) because it requires system `libvirt` library dependencies, which are not included in the bundle.
+The Salt `virt` module is available within the Salt Bundle (`venv-salt-minion`) on SUSE-based operating systems ({sles}, {slemicro}, {opensuse} Leap, and {opensuse} Tumbleweed). The module requires system `libvirt` library dependencies, which are not included in the bundle.
 
-[NOTE]
-====
-Using the classic `salt-minion` package is not a supported workaround. If you use the classic `salt-minion`, {productname} will automatically migrate the system back to the Salt Bundle (`venv-salt-minion`) during highstate application.
-====
+On other operating systems (such as {rhel} or {debian}-based systems), the Salt `virt` module is not available or supported inside the Salt Bundle.
 
-To use the Salt `virt` module (for example, on physical virtual hosts or hypervisors like KVM) with the Salt Bundle, follow the instructions for your operating system:
+To use the Salt `virt` module (for example, to inventory virtual machines on physical KVM hosts), the system `libvirt` libraries must be installed on the managed host:
 
-* **SUSE Linux Enterprise and openSUSE systems**:
-+
-The `libvirt-python` package is already pre-installed inside the Salt Bundle on these systems. To enable the module, you only need to install the system library:
-+
 [role=procedure]
 _____
 . Install the `libvirt-libs` package on the managed host system using the system's package manager.
-_____
-
-* **Other operating systems (such as Red Hat Enterprise Linux or Debian-based systems)**:
-+
-You must manually install the system library and then extend the Salt Bundle to include the Python bindings:
-+
-[role=procedure]
-_____
-. Install the `libvirt-libs` (or equivalent system library package) on the managed host system using the system's package manager.
-
-. Install the `libvirt-python` package inside the Salt Bundle environment:
-+
-[source,bash]
-----
-salt <minion_id> pip.install libvirt-python
-----
 _____

--- a/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
+++ b/en/modules/client-configuration/pages/contact-methods-saltbundle.adoc
@@ -145,16 +145,31 @@ To ensure that such packages are available and functional after an update, it is
 [[contact-methods-saltbundle-virt]]
 == Availability of Salt's "virt" module inside the Salt Bundle
 
-The Salt `virt` module is not available by default inside the Salt Bundle (`venv-salt-minion`) because it requires Python `libvirt` bindings, which are not included in the bundle.
+The Salt `virt` module is not available by default inside the Salt Bundle (`venv-salt-minion`) because it requires system `libvirt` library dependencies, which are not included in the bundle.
 
-If you need to use the `virt` module (for example, on physical virtual hosts or hypervisors like KVM), you have two options:
+[NOTE]
+====
+Using the classic `salt-minion` package is not a supported workaround. If you use the classic `salt-minion`, {productname} will automatically migrate the system back to the Salt Bundle (`venv-salt-minion`) during highstate application.
+====
 
-* Install the classic `salt-minion` package instead of the Salt Bundle.
-* Or, if you want to keep using the Salt Bundle (`venv-salt-minion`), you must manually install the `libvirt-libs` system library on the managed host system, and then install the `libvirt-python` package in the `venv-salt-minion` environment using `pip`:
+To use the Salt `virt` module (for example, on physical virtual hosts or hypervisors like KVM) with the Salt Bundle, follow the instructions for your operating system:
+
+* **SUSE Linux Enterprise and openSUSE systems**:
++
+The `libvirt-python` package is already pre-installed inside the Salt Bundle on these systems. To enable the module, you only need to install the system library:
 +
 [role=procedure]
 _____
 . Install the `libvirt-libs` package on the managed host system using the system's package manager.
+_____
+
+* **Other operating systems (such as Red Hat Enterprise Linux or Debian-based systems)**:
++
+You must manually install the system library and then extend the Salt Bundle to include the Python bindings:
++
+[role=procedure]
+_____
+. Install the `libvirt-libs` (or equivalent system library package) on the managed host system using the system's package manager.
 
 . Install the `libvirt-python` package inside the Salt Bundle environment:
 +

--- a/en/modules/client-configuration/pages/system-types.adoc
+++ b/en/modules/client-configuration/pages/system-types.adoc
@@ -1,7 +1,7 @@
 [[system-types]]
 = System Types
 :description: Configure your clients systems by assigning a base system type and adding virtualization or container build host capabilities
-:revdate: 2026-08-06
+:revdate: 2026-08-10
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -19,7 +19,7 @@ Add-on system types include:
 +
 [NOTE]
 ====
-If the physical virtualization host is managed using the Salt Bundle (`venv-salt-minion`), you must manually install the `libvirt-libs` system library on the host and install the `libvirt-python` package in the `venv-salt-minion` environment. For more information, see xref:client-configuration:contact-methods-saltbundle.adoc#contact-methods-saltbundle-virt[Availability of Salt's "virt" module inside the Salt Bundle].
+If the physical virtualization host is managed using the Salt Bundle (`venv-salt-minion`), it must be a SUSE-based operating system, and the system `libvirt-libs` library must be installed on the host to enable virtual machine inventory tracking. For more information, see xref:client-configuration:contact-methods-saltbundle.adoc#contact-methods-saltbundle-virt[Availability of Salt's "virt" module inside the Salt Bundle].
 ====
 * `Container Build Host`: Assigned to clients that operate as a build host.
 


### PR DESCRIPTION
# Description

This PR refines and corrects the documentation for Salt's "virt" module availability inside the Salt Bundle (`venv-salt-minion`) based on PR review feedback.

Specifically:
- Clarifies that using the classic `salt-minion` package is not a supported workaround because the systems are automatically migrated back to the Salt Bundle (`venv-salt-minion`) during highstate.
- Explains that on SUSE Linux Enterprise and openSUSE systems, `libvirt-python` is already pre-installed inside the Salt Bundle, so only the `libvirt-libs` system library needs to be manually installed on the host.
- Explains that on other operating systems (such as RHEL or Debian-based systems), users must install both `libvirt-libs` on the host and `libvirt-python` inside the Salt Bundle using `pip`.
- Updates `CHANGELOG.md` and page revision dates.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5188
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5189
- manager-5.1 (this PR)

# Links
- Tracks issue https://github.com/SUSE/spacewalk/issues/31166
- Addresses Bugzilla issue https://bugzilla.suse.com/show_bug.cgi?id=1270694
