### PR TITLE
Add support for AlmaLinux 8 ppc64le

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Added ppc64le support for AlmaLinux 8 in Uyuni
+- Corrected the architectures of Rocky Linux 8 in Uyuni, which has no ppc64le build upstream
+- Corrected the s390x information for AlmaLinux and Rocky Linux 9 and 10 in Uyuni
 - Documented deprecation and support limitations of plain salt-minion manual registration (bsc#1275658)
 - Added warning about known issues in Multi-Linux Manager 5.0 and 5.1 server upgrade guides (bsc#1274875)
 - Corrected and restored Debian 12 packages in the OpenSCAP packages table (bsc#1269316)

--- a/en/modules/client-configuration/pages/clients-almalinux.adoc
+++ b/en/modules/client-configuration/pages/clients-almalinux.adoc
@@ -1,6 +1,6 @@
 [[clients-almalinux]]
 = Registering {almalinux} Clients
-:revdate: 2026-03-17
+:revdate: 2026-08-26
 :page-revdate: {revdate}
 
 This section contains information about registering clients running {almalinux} operating systems.
@@ -49,8 +49,18 @@ You do not need to disable SELinux to register {almalinux} clients to {productna
 
 Before you can register {almalinux} clients to your {productname} Server, you need to add the required software channels, and synchronize them.
 
-The architectures currently supported are: `x86_64` and `aarch64`, on version 9 additionally {ppc64le} and {s390x}.
+// The MLM variant below intentionally differs from the Uyuni one: ppc64le and
+// s390x support for AlmaLinux and Rocky Linux exists in the code, but claiming
+// it for MLM is a product management decision, pending a customer request.
+ifeval::[{mlm-content} == true]
+The architectures currently supported are: `x86_64` and `aarch64`.
 For full list of supported products and architectures, see xref:client-configuration:supported-features.adoc[].
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+The architectures currently supported are: `x86_64`, {ppc64le} and `aarch64`, on versions 9 and 10 additionally {s390x}.
+For full list of supported products and architectures, see xref:client-configuration:supported-features.adoc[].
+endif::[]
 
 ifndef::backend-pdf[]
 include::client-configuration:partial$arch-other-note.adoc[]

--- a/en/modules/client-configuration/pages/clients-rocky.adoc
+++ b/en/modules/client-configuration/pages/clients-rocky.adoc
@@ -1,6 +1,6 @@
 [[clients-rocky]]
 = Registering {rocky} Clients
-:revdate: 2026-03-17
+:revdate: 2026-08-26
 :page-revdate: {revdate}
 
 This section contains information about registering clients running {rocky} operating systems.
@@ -39,8 +39,20 @@ You do not need to disable SELinux to register {rocky} clients to {productname}.
 
 Before you can register {rocky} clients to your {productname} Server, you need to add the required software channels, and synchronize them.
 
-The architectures currently supported are: `x86_64` and `aarch64`, on version 9 additionally {ppc64le} and {s390x}.
+// Rocky Linux 8 has no ppc64le nor s390x build upstream. It starts at Rocky 9.
+
+// The MLM variant below intentionally differs from the Uyuni one: ppc64le and
+// s390x support for AlmaLinux and Rocky Linux exists in the code, but claiming
+// it for MLM is a product management decision, pending a customer request.
+ifeval::[{mlm-content} == true]
+The architectures currently supported are: `x86_64` and `aarch64`.
 For full list of supported products and architectures, see xref:client-configuration:supported-features.adoc[].
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+The architectures currently supported are: `x86_64` and `aarch64`, on versions 9 and 10 additionally {ppc64le} and {s390x}.
+For full list of supported products and architectures, see xref:client-configuration:supported-features.adoc[].
+endif::[]
 
 ifndef::backend-pdf[]
 include::client-configuration:partial$arch-other-note.adoc[]

--- a/en/modules/client-configuration/pages/supported-features.adoc
+++ b/en/modules/client-configuration/pages/supported-features.adoc
@@ -1,6 +1,6 @@
 [[supported-features]]
 = Supported Clients and Features
-:revdate: 2026-07-27
+:revdate: 2026-08-26
 :page-revdate: {revdate}
 
 {productname} is compatible with a range of client technologies.
@@ -225,10 +225,17 @@ ifeval::[{uyuni-content} == true]
 | {check}
 | {cross}
 
-| {almalinux} 8, 9, 10
+| {almalinux} 8
+| {check}
 | {check}
 | {cross}
+| {check}
 | {cross}
+
+| {almalinux} 9, 10
+| {check}
+| {check}
+| {check}
 | {check}
 | {cross}
 
@@ -288,10 +295,17 @@ ifeval::[{uyuni-content} == true]
 | {cross}
 | {cross}
 
-| {rocky} 8, 9, 10
+| {rocky} 8
 | {check}
 | {cross}
 | {cross}
+| {check}
+| {cross}
+
+| {rocky} 9, 10
+| {check}
+| {check}
+| {check}
 | {check}
 | {cross}
 


### PR DESCRIPTION
# Description

Add support for AlmaLinux 8 ppc64le.

This changes the Table 1. Supported Client Systems and Architectures in https://www.uyuni-project.org/uyuni-docs/en/uyuni/client-configuration/supported-features.html (while keeping intact https://documentation.suse.com/multi-linux-manager/5.2/en/docs/client-configuration/supported-features.html).

Piggyback: let the descriptions for Rocky Linux and AlmaLinux match what is in the main tables for MLM and Uyuni with respect to ppc64le and s390x.

Experimental verifications - I tested:
 * AlmaLinux 8 ppc64le
 * Rocky Linux 9 ppc64le
 * Rocky Linux 10 ppc64le
 * AlmaLinux 9 s390x - but this one is not in the scope of this PR.

| MLM | x86_64 | ppc64le | s390x | aarch64 |
|---|---|---|---|---|
| AlmaLinux 8, 9, 10 | ✓ | ✗ | ✗ | ✓ |
| Rocky 8, 9, 10 | ✓ | ✗ | ✗ | ✓ |

| Uyuni | x86_64 | ppc64le | s390x | aarch64 |
|---|---|---|---|---|
| AlmaLinux 8 | ✓ | ✓ | ✗ | ✓ |
| AlmaLinux 9, 10 | ✓ | ✓ | ✓ | ✓ |
| Rocky 8 | ✓ | ✗ | ✗ | ✓ |
| Rocky 9, 10 | ✓ | ✓ | ✓ | ✓ |


# Target branches

Uyuni only.

The MLM support matrix is intentionally left unchanged: extending it to ppc64le and s390x would be a product management decision.

The MLM prose in the AlmaLinux and Rocky Linux pages is however corrected to match that matrix. It previously announced ppc64le and s390x on version 9, contradicting the table on the same page.


# Wait for code

Merge https://github.com/uyuni-project/uyuni/pull/12500 first.


# Links

- https://github.com/uyuni-project/uyuni/pull/12500
