### PR TITLE
master - Add Reactivation Key details and behaviors (bsc#1211440)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Documented Web UI Reactivation Key field, Salt Bundle configuration paths, and detailed warnings/behaviors for Reactivation Keys (bsc#1211440)
 - Documented requirements and limitations for container image inspection on SLES 15 and SLES 16 (bsc#1274720)
 - Documented proxy certificate replacement using spacecmd (bsc#1271329)
 - Documented certificate setup and rotation with unified mgradm ssl rotate command

--- a/en/modules/client-configuration/pages/activation-keys.adoc
+++ b/en/modules/client-configuration/pages/activation-keys.adoc
@@ -1,6 +1,6 @@
 [[activation-keys]]
 = Activation Keys
-:revdate: 2026-07-21
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 Activation keys are used to ensure that your clients have the correct software entitlements, are connecting to the appropriate channels, and are subscribed to the relevant groups.
@@ -51,7 +51,6 @@ These tabs are:
 [[activation-keys-reactivation]]
 == Reactivation Keys
 
-
 Reactivation keys can be used once only to re-register a client and regain all {productname} settings.
 Reactivation keys are client-specific, and include the system ID, history, groups, and channels.
 
@@ -60,7 +59,7 @@ Click btn:[Generate New Key] to create the reactivation key.
 Record the details of the key for later use.
 Unlike typical activation keys, which are not associated with a specific system ID, keys created here do not show up on the menu:Systems[Activation Keys] page.
 
-After you have created a reactivation key, you can use it as the `management_key` grain in `/etc/salt/minion.d/susemanager.conf`.
+After you have created a reactivation key, you can use it as the `management_key` grain in `/etc/venv-salt-minion/minion.d/susemanager.conf` (or `/etc/salt/minion.d/susemanager.conf` for traditional clients).
 For example:
 
 ----
@@ -80,6 +79,23 @@ If you autoinstall a client with its existing {productname} profile, the profile
 Do not regenerate, delete, or use this key while a profile-based autoinstallation is in progress.
 Doing so causes the autoinstallation to fail.
 ====
+
+=== Reactivation Key Warnings and Behaviors
+
+System Deletion::
+Deleting a registered client from the server permanently invalidates its reactivation key. Do not delete the server record if you only intend to re-register or rebootstrap the client.
+
+Client-Side Unregistration::
+To rebootstrap without losing system history, unregister from the client side only (stop the minion service, purge local keys/configs), keeping the server record intact so the reactivation key can re-associate the system ID.
+
+Salt Key Conflicts::
+Re-bootstrapping fails if the old Salt key remains on the server. Delete the existing key via menu:Systems[Keys] in the {webui} or with `salt-key -d <minion_id>` on the server CLI before bootstrapping.
+
+Minion ID and Name Reversion::
+Bootstrapping with a reactivation key reverts any client-side or Web UI changes to the Minion ID and System Name back to their original values recorded during initial registration. The active client hostname is updated dynamically in System Info.
+
+Combining Activation Keys::
+Specifying both activation and reactivation keys appends the activation key's system groups and configuration channels to the reactivation profile rather than overwriting them. Leaving the activation key field at `None` has no negative impact.
 
 
 

--- a/en/modules/client-configuration/pages/registration-bootstrap.adoc
+++ b/en/modules/client-configuration/pages/registration-bootstrap.adoc
@@ -1,6 +1,6 @@
 [[registering.clients.bootstrap]]
 = Register Clients With a Bootstrap Script
-:revdate: 2025-06-10
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 == Introduction
@@ -223,7 +223,7 @@ Instead of editing the script manually, user can pass the following environment 
 
 - `ACTIVATION_KEYS`: Activation keys to use for registration
 - `ORG_GPG_KEY`: Path or identifier of the GPG key
-- `REACTIVATION_KEY`: Reactivation key for previously registered systems
+- `REACTIVATION_KEY`: Reactivation key for previously registered systems. Note that reactivation keys are valid for single-use only.
 - `MGR_SERVER_HOSTNAME`: Hostname of the Server or Proxy to register the client against
 
 Using environment variables allows dynamic input at runtime and makes it easier to reuse the same bootstrap script across different systems or environments.

--- a/en/modules/client-configuration/pages/registration-webui.adoc
+++ b/en/modules/client-configuration/pages/registration-webui.adoc
@@ -1,6 +1,6 @@
 [[registering.clients.webui]]
 = Register Clients With the {webui}
-:revdate: 2025-07-09
+:revdate: 2026-08-19
 :page-revdate: {revdate}
 
 == Introduction
@@ -25,6 +25,8 @@ For more information about using multiple servers, see xref:specialized-guides:l
 == Register Clients With the {webui}
 
 .Procedure: Registering Clients With the {webui}
+[role=procedure]
+_____
 
 . In the {productname} {webui}, navigate to menu:Systems[Bootstrapping].
 . In the `Host` field, type the fully qualified domain name (FQDN) of the client to be bootstrapped.
@@ -38,6 +40,8 @@ For more information about using multiple servers, see xref:specialized-guides:l
 .. To bootstrap the client with a password, in the `Authentication` field, check `Password`, and type the password to log in to the client.
 . In the `Activation Key` field, select the activation key that is associated with the software channel you want to use to bootstrap the client.
     For more information, see xref:client-configuration:activation-keys.adoc[].
+. OPTIONAL: In the `Reactivation Key` field, paste in the desired reactivation key.
+    For more information, see xref:client-configuration:activation-keys.adoc#activation-keys-reactivation[Reactivation Keys].
 . OPTIONAL: In the `Proxy` field, select the proxy to register the client to.
 . By default, the `Disable SSH Strict Key Host Checking` checkbox is selected.
     This allows the bootstrap process to automatically accept SSH host keys without requiring you to manually authenticate.
@@ -47,6 +51,8 @@ For more information about using multiple servers, see xref:specialized-guides:l
 For more information about contact methods, see xref:client-configuration:contact-methods-intro.adoc[].
 . Click btn:[Bootstrap] to begin registration.
 . When the bootstrap process has completed, your client is listed at menu:Systems[System List].
+
+_____
 
 
 [IMPORTANT]


### PR DESCRIPTION
# Description

This PR documents the Reactivation Key Web UI bootstrapping field, default Salt configuration paths, and troubleshooting behaviors.

Specifically:
- Adds the optional `Reactivation Key` field to the step-by-step registration Web UI procedure (`registration-webui.adoc`).
- Formats the Web UI registration procedure with the correct procedure role and sidebar delimiters for styling compliance.
- Updates legacy Salt configuration file paths to `/etc/venv-salt-minion/minion.d/susemanager.conf` in `activation-keys.adoc`.
- Adds a comprehensive warnings and behaviors subsection to the Reactivation Keys section, detailing system deletion risks, unregistration, duplicate Salt keys, minion ID/hostname reversions, and key combination logic.
- Notes that reactivation keys are valid for single-use only in `registration-bootstrap.adoc`.

# Target branches

- master (this PR)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5208
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5209

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/28996
- Addresses Bugzilla issue https://bugzilla.suse.com/show_bug.cgi?id=1211440
