### PR TITLE
docs: fix PODMAN_EXTRA_ARGS typo in security policies workflow

### DIFF
--- a/en/modules/common-workflows/pages/workflow-customize-security-policies.adoc
+++ b/en/modules/common-workflows/pages/workflow-customize-security-policies.adoc
@@ -58,7 +58,7 @@ vi /etc/systemd/system/uyuni-server.service.d/custom.conf
 +
 ----
 [Service]
-Environment="PODMAN_EXTRA_ARG=--volume /etc/crypto-policies:/etc/crypto-policies:ro"
+Environment="PODMAN_EXTRA_ARGS=--volume /etc/crypto-policies:/etc/crypto-policies:ro"
 ----
 
 . Reload the systemd manager configuration to apply the new drop-in file:


### PR DESCRIPTION
# Description
Fixed a typo in `workflow-customize-security-policies.adoc` where `PODMAN_EXTRA_ARG` was missing the trailing `S`. Corrected it to `PODMAN_EXTRA_ARGS` to stay consistent with systemd drop-in override naming conventions across the rest of the documentation.

*Note: Per contributing guidelines, cosmetic typo fixes do not require a `CHANGELOG.md` entry.*

# Target branches

- master
- 5.2 https://github.com/uyuni-project/uyuni-docs/pull/5198
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5199

# Links
- This PR tracks issue #
- Related development PR #