### PR TITLE
manager-5.1 - Remove the link to the SSL CA migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Removed a link to the SSL CA migration guide, which does not apply to this version
 - Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search
 - Documented deprecation and support limitations of plain salt-minion manual registration (bsc#1275658)
 - Added warning about known issues in Multi-Linux Manager 5.0 and 5.1 server upgrade guides (bsc#1274875)

--- a/en/modules/common-workflows/pages/workflow-cert-rotation-acme.adoc
+++ b/en/modules/common-workflows/pages/workflow-cert-rotation-acme.adoc
@@ -2,7 +2,7 @@
 [[workflow-cert-rotation-acme]]
 = Set up and rotate certificates using ACME
 :description: Setup and automatic rotation of third-party SSL/TLS certificates using the ACME protocol in containerized environments.
-:revdate: 2026-08-28
+:revdate: 2026-08-31
 :page-revdate: {revdate}
 :page-author: SUSE Product & Solution Documentation Team
 :page-image: https://www.suse.com/assets/img/suse-white-logo-green.svg
@@ -105,4 +105,3 @@ If upgrading a legacy server to a split database release (such as 2025.05), `mgr
 == Related topics
 
 * For details on importing custom certificates, see xref:administration:ssl-certs-imported.adoc[].
-* For CA migration information, see xref:administration:ssl-certs-ca-migration.adoc[].


### PR DESCRIPTION
# Description

Removes the Related topics link to the SSL CA migration guide, a page that does not exist on this branch because the `mgradm ssl addca` and `mgradm ssl rotate` commands it documents were never backported to 5.1.

# Target branches

- manager-5.1 (this PR)

# Links
- This PR fixes a dangling xref left by https://github.com/uyuni-project/uyuni-docs/pull/5223
