### PR TITLE
manager-5.2 - Use mgradm ssl rotate and document proxy certificate replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
+- Documented certificate setup and rotation with unified mgradm ssl rotate command
 - Documented allowing diskcheck environment variables into containers (bsc#1270033)
 - Clarified availability of Salt's "virt" module in the Salt Bundle (bsc#1270694)
 - Added instruction for obtaining the certificate when renaming the server (bsc#1273853)
+- Added a common workflow for certificate setup and rotation with ACME
 - Documented how VMs are listed and referenced by virtual hosts (bsc#1273073)
 - Added a common workflow for certificate setup and rotation with ACME
 - Added documentation support for Ubuntu 26.04 client systems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Documented proxy certificate replacement using spacecmd (bsc#1271329)
 - Documented certificate setup and rotation with unified mgradm ssl rotate command
 - Documented allowing diskcheck environment variables into containers (bsc#1270033)
 - Clarified availability of Salt's "virt" module in the Salt Bundle (bsc#1270694)

--- a/en/modules/administration/pages/ssl-certs-imported.adoc
+++ b/en/modules/administration/pages/ssl-certs-imported.adoc
@@ -1,6 +1,6 @@
 [[ssl-certs-import]]
 = Import SSL Certificates
-:revdate: 2026-06-12
+:revdate: 2026-08-04
 :page-revdate: {revdate}
 
 //By default, {productname} uses a self-signed certificate.
@@ -76,8 +76,8 @@ By default, {productname} uses a self-signed certificate.
 Certificates can be imported with third-party certificates at the installation time.
 
 .Procedure: Importing certificates on a new {productname} server
-[role=procedure]
-____
+[role="procedure"]
+_____
 . Deploy the {productname} Server according to the instructions in xref:installation-and-upgrade:install-server.adoc[].
   Make sure to pass the correct files as parameters to `mgradm install`.
   The parameters are:
@@ -95,7 +95,7 @@ ____
       --ssl-db-cert string             Database certificate path
       --ssl-db-key string              Database key path
 ----
-____
+_____
 
 Intermediate CAs can either be available in the file which is specified with `--ssl-ca-root`, or specified as extra options with `--ssl-ca-intermediate`.
 The `--ssl-ca-intermediate` option can be specified multiple times.
@@ -108,8 +108,8 @@ The proxy certificates are embedded in the generated configuration.
 In order to use a third-party certificate, it needs to be provided during the configuration.
 
 .Procedure: Importing certificates on a new {productname} Proxy
-[role=procedure]
-____
+[role="procedure"]
+_____
 . Install the {productname} Proxy according to the instructions in xref:installation-and-upgrade:install-proxy.adoc[].
 
 . Follow the prompts to complete setup.
@@ -122,7 +122,7 @@ Use the same certificate authority (CA) to sign all certificates for servers and
 Certificates signed with different CAs do not match.
 ====
 
-____
+_____
 
 
 [[ssl-certs-import-replace]]
@@ -142,8 +142,8 @@ The root CA certificate should not be appended to the server certificate file.
 
 
 .Procedure: Replacing all existing certificates
-[role=procedure]
-____
+[role="procedure"]
+_____
 . The following considers that you have `root-ca.pem`, `intermediate-ca1.pem`, `intermediate-ca2.pem`, `server.pem` and `server.key` files.
   It may be different depending on the number of intermediate CAs in the server certificate signature chain.
 
@@ -158,35 +158,17 @@ ____
 cat server.pem intermediate-ca1.pem intermediate-ca2.pem >combined-server.pem
 ----
 
-. On the {productname} container host, at the command prompt, recreate podman certificate secrets passing the files paths:
+. On the {productname} container host, at the command prompt, rotate the certificates using `mgradm ssl rotate`:
 
 +
-
 [source,shell]
 ----
-podman secret create --replace uyuni-ca $path_to_ca_certificate
-podman secret create --replace uyuni-cert $path_to_combined_server_certificate
-podman secret create --replace uyuni-key $path_to_server_key
-
-podman secret create --replace uyuni-db-ca $path_to_database_ca_certificate
-podman secret create --replace uyuni-db-cert $path_to_combined_database_certificate
-podman secret create --replace uyuni-db-key $path_to_database_key
+mgradm ssl rotate \
+   --ssl-ca-root $path_to_ca_certificate \
+   --ssl-server-cert $path_to_combined_server_certificate \
+   --ssl-server-key $path_to_server_key
 ----
-____
-
-
-.Procedure: Restarting the server
-[role=procedure]
-____
-. On the container host, restart the server to pick up the changes:
-
-+
-
-[source,shell]
-----
-mgradm restart
-----
-____
+_____
 
 
 If you are using a proxy, you need to generate a server certificate RPM for each proxy, using their hostnames and cnames.
@@ -208,8 +190,8 @@ This is ideally done in advance to minimize the disruption.
 
 [[ssl-certs-import-deploy-root-ca]]
 .Procedure: Deploying the root CA on clients
-[role=procedure]
-____
+[role="procedure"]
+_____
 . In the {productname} {webui}, navigate to menu:Systems[Overview].
 
 . Check all your clients to add them to the system set manager.
@@ -219,4 +201,4 @@ ____
 . In the `States` field, click btn:[Apply] to apply the system states.
 
 . In the `Highstate` page, click btn:[Apply Highstate] to propagate the changes to the clients.
-____
+_____

--- a/en/modules/administration/pages/ssl-certs-imported.adoc
+++ b/en/modules/administration/pages/ssl-certs-imported.adoc
@@ -1,6 +1,6 @@
 [[ssl-certs-import]]
 = Import SSL Certificates
-:revdate: 2026-08-04
+:revdate: 2026-08-12
 :page-revdate: {revdate}
 
 //By default, {productname} uses a self-signed certificate.
@@ -171,17 +171,83 @@ mgradm ssl rotate \
 _____
 
 
-If you are using a proxy, you need to generate a server certificate RPM for each proxy, using their hostnames and cnames.
-Generate a new configuration tarball and deploy it.
+// bsc#1271329
+[[ssl-certs-import-replace-proxy]]
+== Replace certificates on a Proxy
 
-ifeval::[{mlm-content} == true]
-For more information, see xref:installation-and-upgrade:container-deployment/mlm/proxy-deployment-mlm.adoc#_generate_proxy_configuration[].
-endif::[]
+If you are using a {productname} Proxy, you must regenerate and redeploy the Proxy's configuration after replacing the certificates on the {productname} Server.
+This ensures the Proxy trusts the Server's new CA and uses its own updated server certificate.
 
-ifeval::[{uyuni-content} == true]
-For more information, see xref:installation-and-upgrade:container-deployment/uyuni/proxy-deployment-uyuni.adoc#proxy-setup-containers-generate-config[].
-proxy-deployment-uyuni.adoc
-endif::[]
+Generating the Proxy configuration using the Web UI is not supported for replacing certificates. You must use `spacecmd` from the command line.
+
+.Procedure: Replacing certificates on a {productname} Proxy
+[role=procedure]
+_____
+. On your {productname} Server container host, copy the Root CA certificate (`ca.crt`), the Proxy certificate (`proxy.crt`), and the Proxy private key (`proxy.key`) into the server container:
++
+[source,shell]
+----
+for f in ca.crt proxy.crt proxy.key; do
+  mgrctl cp $f server:/tmp/$f
+done
+----
+
+. If your environment uses one or more intermediate CAs, also copy them into the container:
++
+[source,shell]
+----
+mgrctl cp intermediateCA.pem server:/tmp/intermediateCA.pem
+----
+
+. Execute `spacecmd proxy_container_config` inside the server container to generate the new configuration archive, replacing the FQDNs and admin email:
++
+[source,shell]
+----
+mgrctl exec -ti 'spacecmd proxy_container_config -- -p 8022 pxy.example.com srv.example.com 2048 email@example.com /tmp/ca.crt /tmp/proxy.crt /tmp/proxy.key -o /tmp/config.tar.gz'
+----
++
+If you copied an intermediate CA in the previous step, append the `-i` parameter:
++
+[source,shell]
+----
+mgrctl exec -ti 'spacecmd proxy_container_config -- -p 8022 -i /tmp/intermediateCA.pem pxy.example.com srv.example.com 2048 email@example.com /tmp/ca.crt /tmp/proxy.crt /tmp/proxy.key -o /tmp/config.tar.gz'
+----
+
+. Copy the generated configuration archive from the server container to the Server host:
++
+[source,shell]
+----
+mgrctl cp server:/tmp/config.tar.gz .
+----
+
+. Transfer the `config.tar.gz` archive to the Proxy host:
++
+[source,shell]
+----
+scp config.tar.gz root@pxy.example.com:/root/
+----
+
+. On the Proxy host, stop the Proxy:
++
+[source,shell]
+----
+mgrpxy stop
+----
+
+. Install the new configuration on the Proxy host:
++
+[source,shell]
+----
+mgrpxy install config.tar.gz
+----
+
+. Start the Proxy:
++
+[source,shell]
+----
+mgrpxy start
+----
+_____
 
 
 

--- a/en/modules/administration/pages/ssl-certs-imported.adoc
+++ b/en/modules/administration/pages/ssl-certs-imported.adoc
@@ -76,7 +76,7 @@ By default, {productname} uses a self-signed certificate.
 Certificates can be imported with third-party certificates at the installation time.
 
 .Procedure: Importing certificates on a new {productname} server
-[role="procedure"]
+[role=procedure]
 _____
 . Deploy the {productname} Server according to the instructions in xref:installation-and-upgrade:install-server.adoc[].
   Make sure to pass the correct files as parameters to `mgradm install`.
@@ -108,7 +108,7 @@ The proxy certificates are embedded in the generated configuration.
 In order to use a third-party certificate, it needs to be provided during the configuration.
 
 .Procedure: Importing certificates on a new {productname} Proxy
-[role="procedure"]
+[role=procedure]
 _____
 . Install the {productname} Proxy according to the instructions in xref:installation-and-upgrade:install-proxy.adoc[].
 
@@ -142,7 +142,7 @@ The root CA certificate should not be appended to the server certificate file.
 
 
 .Procedure: Replacing all existing certificates
-[role="procedure"]
+[role=procedure]
 _____
 . The following considers that you have `root-ca.pem`, `intermediate-ca1.pem`, `intermediate-ca2.pem`, `server.pem` and `server.key` files.
   It may be different depending on the number of intermediate CAs in the server certificate signature chain.
@@ -190,7 +190,7 @@ This is ideally done in advance to minimize the disruption.
 
 [[ssl-certs-import-deploy-root-ca]]
 .Procedure: Deploying the root CA on clients
-[role="procedure"]
+[role=procedure]
 _____
 . In the {productname} {webui}, navigate to menu:Systems[Overview].
 


### PR DESCRIPTION
This PR includes 2 separate but related changes:

* Replaced manual `podman secret create` commands and explicit restarts with the unified `mgradm ssl rotate` command in the SSL certificate importation guides. Discovered when implementing https://github.com/uyuni-project/uyuni-docs/pull/5167
* Documented how to replace third-party certificates on a proxy

# Target branches

- master (https://github.com/uyuni-project/uyuni-docs/pull/5175)
- manager-5.2 (this PR)
- manager-5.1 (https://github.com/uyuni-project/uyuni-docs/pull/5192)

Tracked issues: https://github.com/SUSE/spacewalk/issues/31223 / https://bugzilla.suse.com/show_bug.cgi?id=1271329