### PR TITLE
manager-5.1 - Move noindex guards above the page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search
 - Documented deprecation and support limitations of plain salt-minion manual registration (bsc#1275658)
 - Added warning about known issues in Multi-Linux Manager 5.0 and 5.1 server upgrade guides (bsc#1274875)
 - Corrected and restored Debian 12 packages in the OpenSCAP packages table (bsc#1269316)

--- a/en/modules/administration/pages/admin-overview.adoc
+++ b/en/modules/administration/pages/admin-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[admin-overview]]
 = Administration Guide
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/client-configuration/pages/client-config-overview.adoc
+++ b/en/modules/client-configuration/pages/client-config-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[client-cfg-overview]]
 = Client Configuration Guide
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/client-configuration/pages/client-upgrades-uyuni.adoc
+++ b/en/modules/client-configuration/pages/client-upgrades-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[client-upgrades-uyuni]]
 = Upgrade Uyuni Clients
 :description: Configure Uyuni clients by adding channels, synchronizing repositories, and upgrading packages; ensure that all changes are successfully synced
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 In this section, we use openSUSE Leap as an example.
 

--- a/en/modules/client-configuration/pages/clients-openeuler.adoc
+++ b/en/modules/client-configuration/pages/clients-openeuler.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[clients-openeuler]]
 = Registering {openeuler} Clients
 :description: Register openEuler clients with your SUSE Multi-Linux Manager Server by adding software channels and then synchronizing them
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 This section contains information about registering clients running {openeuler} operating systems.
 

--- a/en/modules/client-configuration/pages/registration-overview-openeuler.adoc
+++ b/en/modules/client-configuration/pages/registration-overview-openeuler.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[openeuler-registration-overview]]
 = {openeuler} Client Registration
 :description: Configure openEuler clients to a SUSE Multi-Linux Manager Server via registration methods suited for various operating systems
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 ifeval::[{mlm-content} == true]
 

--- a/en/modules/client-configuration/pages/supported-features-openeuler.adoc
+++ b/en/modules/client-configuration/pages/supported-features-openeuler.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[supported-features-openeuler]]
 = Supported {openeuler} Features
 :description: Here is the corrected sentence Learn about supported features on openEuler clients, including system packages, registration options, package installation
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 This table lists the availability of various features on {openeuler} clients.
 

--- a/en/modules/common-workflows/pages/common-workflows-overview.adoc
+++ b/en/modules/common-workflows/pages/common-workflows-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[common-workflows-overview]]
 = Common workflows
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/proxy/proxy-mlm-43-51.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Proxy Migration from 4.3 to 5.1
 :description: Migrate your SUSE Manager 4.3 Proxy to SUSE Manager 5.1 by deploying a new proxy with a new FQDN and following the outlined migration procedures. (I removed
 :revdate: 2026-06-29
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Requirements and considerations
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/migrations/server/server-mlm-43-51.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} Server Migration to a Containerized Environment
 :description: Learn to migrate your SUSE Multi-Linux Manager 4.3 Server to a container by preparing the host system, migrating clients and GPG keys, then executing the mgradm
 :revdate: 2026-08-20
@@ -11,10 +16,6 @@ For a list of known issues, see  link:https://documentation.suse.com/releasenote
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 // container host = new server = new server machine with the {productname} {productnumber} Server container(s)
 // old server = {productname} 4.3 Server

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-air-gapped-deployment-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} Proxy Air-gapped Deployment
 :description: Configure and deploy secure air-gapped systems in high-security environments with SUSE Multi-Linux Manager tools
 :revdate: 2025-04-28
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == What is air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-conversion-from-client-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-conversion-from-client-mlm]]
 = Convert a Client to MLM Proxy
 :description: Configure a client system to function as a SUSE Multi-Linux Manager Proxy, following the step-by-step guide and making any necessary

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-proxy-containers]]
 = {productname} Proxy Deployment
 :description: Configure a SUSE Multi-Linux Manager 5.1 proxy container on SL Micro or SLES using this deployment guide for a fully functional setup
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 
 This guide outlines the deployment process for the {productname} {productnumber} Proxy container on {sl-micro} {microversion} or {sles} {bci-mlm}.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vm-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vm-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-install-vm]]
 = {productname} Proxy Deployment as a Virtual Machine - KVM
 :description: Configure SUSE Multi-Linux Manager 5.1 Proxy deployment as a virtual machine using KVM with Virtual Machine Manager (virt-manager), ensuring a successful
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This chapter provides the Virtual Machine settings for deployment of {productname} {productnumber} Proxy as an image.
 KVM will be combined with Virtual Machine Manager (_virt-manager_) as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-deployment-vmdk-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-install-vmware]]
 = {productname} Proxy Deployment as a Virtual Machine - VMware
 :description: Learn how to configure a SUSE Multi-Linux Manager Proxy as a virtual machine in VMware environments for efficient storage partition management, and improve
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This chapter provides the Virtual Machine settings for deployment of {productname} {productnumber} Proxy as an image.
 VMware will be used as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/proxy-k3s-deployment-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-proxy-containers-k3s]]
 = {productname} {productnumber}  Proxy Deployment on K3s
 :description: Learn how to deploy and configure a SUSE Multi-Linux Manager Proxy on top of K3s for optimized Kubernetes management
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 
 [[installation-proxy-containers-k3s-k3s]]

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-air-gapped-deployment-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} Server Air-gapped Deployment
 :description: Deploy SUSE Multi-Linux Manager in secure, air-gapped environments using supported installation and upgrade procedures
 :revdate: 2025-05-14
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == What is Air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[deploy-mlm-server]]
 = {productname} {productnumber} Server Deployment
 :description: Configure a SUSE Multi-Linux Manager 5.1 server on SL Micro 6.1, SUSE Linux Enterprise Server 15 SP7, or other compatible systems to manage multiple Linux
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This guide shows you how to install and configure a {productname} {productnumber} container on {sl-micro} {microversion} or {sles} {bci-mlm}.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vm-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[install-vm-kvm]]
 = {productname} {productnumber} Server Deployment as a Virtual Machine - KVM
 :description: Learn how to deploy SUSE Multi-Linux Manager 5.1 as a virtual machine with KVM, following its settings and configuration procedures for a successful
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This chapter provides the required Virtual Machine settings for deployment of {productname} {productnumber} as an image.
 KVM will be combined with Virtual Machine Manager (_virt-manager_) as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/mlm/server-deployment-vmdk-mlm.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[install-vm-vmware]]
 = {productname} {productnumber} Server Deployment as a Virtual Machine - VMware
 :description: Configure VMware virtual machines for SUSE Multi-Linux Manager 5.1 Server deployments as Virtual Machines, including detailed settings and registration
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This chapter provides the required Virtual Machine settings for deployment of {productname} {productnumber} as an Image.
 VMware will be used as a sandbox for this installation.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-to-a-container.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/migrate-uyuni-to-a-container.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 = Legacy {productname} Server Migration to Container
 :description: Learn how to migrate a legacy SUSE Multi-Linux Manager Server to a container, preparing your new machine along the way
 :revdate: 2025-07-30
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 To migrate a legacy {productname} Server to a container, a new machine is required.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-container-setup-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-container-setup-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-setup-containers-uyuni]]
 = Containerized {productname} Proxy Setup
 :description: Configure SUSE Multi-Linux Manager Proxy containers using a configuration archive generate one, transfer and extract it to the container host, start proxy
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 Once container host for {productname} Proxy containers is prepared, setup of containers require few additional steps to finish configuration.
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-conversion-from-client-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-conversion-from-client-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[proxy-conversion-from-client-uyuni]]
 = Proxy conversion from client
 :description: Configure a SUSE Multi-Linux Manager Proxy using the Web UI by configuring an existing client system as a proxy

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-deployment-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-proxy-containers]]
 = {productname} Proxy Deployment on {leapmicro} {microversion}
 :description: Configure a SUSE Multi-Linux Manager 5.1 proxy deployment using the step-by-step guide for openSUSE Leap Micro 6.1
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 
 This guide outlines the deployment process for the {productname} {productnumber} Proxy.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-k3s-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-k3s-deployment-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-proxy-containers-k3s-uyuni]]
 = {productname} Proxy Deployment on K3s
 :description: Learn to configure and deploy SUSE Multi-Linux Manager Proxy on K3s by following the procedure
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 
 [[installation-proxy-containers-k3s-k3s]]

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-migration-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/proxy-migration-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 = Legacy Proxy Migration to Container
 :description: Migrate your SUSE Multi-Linux Manager containerized proxy to the new containerized proxy in SUSE Multi-Linux Manager 5.1 now
 :revdate: 2025-02-06
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 The containerized proxy now is managed by a set of systemd services.
 For managing the containerized proxy, use the `mgrpxy` tool.

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-air-gapped-deployment-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} Server Air-gapped Deployment
 :description: Learn how to deploy secure container images using Podman, Docker, or Skopeo in air-gapped environments
 :revdate: 2025-07-25
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 == What is air-gapped deployment?
 

--- a/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-deployment-uyuni.adoc
+++ b/en/modules/installation-and-upgrade/pages/container-deployment/uyuni/server-deployment-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} Server Deployment on {leapmicro} {microversion}
 :description: Learn how to deploy a SUSE Multi-Linux Manager server as a container with Podman and use the Uyuni utility
 :revdate: 2025-07-09
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 
 == Deployment Preparations

--- a/en/modules/installation-and-upgrade/pages/general-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/general-requirements.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[installation-general-requirements]]
 = General Requirements
 :description: Learn the steps to obtain and record your organizations credentials for a successful SUSE Multi-Linux Manager setup and registration
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 Before you begin installation, ensure that you have:
 

--- a/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/hardware-requirements.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[install-hardware-requirements]]
 = Hardware Requirements
 :description: Learn how to configure hardware requirements for the SUSE Multi-Linux Manager Server and Proxy based on your architecture and storage needs, considering factors
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This table outlines hardware and software requirements for the {productname} Server and Proxy, on {x86_64}, {arm}, {ppc64le} and {s390x} architecture.
 

--- a/en/modules/installation-and-upgrade/pages/installation-and-upgrade-overview.adoc
+++ b/en/modules/installation-and-upgrade/pages/installation-and-upgrade-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[installation-and-upgrade-overview]]
 = Installation, Deployment and Upgrade
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
+++ b/en/modules/installation-and-upgrade/pages/uyuni-install-requirements.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[uyuni-install-requirements]]
 = General Requirements
 :description: Configure server and proxy requirements for a successful deployment of openSUSE Leap Micro 6.1 by meeting the minimum hardware specifications for CPU, RAM, disk
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 The following tables specify the minimum server and proxy requirements.
 

--- a/en/modules/installation-and-upgrade/partials/snippet-register-proxy-mlm.adoc
+++ b/en/modules/installation-and-upgrade/partials/snippet-register-proxy-mlm.adoc
@@ -1,8 +1,5 @@
 == Register {sl-micro} and {productname} {productnumber} Proxy
 
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 // Before starting obtain your SUSE Manager Registration Code from SUSE Customer Center - https://scc.suse.com.
 
 .Procedure: Registering {sl-micro} and {productname} {productnumber} Proxy

--- a/en/modules/legal/pages/copyright-uyuni.adoc
+++ b/en/modules/legal/pages/copyright-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 = Copyright Notice
 :description: Configure Linux systems efficiently with SUSE Multi-Linux Manager, a comprehensive open-source management solution for managing multiple Linux platforms
 :revdate: 2025-06-17
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 {productname} is an open source (GPLv2) Linux systems management solution.
 

--- a/en/modules/legal/pages/copyright.adoc
+++ b/en/modules/legal/pages/copyright.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Copyright Notice
 :description: Learn how to configure and deploy SUSE Multi-Linux Manager software, including materials licensed under the GNU General Public License, with access
 :revdate: 2025-04-24
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 Copyright (c) {copyrightdate} SUSE LLC.
 {productname} LICENSE AGREEMENT

--- a/en/modules/legal/pages/eula.adoc
+++ b/en/modules/legal/pages/eula.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = End User License Agreement
 :description: Comply with the terms and conditions of the End User License Agreement when using software products
 :revdate: 2025-05-14
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 [NOTE]
 ====

--- a/en/modules/reference/pages/reference-overview.adoc
+++ b/en/modules/reference/pages/reference-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[reference-guide-overview]]
 = Reference Guide
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/retail/pages/retail-install-uyuni.adoc
+++ b/en/modules/retail/pages/retail-install-uyuni.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[retail-install-uyuni]]
 = Install Uyuni Retail Server with openSUSE
 :description: Configure a fully qualified resolvable domain name and set required variables to install the Uyuni Retail Server on openSUSE
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 {productname} {smr} Server can be installed on openSUSE.
 

--- a/en/modules/retail/pages/retail-overview.adoc
+++ b/en/modules/retail/pages/retail-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[retail-overview]]
 = Retail Guide
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}

--- a/en/modules/retail/pages/retail-uyuni-branchserver.adoc
+++ b/en/modules/retail/pages/retail-uyuni-branchserver.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[retail-branchserver]]
 = Retail Uyuni Branch Server
 :description: Configure a retail Uyuni Branch Server using SUSE Multi-Linux Manager for retail branch server installation and setup
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 This section covers {productname} {smr} Branch Server installation and setup, using these procedures:
 

--- a/en/modules/retail/pages/retail-uyuni-server-setup.adoc
+++ b/en/modules/retail/pages/retail-uyuni-server-setup.adoc
@@ -1,3 +1,8 @@
+ifeval::[{mlm-content} == true]
+
+:noindex:
+endif::[]
+
 [[retail-server-setup]]
 = Retail Uyuni Server Setup
 :description: Configure the SUSE Multi-Linux Manager for a Retail Server setup by following these procedures configure YaST tools, create main administration accounts, add
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{mlm-content} == true]
-
-:noindex:
-endif::[]
 
 This section covers {productname} {smr} Server setup, using these procedures:
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/byos-overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/byos-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {byos} Guide
 :description: Configure your system to run on a cloud instance by registering it with SUSE Customer Center or connecting to your RMT infrastructure
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == {byoslongform} ({byos})
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/clients.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/clients.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[quickstart-publiccloud-clients]]
 = Client Registration
 :description: Learn effective techniques for registering clients using a SUSE Multi-Linux Manager Server and Proxy setup for secure client management and centralized
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 When you have your {productname} Server and, optionally, your {productname} Proxy set up, you are ready to start registering clients.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/byos/setup.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/byos/setup.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[quickstart-publiccloud-setup]]
 = Initial Setup
 :description: Learn to deploy and manage SUSE Multi-Linux Manager using this guide, which covers three main methods
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Introduction
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-appendix.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-appendix.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Appendix
 :description: Access a list of countries enabled for transactions in cloud marketplaces to learn more about their capabilities and configurations
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Countries that can transact {productname} {payg} through the cloud marketplace
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-general.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-general.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Billing - General
 :description: Learn to deploy and manage instances using SUSE Multi-Linux Manager on cloud platforms like AWS, Azure
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-products.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-products.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Billing - Products
 :description: Learn how to deploy and manage your SUSE workloads in the cloud through our centralized resource for SUSE Multi-Linux Manager information, which covers
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-technical.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-billing-technical.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Billing - Technical
 :description: Deploy a SUSE Multi-Linux Manager instance with an embedded billing engine via the cloud marketplace listing
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-listings.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-listings.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Public Cloud Listings
 :description: Deploy SUSE Multi-Linux Manager in your cloud environment with flexible billing options through cloud providers, allowing for more cost-effective infrastructure
 :revdate: 2026-07-13
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-miscellaneous.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/faq/faq-miscellaneous.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Miscellaneous
 :description: Leverage the flexibility of YaST tools across both AWS and Azure cloud platforms to streamline SUSE Multi-Linux Manager deployments
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS & Azure
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[public-cloud-guide]]
 = Public Cloud Guide
 :description: Configure and deploy the SUSE Multi-Linux Manager in a public cloud environment using on-demand services like AWS or Azure
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This guide shows you the fastest way to get {productname} up and running in a public cloud environment using on-demand, {payglongform} ({payg}), or {byoslongform} ({byos}) services.
 {productname} Proxy in a public cloud is only supported using {byos} services.

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg-support.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg-support.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Public Cloud Support
 :description: Learn how to collect detailed system information for easy troubleshooting and submission to Global Technical Support
 :revdate: 2026-05-06
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == {byos} and {payg} support
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-configure-the-image.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-configure-the-image.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {aws} Image Preparation and Configuration
 :description: Configure IAM permissions for seamless operation with the AWSMarketplaceMeteringFullAccess policy attached
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 This section covers initial preparation and configuration of the image on {aws}.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-connections-and-bootstrapping.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-connections-and-bootstrapping.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Connecting {payg} Clients and Client Registration
 :description: Learn to onboard and manage SUSE Linux Enterprise instances with the SUSE Multi-Linux Manager Server Web UI
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Managing Connections and Registering {payg} and {byos} images
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-public-cloud-images.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-public-cloud-images.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = Obtaining the {productname} Server {payg} Public Cloud Image on {aws}
 :description: Locate the SUSE Multi-Linux Manager 5.1 image on AWS using these step-by-step instructions, or review public cloud images with Pint
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 Follow these step-by-step instructions to locate the {productname} {productnumber} {payg} image on {aws}.
 You can also review the latest available images for the public cloud using Pint (Public Cloud Information Tracker).

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-requirements.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-requirements.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {aws} System Requirements
 :description: Configure a SUSE Multi-Linux Manager instance on a suitable platform with consideration for essential system requirements such as root storage space, CPU cores
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 When setting up a {productname} {payg} instance on {aws}, it is essential to consider system requirements for optimal performance and functionality. 
 The default requirements outlined below have been tailored for smooth deployment and operation. 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-server-setup.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-server-setup.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[aws-server-setup]]
 = Server Setup
 :description: Configure storage for your container and database using the mgr-storage-server tool or mgr-storage-proxy
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 .Procedure: Log in and Update the System
 . SSH into your {AWS} instance.

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-webui-configuration.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/aws/payg-aws-webui-configuration.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} {payg} {webui} Configuration 
 :description: Learn to configure and use SUSE Multi-Linux Managers essential tools, such as instance-flavor-check and Schedule Check
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Requirements
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-limitations.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-limitations.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {payg} Limitations
 :description: Manage SUSE product instances in SUSE Multi-Linux Manager with valid SUSE Customer Center credentials to ensure they are properly configured
 :revdate: 2025-02-26
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Onboarded {byos} Instances without {scc} Credentials
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-overview.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/payg/payg-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {payg} Overview
 :revdate: 2026-07-13
 :page-revdate: {revdate}
@@ -5,10 +10,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :description: Learn how to manage and monitor multiple Linux systems cost-effectively with SUSEs flexible solutions, which include pay-per-use options
 {payg} does not require a long-term subscription. 
 Users can leverage the images of {productname} on a {payglongform} basis, paying only for the time of use, and the number of managed and monitored systems. 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/public-cloud-faq.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/public-cloud-faq.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 = {productname} {payg} on the Cloud: FAQ
 :description: Learn how to access and configure SUSE Multi-Linux Manager on both AWS and Azure with our central resource for public cloud listings
 :revdate: 2026-07-14
@@ -6,10 +11,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 :availability: AWS
 :sectnums!:
 :lastupdate: October 2023

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-configure-payg-behind-proxy.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-configure-payg-behind-proxy.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[tshoot-public-cloud-configure-payg-behind-proxy]]
 = Configure {payglongform} Behind Proxy
 :description: Configure your machines proxy settings using SUSE Multi-Linux Manager with the sudo instance-flavor-checktool, adding necessary files for proxy preservation
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 To identify if a machine is {payg} or not, {productname} needs to use `sudo` to run `instance-flavor-check`tool.
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-intro.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-intro.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[troubleshooting-public-cloud]]
 = Troubleshooting Public Cloud
 :description: Learn to troubleshoot common issues with SUSE Multi-Linux Manager on AWS, Azure, and other cloud platforms
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 :availability: AWS & Azure
 :sectnums!:

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-payg-checks.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-payg-checks.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[tshoot-public-cloud-payg-checks]]
 = {payg} Checks
 :description: Learn how to troubleshoot and resolve issues related to checks, credentials, and RegisterCloudGuest commands
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 ////
 

--- a/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-setup-separate-disk-byos.adoc
+++ b/en/modules/specialized-guides/pages/public-cloud-guide/troubleshooting/tshoot-public-cloud-setup-separate-disk-byos.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 [[tshoot-public-cloud-setup-separate-disk-byos]]
 = Set up {productname} with Separate Disk for {byos}
 :description: Configure your SUSE Multi-Linux Manager setup to avoid data loss by copying existing data into new partitions, ensuring a safe transition
@@ -7,10 +12,6 @@
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-ifeval::[{uyuni-content} == true]
-
-:noindex:
-endif::[]
 
 == Issue
 

--- a/en/modules/specialized-guides/pages/specialized-guides-overview.adoc
+++ b/en/modules/specialized-guides/pages/specialized-guides-overview.adoc
@@ -1,3 +1,8 @@
+ifeval::[{uyuni-content} == true]
+
+:noindex:
+endif::[]
+
 ifndef::backend-pdf[]
 [[specialized-guides-overview]]
 = Specialized Guides
@@ -8,10 +13,6 @@ ifndef::backend-pdf[]
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
 :page-product-name: SUSE Multi-Linux Manager
 :page-product-version: 5.1
-
-ifeval::[{uyuni-content} == true]
-:noindex:
-endif::[]
 
 // HTML Publication date 
 **Publication Date:** {docdate}


### PR DESCRIPTION
# Description

Pages meant for one product showed up in the other product's search, because the `:noindex:` line sat below the page title where Antora never reads it; this moves every guard above the title.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5227
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5228
- manager-5.1 (this PR)

# Links
- This PR tracks issue https://github.com/SUSE/spacewalk/issues/31136
