### PR TITLE
manager-5.2 - Clear staged content so builds do not reuse stale pages

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -542,9 +542,11 @@ tasks:
     sources:
       - l10n-weblate/**/*.po
       - l10n-weblate/**/*.cfg
+      - en/modules/**/*
     generates:
       - translations/**/*.adoc
     cmds:
+      - rm -rf translations
       - bash scripts/use_po.sh
 
   pot:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -539,6 +539,9 @@ tasks:
   # --------------------------------------------------------------------------
   translations:
     desc: "[Dev] Apply .po translation files (generates translated AsciiDoc)"
+    # Run once per invocation: pdf:all invokes pdf:mlm and pdf:uyuni as parallel
+    # deps, and a concurrent rm -rf of the tree makes the other invocation fail.
+    run: once
     sources:
       - l10n-weblate/**/*.po
       - l10n-weblate/**/*.cfg


### PR DESCRIPTION
# Description

Builds reused stale content because nothing cleared the `translations/` staging tree, so pages deleted or renamed on the current branch survived into the published output and silently resolved xrefs that should have failed (and on manager-5.2, edits to `en/modules/**` were not picked up either); the tree is now cleared before staging, which is also marked `run: once` because `pdf:all` runs its two product builds as parallel deps that would otherwise clear it from under each other.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5236 (race fix only; staging clear already landed in #5110)
- manager-5.2 (this PR)
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5235

# Links
- This PR tracks issue https://github.com/uyuni-project/uyuni-docs/issues/5226

