### PR TITLE
manager-5.2 - Move noindex guards above the page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search
 - Documented deprecation and support limitations of plain salt-minion manual registration (bsc#1275658)
 - Added warning about known issues in Multi-Linux Manager 5.0 and 5.1 server upgrade guides (bsc#1274875)
 - Corrected and restored Debian 12 packages in the OpenSCAP packages table (bsc#1269316)

--- a/en/modules/client-configuration/pages/client-upgrades-uyuni.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-uyuni.adoc
@@ -1,11 +1,12 @@
-[[client-upgrades-uyuni]]
-= Upgrade Uyuni Clients
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[client-upgrades-uyuni]]
+= Upgrade Uyuni Clients
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 In this section, we use openSUSE Leap as an example.
 

--- a/en/modules/client-configuration/pages/clients-openeuler.adoc
+++ b/en/modules/client-configuration/pages/clients-openeuler.adoc
@@ -1,11 +1,12 @@
-[[clients-openeuler]]
-= Registering {openeuler} Clients
-:revdate: 2025-07-01
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[clients-openeuler]]
+= Registering {openeuler} Clients
+:revdate: 2025-07-01
+:page-revdate: {revdate}
 
 This section contains information about registering clients running {openeuler} operating systems.
 

--- a/en/modules/client-configuration/pages/clients-opensuseleapmicro.adoc
+++ b/en/modules/client-configuration/pages/clients-opensuseleapmicro.adoc
@@ -1,10 +1,12 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[clients-opensuseleapmicro]]
 = Registering {leapmicro} Clients
 :revdate: 2025-02-06
 :page-revdate: {revdate}
-ifeval::[{mlm-content} == true]
-:noindex:
-endif::[]
 
 This section contains information about registering clients running {leapmicro} operating systems on {x86_64} and {aarch64} architectures.
 

--- a/en/modules/client-configuration/pages/clients-tumbleweed.adoc
+++ b/en/modules/client-configuration/pages/clients-tumbleweed.adoc
@@ -1,11 +1,12 @@
-[[clients-opensuse-tumbleweed]]
-= Registering {opensuse} {tumbleweed} Clients
-:revdate: 2025-10-08
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[clients-opensuse-tumbleweed]]
+= Registering {opensuse} {tumbleweed} Clients
+:revdate: 2025-10-08
+:page-revdate: {revdate}
 
 This section contains information about registering clients running {opensuse} operating systems.
 {productname} supports {opensuse} Tumbleweed clients using {salt}.

--- a/en/modules/client-configuration/pages/registration-overview-openeuler.adoc
+++ b/en/modules/client-configuration/pages/registration-overview-openeuler.adoc
@@ -1,11 +1,12 @@
-[[openeuler-registration-overview]]
-= {openeuler} Client Registration
-:revdate: 2025-06-30
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[openeuler-registration-overview]]
+= {openeuler} Client Registration
+:revdate: 2025-06-30
+:page-revdate: {revdate}
 
 ifeval::[{mlm-content} == true]
 

--- a/en/modules/client-configuration/pages/supported-features-openeuler.adoc
+++ b/en/modules/client-configuration/pages/supported-features-openeuler.adoc
@@ -1,11 +1,12 @@
-[[supported-features-openeuler]]
-= Supported {openeuler} Features
-:revdate: 2025-06-30
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[supported-features-openeuler]]
+= Supported {openeuler} Features
+:revdate: 2025-06-30
+:page-revdate: {revdate}
 
 This table lists the availability of various features on {openeuler} clients.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-50-52.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Proxy Upgrade from 5.0 to 5.2
 :revdate: 2026-06-30
 :page-revdate: {revdate}

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-51-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-51-52.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Proxy Upgrade from 5.1 to 5.2
 :revdate: 2026-06-30
 :page-revdate: {revdate}

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-50-52.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Server Upgrade from 5.0 to 5.2
 :revdate: 2026-08-20
 :page-revdate: {revdate}

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-51-52.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Server Upgrade from 5.1 to 5.2
 :revdate: 2026-08-20
 :page-revdate: {revdate}

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
@@ -1,10 +1,11 @@
-= {productname} Proxy Air-gapped Deployment
-:revdate: 2026-04-29
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} Proxy Air-gapped Deployment
+:revdate: 2026-04-29
+:page-revdate: {revdate}
 
 == What is air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-conversion-from-client-mlm]]
 = Convert a Client to MLM Proxy
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -1,12 +1,13 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-proxy-containers]]
 = {productname} Proxy Deployment
 :description: Configure a SUSE Multi-Linux Manager proxy container on SL Micro or SLES using this deployment guide for a fully functional setup
 :revdate: 2026-04-29
 :page-revdate: {revdate}
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 
 This guide outlines the deployment process for the {productname} {productnumber} Proxy container on {sl-micro} {microversion} or {sles} {bci-mlm}.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vm-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vm-mlm.adoc
@@ -1,11 +1,12 @@
-[[proxy-install-vm]]
-= {productname} Proxy Deployment as a Virtual Machine - KVM
-:revdate: 2026-04-29
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[proxy-install-vm]]
+= {productname} Proxy Deployment as a Virtual Machine - KVM
+:revdate: 2026-04-29
+:page-revdate: {revdate}
 
 This chapter provides the Virtual Machine settings for deployment of {productname} {productnumber} Proxy as an image.
 KVM will be combined with Virtual Machine Manager (_virt-manager_) as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
@@ -1,11 +1,12 @@
-[[proxy-install-vmware]]
-= {productname} Proxy Deployment as a Virtual Machine - VMware
-:revdate: 2025-06-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[proxy-install-vmware]]
+= {productname} Proxy Deployment as a Virtual Machine - VMware
+:revdate: 2025-06-26
+:page-revdate: {revdate}
 
 This chapter provides the Virtual Machine settings for deployment of {productname} {productnumber} Proxy as an image.
 VMware will be used as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -1,10 +1,11 @@
-= {productname} Server Air-gapped Deployment
-:revdate: 2026-07-27
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} Server Air-gapped Deployment
+:revdate: 2026-07-27
+:page-revdate: {revdate}
 
 == What is Air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
@@ -1,11 +1,12 @@
-[[deploy-mlm-server]]
-= {productname} {productnumber} Server Deployment
-:revdate: 2026-08-12
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[deploy-mlm-server]]
+= {productname} {productnumber} Server Deployment
+:revdate: 2026-08-12
+:page-revdate: {revdate}
 
 This guide shows you how to install and configure a {productname} {productnumber} container on {sl-micro} {microversion} or {sles} {bci-mlm}.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
@@ -1,11 +1,12 @@
-[[install-vm-kvm]]
-= {productname} {productnumber} Server Deployment as a Virtual Machine - KVM
-:revdate: 2026-04-29
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[install-vm-kvm]]
+= {productname} {productnumber} Server Deployment as a Virtual Machine - KVM
+:revdate: 2026-04-29
+:page-revdate: {revdate}
 
 This chapter provides the required Virtual Machine settings for deployment of {productname} {productnumber} as an image.
 KVM will be combined with Virtual Machine Manager (_virt-manager_) as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
@@ -1,11 +1,12 @@
-[[install-vm-vmware]]
-= {productname} {productnumber} Server Deployment as a Virtual Machine - VMware
-:revdate: 2026-04-29
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[install-vm-vmware]]
+= {productname} {productnumber} Server Deployment as a Virtual Machine - VMware
+:revdate: 2026-04-29
+:page-revdate: {revdate}
 
 This chapter provides the required Virtual Machine settings for deployment of {productname} {productnumber} as an Image.
 VMware will be used as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-proxy-from-micro55-tumbleweed.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-proxy-from-micro55-tumbleweed.adoc
@@ -1,11 +1,12 @@
-= Migrating the {productname} Proxy to {opensuse} Tumbleweed
-:revdate: 2025-10-27
-:page-revdate: {revdate}
-:description: This page describes how to migrate a {productname} Proxy host from openSUSE Leap Micro 5.5 to a fresh openSUSE Tumbleweed installation using the proxy administration tool `mgrpxy`.
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= Migrating the {productname} Proxy to {opensuse} Tumbleweed
+:revdate: 2025-10-27
+:page-revdate: {revdate}
+:description: This page describes how to migrate a {productname} Proxy host from openSUSE Leap Micro 5.5 to a fresh openSUSE Tumbleweed installation using the proxy administration tool `mgrpxy`.
 
 This page describes how to migrate a {productname} Proxy host from openSUSE Leap Micro 5.5 to a fresh openSUSE Tumbleweed installation using the proxy administration tool `mgrpxy`.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-server-from-micro55-tumbleweed.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-server-from-micro55-tumbleweed.adoc
@@ -1,11 +1,12 @@
-= Migrating the {productname} Server to {opensuse} Tumbleweed
-:revdate: 2025-10-27
-:page-revdate: {revdate}
-:description: This page describes how to migrate a {productname} Server running on openSUSE Leap Micro 5.5 to a fresh host running openSUSE Tumbleweed as the base OS.
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= Migrating the {productname} Server to {opensuse} Tumbleweed
+:revdate: 2025-10-27
+:page-revdate: {revdate}
+:description: This page describes how to migrate a {productname} Server running on openSUSE Leap Micro 5.5 to a fresh host running openSUSE Tumbleweed as the base OS.
 
 This page describes a simple, backup-and-restore migration of a {productname} Server running on openSUSE Leap Micro 5.5 to a fresh host running openSUSE Tumbleweed as the base OS.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-container-setup-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-container-setup-uyuni.adoc
@@ -1,11 +1,12 @@
-[[proxy-setup-containers-uyuni]]
-= Containerized {productname} Proxy Setup
-:revdate: 2025-06-30
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[proxy-setup-containers-uyuni]]
+= Containerized {productname} Proxy Setup
+:revdate: 2025-06-30
+:page-revdate: {revdate}
 
 Once container host for {productname} Proxy containers is prepared, setup of containers require few additional steps to finish configuration.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-conversion-from-client-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-conversion-from-client-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-conversion-from-client-uyuni]]
 = Proxy conversion from client
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-deployment-uyuni.adoc
@@ -1,11 +1,12 @@
-[[installation-proxy-containers]]
-= {productname} Proxy Deployment on {opensuse} {tumbleweed}
-:revdate: 2025-10-08
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[installation-proxy-containers]]
+= {productname} Proxy Deployment on {opensuse} {tumbleweed}
+:revdate: 2025-10-08
+:page-revdate: {revdate}
 
 
 This guide outlines the deployment process for the {productname} {productnumber} Proxy.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-migration-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-migration-uyuni.adoc
@@ -1,10 +1,11 @@
-= Legacy Proxy Migration to Container
-:revdate: 2025-02-06
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= Legacy Proxy Migration to Container
+:revdate: 2025-02-06
+:page-revdate: {revdate}
 
 The containerized proxy now is managed by a set of systemd services.
 For managing the containerized proxy, use the `mgrpxy` tool.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -1,10 +1,11 @@
-= {productname} Server Air-gapped Deployment
-:revdate: 2025-07-25
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} Server Air-gapped Deployment
+:revdate: 2025-07-25
+:page-revdate: {revdate}
 
 == What is air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-deployment-uyuni.adoc
@@ -1,10 +1,11 @@
-= {productname} Server Deployment on {opensuse} {tumbleweed}
-:revdate: 2025-10-08
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} Server Deployment on {opensuse} {tumbleweed}
+:revdate: 2025-10-08
+:page-revdate: {revdate}
 
 
 == Deployment Preparations

--- a/en/modules/installation-and-upgrade/pages/general-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/general-requirements.adoc
@@ -1,11 +1,12 @@
-[[installation-general-requirements]]
-= General Requirements
-:revdate: 2026-06-12
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[installation-general-requirements]]
+= General Requirements
+:revdate: 2026-06-12
+:page-revdate: {revdate}
 
 Before you begin installation, ensure that you have:
 

--- a/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
@@ -1,11 +1,12 @@
-[[install-hardware-requirements]]
-= Hardware Requirements
-:revdate: 2025-07-03
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[install-hardware-requirements]]
+= Hardware Requirements
+:revdate: 2025-07-03
+:page-revdate: {revdate}
 
 This table outlines hardware and software requirements for the {productname} Server and Proxy, on {x86_64}, {arm}, {ppc64le} and {s390x} architecture.
 

--- a/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
@@ -1,11 +1,12 @@
-[[uyuni-install-requirements]]
-= General Requirements
-:revdate: 2025-10-08
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[uyuni-install-requirements]]
+= General Requirements
+:revdate: 2025-10-08
+:page-revdate: {revdate}
 
 The following tables specify the minimum server and proxy requirements.
 

--- a/en/modules/installation-and-upgrade/partials/snippet-register-proxy-mlm.adoc
+++ b/en/modules/installation-and-upgrade/partials/snippet-register-proxy-mlm.adoc
@@ -1,8 +1,5 @@
 == Register {sl-micro} and {productname} {productnumber} Proxy
 
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 // Before starting obtain your SUSE Manager Registration Code from SUSE Customer Center - https://scc.suse.com.
 
 .Procedure: Registering {sl-micro} and {productname} {productnumber} Proxy

--- a/en/modules/legal/pages/copyright-uyuni.adoc
+++ b/en/modules/legal/pages/copyright-uyuni.adoc
@@ -1,10 +1,11 @@
-= Copyright Notice
-:revdate: 2025-06-17
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+= Copyright Notice
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 {productname} is an open source (GPLv2) Linux systems management solution.
 

--- a/en/modules/legal/pages/copyright.adoc
+++ b/en/modules/legal/pages/copyright.adoc
@@ -1,10 +1,11 @@
-= Copyright Notice
-:revdate: 2025-04-24
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Copyright Notice
+:revdate: 2025-04-24
+:page-revdate: {revdate}
 
 ifeval::[{mlm-content} == true]
 Copyright (c) {copyrightdate} SUSE LLC.

--- a/en/modules/legal/pages/eula.adoc
+++ b/en/modules/legal/pages/eula.adoc
@@ -1,10 +1,11 @@
-= End User License Agreement
-:revdate: 2025-05-14
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= End User License Agreement
+:revdate: 2025-05-14
+:page-revdate: {revdate}
 
 [NOTE]
 ====

--- a/en/modules/retail/pages/retail-install-uyuni.adoc
+++ b/en/modules/retail/pages/retail-install-uyuni.adoc
@@ -1,11 +1,12 @@
-[[retail-install-uyuni]]
-= Install Uyuni Retail Server with openSUSE
-:revdate: 2025-06-25
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[retail-install-uyuni]]
+= Install Uyuni Retail Server with openSUSE
+:revdate: 2025-06-25
+:page-revdate: {revdate}
 
 {productname} {smr} Server can be installed on openSUSE.
 

--- a/en/modules/retail/pages/retail-uyuni-branchserver.adoc
+++ b/en/modules/retail/pages/retail-uyuni-branchserver.adoc
@@ -1,11 +1,12 @@
-[[retail-branchserver]]
-= Retail Uyuni Branch Server
-:revdate: 2025-06-24
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[retail-branchserver]]
+= Retail Uyuni Branch Server
+:revdate: 2025-06-24
+:page-revdate: {revdate}
 
 This section covers {productname} {smr} Branch Server installation and setup, using these procedures:
 

--- a/en/modules/retail/pages/retail-uyuni-server-setup.adoc
+++ b/en/modules/retail/pages/retail-uyuni-server-setup.adoc
@@ -1,11 +1,12 @@
-[[retail-server-setup]]
-= Retail Uyuni Server Setup
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{mlm-content} == true]
 
 :noindex:
 endif::[]
+
+[[retail-server-setup]]
+= Retail Uyuni Server Setup
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 This section covers {productname} {smr} Server setup, using these procedures:
 

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-configure-the-image.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-configure-the-image.adoc
@@ -1,10 +1,11 @@
-= Initial Preparation and Configuration of the {azure} Managed Application
-:revdate: 2025-02-28
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Initial Preparation and Configuration of the {azure} Managed Application
+:revdate: 2025-02-28
+:page-revdate: {revdate}
 
 This section covers initial preparation and configuration of the Managed Application on {azure}.
 

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-connections-and-bootstrapping.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-connections-and-bootstrapping.adoc
@@ -1,10 +1,11 @@
-= {payg} Client connections and Client Registration
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {payg} Client connections and Client Registration
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Managing Connections and Registering {payg} and {byos} Images
 

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-public-cloud-images.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-public-cloud-images.adoc
@@ -1,10 +1,11 @@
-= Obtaining the {productname} Server {payg} Public Cloud Image on {azure}
-:revdate: 2025-02-28
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Obtaining the {productname} Server {payg} Public Cloud Image on {azure}
+:revdate: 2025-02-28
+:page-revdate: {revdate}
 
 Follow these step-by-step instructions to locate the {productname} {productnumber} {payg} image on {azure}.
 

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-requirements.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-requirements.adoc
@@ -1,10 +1,11 @@
-= Azure System Requirements
-:revdate: 2025-06-06
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Azure System Requirements
+:revdate: 2025-06-06
+:page-revdate: {revdate}
 
 The {productname} {payg} offering in Azure need to communicate with the Azure Billing API, therefore it is not a simple virtual machine (VM) offering.
 

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-server-setup.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-server-setup.adoc
@@ -1,11 +1,12 @@
-[[azure-server-setup]]
-= Initial Setup
-:revdate: 2025-03-03
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[azure-server-setup]]
+= Initial Setup
+:revdate: 2025-03-03
+:page-revdate: {revdate}
 
 .Procedure: Log in and Update the System
 . Within the Managed Resource group you have set up, you will find the virtual machine. To get the details, click on the name of the virtual machine.

--- a/en/modules/specialized-guides/_unpublished/azure/payg-azure-webui-configuration.adoc
+++ b/en/modules/specialized-guides/_unpublished/azure/payg-azure-webui-configuration.adoc
@@ -1,10 +1,11 @@
-= {productname} {payg} {webui} Setup 
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} {payg} {webui} Setup 
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Requirements
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/byos-overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/byos-overview.adoc
@@ -1,10 +1,11 @@
-= {byos} Guide
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {byos} Guide
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == {byoslongform} ({byos})
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/clients.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/clients.adoc
@@ -1,11 +1,12 @@
-[[quickstart-publiccloud-clients]]
-= Client Registration
-:revdate: 2025-06-25
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[quickstart-publiccloud-clients]]
+= Client Registration
+:revdate: 2025-06-25
+:page-revdate: {revdate}
 
 When you have your {productname} Server and, optionally, your {productname} Proxy set up, you are ready to start registering clients.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/setup.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/setup.adoc
@@ -1,11 +1,12 @@
-[[quickstart-publiccloud-setup]]
-= Initial Setup
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[quickstart-publiccloud-setup]]
+= Initial Setup
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Introduction
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-appendix.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-appendix.adoc
@@ -1,10 +1,11 @@
-= Appendix
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Appendix
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Countries that can transact {productname} {payg} through the cloud marketplace
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-general.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-general.adoc
@@ -1,10 +1,11 @@
-= Billing - General
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Billing - General
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 :availability: AWS
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-products.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-products.adoc
@@ -1,10 +1,11 @@
-= Billing - Products
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Billing - Products
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-technical.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-technical.adoc
@@ -1,10 +1,11 @@
-= Billing - Technical
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Billing - Technical
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-listings.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-listings.adoc
@@ -1,10 +1,11 @@
-= Public Cloud Listings
-:revdate: 2026-07-13
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Public Cloud Listings
+:revdate: 2026-07-13
+:page-revdate: {revdate}
 :availability: AWS
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-miscellaneous.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-miscellaneous.adoc
@@ -1,10 +1,11 @@
-= Miscellaneous
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Miscellaneous
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/overview.adoc
@@ -1,11 +1,12 @@
-[[public-cloud-guide]]
-= Public Cloud Guide
-:revdate: 2026-05-06
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[public-cloud-guide]]
+= Public Cloud Guide
+:revdate: 2026-05-06
+:page-revdate: {revdate}
 
 This guide shows you the fastest way to get {productname} up and running in a public cloud environment using on-demand, {payglongform} ({payg}), or {byoslongform} ({byos}) services.
 {productname} Proxy in a public cloud is only supported using {byos} services.

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg-support.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg-support.adoc
@@ -1,10 +1,11 @@
-= Public Cloud Support
-:revdate: 2026-05-06
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Public Cloud Support
+:revdate: 2026-05-06
+:page-revdate: {revdate}
 
 
 == {byos} and {payg} support

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-configure-the-image.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-configure-the-image.adoc
@@ -1,10 +1,11 @@
-= {aws} Image Preparation and Configuration
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {aws} Image Preparation and Configuration
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 This section covers initial preparation and configuration of the image on {aws}.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-connections-and-bootstrapping.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-connections-and-bootstrapping.adoc
@@ -1,10 +1,11 @@
-= Connecting {payg} Clients and Client Registration
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Connecting {payg} Clients and Client Registration
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Managing Connections and Registering {payg} and {byos} images
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-public-cloud-images.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-public-cloud-images.adoc
@@ -1,10 +1,11 @@
-= Obtaining the {productname} Server {payg} Public Cloud Image on {aws}
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= Obtaining the {productname} Server {payg} Public Cloud Image on {aws}
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 Follow these step-by-step instructions to locate the {productname} {productnumber} {payg} image on {aws}.
 You can also review the latest available images for the public cloud using Pint (Public Cloud Information Tracker).

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-requirements.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-requirements.adoc
@@ -1,10 +1,11 @@
-= {aws} System Requirements
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {aws} System Requirements
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 When setting up a {productname} {payg} instance on {aws}, it is essential to consider system requirements for optimal performance and functionality. 
 The default requirements outlined below have been tailored for smooth deployment and operation. 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-server-setup.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-server-setup.adoc
@@ -1,11 +1,12 @@
-[[aws-server-setup]]
-= Server Setup
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[aws-server-setup]]
+= Server Setup
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 .Procedure: Log in and Update the System
 . SSH into your {AWS} instance.

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-webui-configuration.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-webui-configuration.adoc
@@ -1,10 +1,11 @@
-= {productname} {payg} {webui} Configuration 
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} {payg} {webui} Configuration 
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Requirements
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-limitations.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-limitations.adoc
@@ -1,10 +1,11 @@
-= {payg} Limitations
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {payg} Limitations
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Onboarded {byos} Instances without {scc} Credentials
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-overview.adoc
@@ -1,10 +1,11 @@
-= {payg} Overview
-:revdate: 2026-05-06
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {payg} Overview
+:revdate: 2026-05-06
+:page-revdate: {revdate}
 :description: {productname} {payg} or {payglongform} is a flexible and cost-effective solution that allows users to manage and monitor their systems. 
 {payg} does not require a long-term subscription. 
 Users can leverage the images of {productname} on a {payglongform} basis, paying only for the time of use, and the number of managed and monitored systems. 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/public-cloud-faq.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/public-cloud-faq.adoc
@@ -1,10 +1,11 @@
-= {productname} {payg} on the Cloud: FAQ
-:revdate: 2026-07-15
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+= {productname} {payg} on the Cloud: FAQ
+:revdate: 2026-07-15
+:page-revdate: {revdate}
 :availability: AWS
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-configure-payg-behind-proxy.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-configure-payg-behind-proxy.adoc
@@ -1,11 +1,12 @@
-[[tshoot-public-cloud-configure-payg-behind-proxy]]
-= Configure {payglongform} Behind Proxy
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[tshoot-public-cloud-configure-payg-behind-proxy]]
+= Configure {payglongform} Behind Proxy
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 To identify if a machine is {payg} or not, {productname} needs to use `sudo` to run `instance-flavor-check`tool.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-intro.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-intro.adoc
@@ -1,11 +1,12 @@
-[[troubleshooting-public-cloud]]
-= Troubleshooting Public Cloud
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[troubleshooting-public-cloud]]
+= Troubleshooting Public Cloud
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 :availability: AWS & Azure
 :sectnums!:

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-payg-checks.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-payg-checks.adoc
@@ -1,11 +1,12 @@
-[[tshoot-public-cloud-payg-checks]]
-= {payg} Checks
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[tshoot-public-cloud-payg-checks]]
+= {payg} Checks
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 ////
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-setup-separate-disk-byos.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-setup-separate-disk-byos.adoc
@@ -1,11 +1,12 @@
-[[tshoot-public-cloud-setup-separate-disk-byos]]
-= Set up {productname} with Separate Disk for {byos}
-:revdate: 2025-02-26
-:page-revdate: {revdate}
 ifeval::[{uyuni-content} == true]
 
 :noindex:
 endif::[]
+
+[[tshoot-public-cloud-setup-separate-disk-byos]]
+= Set up {productname} with Separate Disk for {byos}
+:revdate: 2025-02-26
+:page-revdate: {revdate}
 
 == Issue
 


### PR DESCRIPTION
# Description

Pages meant for one product showed up in the other product's search, because the `:noindex:` line sat below the page title where Antora never reads it; this moves every guard above the title.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5227
- manager-5.2 (this PR)
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5229

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31136
