### PR TITLE
manager-5.1 - Document container image inspection requirements and SLES 16 limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Documented requirements and limitations for container image inspection on SLES 15 and SLES 16 (bsc#1274720)
 - Documented proxy certificate replacement using spacecmd (bsc#1271329)
 - Documented certificate setup and rotation with unified mgradm ssl rotate command
 - Documented allowing diskcheck environment variables into containers (bsc#1270033)

--- a/en/modules/administration/pages/image-management.adoc
+++ b/en/modules/administration/pages/image-management.adoc
@@ -1,7 +1,7 @@
 [[image-management]]
 = Image Building and Management
 :description: Configure system builds and manage container deployments with SUSE Multi-Linux Managers intuitive tools for efficient management
-:revdate: 2026-07-21
+:revdate: 2026-08-17
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg

--- a/en/modules/administration/partials/image-mgmt-container-inspection.adoc
+++ b/en/modules/administration/partials/image-mgmt-container-inspection.adoc
@@ -1,18 +1,33 @@
 :description: Learn to prevent container inspection errors by adding necessary software to your base container image
 ==== Image Inspection
 
+Base container images (BCIs) come with all the software to run them, but because they are lightweight, they may not include all the tools and libraries required for inspection.
 
-A base container image (BCI) comes with all the software to run it, but because BCIs are lightweight they may not come with all tools and libraries you may need for inspection.
+When performing container image inspection, {productname} copies and extracts the {salt} bundle (`venv-salt-minion`) from the build host (where the inspection is scheduled) into the target container, and then executes it inside the container.
+Therefore, the target container image must satisfy any dynamic dependencies of the build host's {salt} bundle.
 
-When inspecting a container image you can see an error message such as:
+If the target image is missing required dynamic libraries, the inspection fails.
+For example, you might see error messages like:
 
 ----
 libssl.so.1.1: cannot open shared object file: No such file or directory
 ----
 
-A BCI can be used in the other scenarios than with the container build host and using the {salt} bundle for the inspection, but if you need inspection to work you must add all needed software in advance.
+The most common dependency issue is with OpenSSL libraries, because the {salt} bundle's Python modules are dynamically linked against the build host's OpenSSL version.
+Because OpenSSL versions differ between major operating system versions (such as SLE 15 and SLE 16), compatibility depends on both the build host and the target image:
 
-To avoid such issues you must add `libopenssl` to the image with `Dockerfile` and rebuild the image.
+* **On a SLE 15 build host**:
+  The {salt} bundle is compiled against OpenSSL 1.1 (providing `libssl.so.1.1`).
+  Therefore, any image inspected on a SLE 15 build host must have OpenSSL 1.1 installed (typically via the `libopenssl1_1` package).
+  Since OpenSSL 1.1 is not available on SLE 16 and openSUSE Leap 16, a SLE 16 / Leap 16 image *cannot* be inspected on a SLE 15 build host.
 
-The same can happen with `libexpat`.
+* **On a SLE 16 build host**:
+  The {salt} bundle is compiled against OpenSSL 3 (providing `libssl.so.3`).
+  Therefore, any image inspected on a SLE 16 build host must have OpenSSL 3 installed (typically via the `libopenssl3` package).
 
+To ensure successful image inspection, follow these best practices:
+
+* Match the major operating system version of the build host and the target image. For example, use a SLE 16 / Leap 16 build host to inspect SLE 16 / Leap 16 images, and a SLE 15 build host to inspect SLE 15 images.
+* Install the correct version of OpenSSL inside your image (for example, by adding `libopenssl3` for SLE 16 or `libopenssl1_1` for SLE 15 to the `Dockerfile`) and rebuilding the image.
+
+The same dependency requirements apply to other dynamic libraries, such as `libexpat`.


### PR DESCRIPTION
# Description

This PR documents the requirements and limitations for container image inspection on SLES 15 and SLES 16 / Leap 16.

Specifically:
- Updates `image-mgmt-container-inspection.adoc` with detailed information on the dynamic dependencies of the Salt Bundle used during container image inspection.
- Clarifies that because of the Salt Bundle's OpenSSL compilation targets (OpenSSL 1.1 on SLE 15 vs OpenSSL 3 on SLE 16), SLES 16 or Leap 16 images cannot be inspected on SLES 15 build hosts.
- Adds best practices to align the major operating system versions of the build host and target images, and to ensure the correct OpenSSL packages (`libopenssl3` or `libopenssl1_1`) are pre-installed in the images.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5200
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5201
- manager-5.1 (this PR)

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31628
- Addresses Bugzilla issue https://bugzilla.suse.com/show_bug.cgi?id=1274720
