### PR TITLE
master - Run the translations task once so parallel PDF builds do not race

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -539,6 +539,9 @@ tasks:
   # --------------------------------------------------------------------------
   translations:
     desc: "[Dev] Apply .po translation files (generates translated AsciiDoc)"
+    # Run once per invocation: pdf:all invokes pdf:mlm and pdf:uyuni as parallel
+    # deps, and a concurrent rm -rf of the tree makes the other invocation fail.
+    run: once
     sources:
       - l10n-weblate/**/*.po
       - l10n-weblate/**/*.cfg


### PR DESCRIPTION
# Description

`pdf:all` invokes `pdf:mlm` and `pdf:uyuni` as parallel deps and both call `translations`, which Task runs concurrently, so the `rm -rf translations` added by #5110 deletes the tree the other invocation is copying into and the build aborts with `cp: cannot create directory ... File exists`; marking the task `run: once` stages it a single time per run.

# Target branches

- master (this PR)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5234
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5235

# Links
- This PR tracks issue https://github.com/uyuni-project/uyuni-docs/issues/5226
