### PR TITLE
5.2 - Fixed typo in command argument

### DIFF
--- a/en/modules/common-workflows/pages/workflow-customize-security-policies.adoc
+++ b/en/modules/common-workflows/pages/workflow-customize-security-policies.adoc
@@ -1,6 +1,6 @@
 [[workflow-customize-security-policies]]
 = Customize security policies on the server
-:revdate: 2020-06-24
+:revdate: 2026-08-17
 :page-revdate: {revdate}
 
 The default allowed security algorithms on the server may contain weak ones.
@@ -58,7 +58,7 @@ vi /etc/systemd/system/uyuni-server.service.d/custom.conf
 +
 ----
 [Service]
-Environment="PODMAN_EXTRA_ARG=--volume /etc/crypto-policies:/etc/crypto-policies:ro"
+Environment="PODMAN_EXTRA_ARGS=--volume /etc/crypto-policies:/etc/crypto-policies:ro"
 ----
 
 . Reload the systemd manager configuration to apply the new drop-in file:


### PR DESCRIPTION
# Description
Fixed a typo in `workflow-customize-security-policies.adoc` where `PODMAN_EXTRA_ARG` was missing the trailing `S`. Corrected it to `PODMAN_EXTRA_ARGS` to stay consistent with systemd drop-in override naming conventions across the rest of the documentation.


# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5197
- 5.2
- 5.1 https://github.com/uyuni-project/uyuni-docs/pull/5199

# Links
- This PR tracks issue #
- Related development PR #