### PR TITLE
master - Fix validate tasks to use Antora's built-in xref checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed the validate tasks to use Antora's built-in xref checking instead of the removed Antora 2 xref-validator plugin
 - Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search
 - Added ppc64le support for AlmaLinux 8 in Uyuni
 - Corrected the architectures of Rocky Linux 8 in Uyuni, which has no ppc64le build upstream

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,7 +35,7 @@
 #    task container:draft:uyuni-website             Uyuni HTML — website (all languages)
 #    task container:draft:uyuni-webui               Uyuni HTML — product WebUI (all languages)
 #    task container:draft:all                       All four HTML output targets
-#    (All draft/publish/pdf container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
+#    (All draft/publish/pdf/validate container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
 #    task container:pdf:mlm             All MLM PDFs
 #    task container:pdf:uyuni           All Uyuni PDFs
 #    task container:pdf:all             All PDFs
@@ -518,21 +518,33 @@ tasks:
   # --------------------------------------------------------------------------
   validate:mlm:
     desc: "[Local] Antora xref validation — MLM"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: translations
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator mlm-dsc.site.yml
+          echo "==> Validating mlm-dsc / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product mlm -output mlm-dsc -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product mlm -lang {{.ITEM}}
+          mkdir -p translations/{{.ITEM}}/modules
+          cp -an en/modules/. translations/{{.ITEM}}/modules/ || true
+          npx antora --log-failure-level=error --to-dir build/{{.ITEM}}/validate-mlm \
+            translations/{{.ITEM}}/mlm-dsc.site.yml
 
   validate:uyuni:
     desc: "[Local] Antora xref validation — Uyuni"
-    deps: [gen]
+    deps: [setup]
     cmds:
+      - task: translations
       - for: {var: LANGUAGES}
         cmd: |
-          cd translations/{{.ITEM}}
-          NODE_PATH="$(npm -g root)" antora --generator @antora/xref-validator uyuni-website.site.yml
+          echo "==> Validating uyuni-website / {{.ITEM}}"
+          {{.DOCBUILD}} gen-site -product uyuni -output uyuni-website -lang {{.ITEM}}
+          {{.DOCBUILD}} gen-antora -product uyuni -lang {{.ITEM}}
+          mkdir -p translations/{{.ITEM}}/modules
+          cp -an en/modules/. translations/{{.ITEM}}/modules/ || true
+          npx antora --log-failure-level=error --to-dir build/{{.ITEM}}/validate-uyuni \
+            translations/{{.ITEM}}/uyuni-website.site.yml
 
   # --------------------------------------------------------------------------
   # Translations
@@ -696,14 +708,14 @@ tasks:
 
   # Validation
   container:validate:mlm:
-    desc: "[Container] Antora xref validation — MLM"
+    desc: "[Container] Antora xref validation — MLM (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:uyuni:
-    desc: "[Container] Antora xref validation — Uyuni"
+    desc: "[Container] Antora xref validation — Uyuni (all languages; override with LANGUAGES=en)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # Translations
   container:translations:


### PR DESCRIPTION
# Description

`task validate:mlm` and `task validate:uyuni` have never run: they `cd` into a `translations/` tree that nothing had generated and invoke `--generator @antora/xref-validator`, an obsolete Antora 2 plugin that is not installed in the builder image; they now do the same prep as the draft targets and let Antora 3 report broken xrefs itself via `--log-failure-level=error`.

# Target branches

- master (this PR)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5238
- manager-5.1 not affected, already fixed by https://github.com/uyuni-project/uyuni-docs/pull/5125

# Links
- Stopgap so validation works on the current toolchain; https://github.com/uyuni-project/uyuni-docs/pull/5123 and https://github.com/uyuni-project/uyuni-docs/pull/5124 replace this with the `stage-content` variant once the AI localization migration is backported from manager-5.1
