### PR TITLE
manager-5.1 - Clear staged content so builds do not reuse stale pages

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -552,6 +552,7 @@ tasks:
           LANG="{{.ITEM}}"
           CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang "${LANG}")
           echo "==> Staging content for ${LANG} (source: ${CONTENT_DIR}/modules/)"
+          rm -rf translations/${LANG}/modules
           mkdir -p translations/${LANG}/modules
           cp -a en/modules/. translations/${LANG}/modules/
           if [ -d "${CONTENT_DIR}/modules" ]; then

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -546,6 +546,9 @@ tasks:
   stage-content:
     desc: "[Dev] Stage translated content for build (en base + lang overlay → translations/{lang}/modules/)"
     deps: [setup]
+    # Stage once per run: pdf:all invokes pdf:mlm and pdf:uyuni as parallel deps,
+    # and a concurrent removal of the tree makes the other invocation's cp fail.
+    run: once
     cmds:
       - for: {var: LANGUAGES}
         cmd: |


### PR DESCRIPTION
# Description

Builds reused stale content because nothing cleared the `translations/` staging tree, so pages deleted or renamed on the current branch survived into the published output and silently resolved xrefs that should have failed (and on manager-5.2, edits to `en/modules/**` were not picked up either); the tree is now cleared before staging, which is also marked `run: once` because `pdf:all` runs its two product builds as parallel deps that would otherwise clear it from under each other.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5236 (race fix only; staging clear already landed in #5110)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5234
- manager-5.1 (this PR)

# Links
- This PR tracks issue https://github.com/uyuni-project/uyuni-docs/issues/5226

