### PR TITLE
Drop trailing slash from the helm repository value

### DIFF
--- a/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/proxy-kubernetes-deployment.adoc
@@ -423,7 +423,7 @@ helm install smlm-proxy \
     -n uyuni-proxy \
     --description "Proxy installation" \
     --set "registrySecret=the-scc-secret" \
-    --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/" \
+    --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$" \
     --set-file global.config=path/to/config.yaml \
     --set-file global.ssh=path/to/ssh.yaml \
     --set-file global.httpd=path/to/httpd.yaml \

--- a/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
+++ b/en/modules/specialized-guides/pages/kubernetes-guide/server-kubernetes-deployment.adoc
@@ -656,7 +656,7 @@ helm install smlm-server \
      --description "Server installation" \
      --set "global.fqdn=the.server.fqdn" \
      --set "registrySecret=scc-credentials" \
-     --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$/" \
+     --set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$" \
      --set tag={productchartversion} \
      --version {productchartversion}
 ----


### PR DESCRIPTION
# Description

Drops the trailing slash from the `repository` value in the Kubernetes helm install commands for the MLM server and proxy.

The `proxy-helm` and `server-helm` charts build every image URI with `printf "%s/%s:%s"` from the `repository` value, so the documented path ending in `$ARCH$/` renders a double slash and the deployment fails to pull the images.

```
--set "repository=registry.suse.com/suse/multi-linux-manager/5.2/$ARCH$"
```

# Target branches

- master
- 5.2

Ports:
manager-5.2: https://github.com/uyuni-project/uyuni-docs/pull/5222
