### PR TITLE
master - Build only English in CI

### DIFF
--- a/.github/workflows/build_and_archive_devel_docs.yml
+++ b/.github/workflows/build_and_archive_devel_docs.yml
@@ -14,10 +14,16 @@ on:
     types:
       - completed
 
+# Only English is archived here. Every artifact below is English, and
+# test_pdf_translations.yml covers the translated builds.
+#
+# publish:* already runs the PDF build, collection and zipping, so each product
+# archives its HTML and its PDFs from a single job.
+
 jobs:
 
-  # ── Uyuni HTML ─────────────────────────────────────────────────────────────
-  uyuni-html:
+  # ── Uyuni ──────────────────────────────────────────────────────────────────
+  uyuni:
     runs-on: ubuntu-latest
 
     container:
@@ -30,8 +36,8 @@ jobs:
     - name: Build toolchain binary and generate configs
       run: task setup && task gen
 
-    - name: Build Uyuni HTML documentation
-      run: task publish:uyuni
+    - name: Build Uyuni documentation (English)
+      run: task publish:uyuni LANGUAGES=en
 
     - name: Archive Uyuni HTML documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -39,63 +45,34 @@ jobs:
         name: documentation-uyuni-${{ github.ref_name }}
         path: build/en/
 
-  # ── MLM HTML ───────────────────────────────────────────────────────────────
-  mlm-html:
-    runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v4
-
-    - name: Build toolchain binary and generate configs
-      run: task setup && task gen
-
-    - name: Build SUSE Multi-Linux Manager HTML documentation
-      run: task publish:dsc
-
-    - name: Archive SUSE Multi-Linux Manager HTML documentation
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-      with:
-        name: documentation-suse-multi-linux-manager-${{ github.ref_name }}
-        path: build/en/
-
-  # ── PDFs — English only (for translator review) ────────────────────────────
-  pdfs:
-    runs-on: ubuntu-latest
-
-    container:
-      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v4
-
-    - name: Build toolchain binary and generate configs
-      run: task setup && task gen
-
-    - name: Build Uyuni PDFs (English)
-      run: task pdf:uyuni LANGUAGES=en
-
-    - name: Collect Uyuni PDFs
-      run: task pdf-collect:uyuni LANGUAGES=en
-
     - name: Archive Uyuni PDFs (English)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: documentation-uyuni-pdf-en-${{ github.ref_name }}
         path: build/pdf/en/
 
-    - name: Clean PDF output before MLM build
-      run: rm -rf build/pdf/en/
+  # ── SUSE Multi-Linux Manager ───────────────────────────────────────────────
+  mlm:
+    runs-on: ubuntu-latest
 
-    - name: Build SUSE Multi-Linux Manager PDFs (English)
-      run: task pdf:mlm LANGUAGES=en
+    container:
+      image: ghcr.io/uyuni-project/uyuni-docs-builder:latest
 
-    - name: Collect MLM PDFs
-      run: task pdf-collect:mlm LANGUAGES=en
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v4
+
+    - name: Build toolchain binary and generate configs
+      run: task setup && task gen
+
+    - name: Build SUSE Multi-Linux Manager documentation (English)
+      run: task publish:dsc LANGUAGES=en
+
+    - name: Archive SUSE Multi-Linux Manager HTML documentation
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+      with:
+        name: documentation-suse-multi-linux-manager-${{ github.ref_name }}
+        path: build/en/
 
     - name: Archive SUSE Multi-Linux Manager PDFs (English)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1

--- a/.github/workflows/test_pdf_translations.yml
+++ b/.github/workflows/test_pdf_translations.yml
@@ -44,6 +44,12 @@ jobs:
 
     # ── MLM translated PDFs (master only) ────────────────────────────────────
 
+    # Both products collect into build/pdf/, so clear it first; otherwise the
+    # MLM artifact carries the Uyuni PDFs as well.
+    - name: Clear collected PDFs before the MLM build
+      run: rm -rf build/pdf/
+      if: github.ref_name == 'master'
+
     - name: Build MLM PDFs (ja, ko, zh_CN)
       run: task pdf:mlm LANGUAGES="ja ko zh_CN"
       if: github.ref_name == 'master'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,16 @@ jobs:
     - name: Build toolchain binary and generate configs
       run: task setup && task gen
 
-    # ── Uyuni HTML ────────────────────────────────────────────────────────────
+    # Only English is built here. Every artifact below is English, and
+    # test_pdf_translations.yml covers the translated builds on master.
+    #
+    # publish:* already runs the PDF build, collection and zipping, so there are
+    # no separate PDF steps.
 
-    - name: Build Uyuni HTML documentation
-      run: task publish:uyuni
+    # ── Uyuni ─────────────────────────────────────────────────────────────────
+
+    - name: Build Uyuni documentation (English)
+      run: task publish:uyuni LANGUAGES=en
 
     - name: Upload Uyuni HTML documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -34,10 +40,22 @@ jobs:
         path: build/en/
         retention-days: 1
 
-    # ── MLM HTML ──────────────────────────────────────────────────────────────
+    - name: Upload Uyuni PDFs (English)
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
+      with:
+        name: uyuni-docs-pdf-en
+        path: build/pdf/en/
+        retention-days: 1
 
-    - name: Build SUSE Multi-Linux Manager HTML documentation
-      run: task publish:dsc
+    # Both products write into build/en/ and build/pdf/en/, so the MLM build
+    # starts from a clean tree; otherwise its artifacts carry the Uyuni output.
+    - name: Clear build output before the MLM build
+      run: rm -rf build/
+
+    # ── SUSE Multi-Linux Manager ──────────────────────────────────────────────
+
+    - name: Build SUSE Multi-Linux Manager documentation (English)
+      run: task publish:dsc LANGUAGES=en
 
     - name: Upload SUSE Multi-Linux Manager HTML documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
@@ -46,30 +64,9 @@ jobs:
         path: build/en/
         retention-days: 1
 
-    # ── PDFs — English only (for translator review) ───────────────────────────
-
-    - name: Build MLM PDFs (English)
-      run: task pdf:mlm LANGUAGES=en
-
-    - name: Collect MLM PDFs
-      run: task pdf-collect:mlm LANGUAGES=en
-
-    - name: Upload MLM PDFs (English)
+    - name: Upload SUSE Multi-Linux Manager PDFs (English)
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
       with:
         name: mlm-docs-pdf-en
-        path: build/pdf/en/
-        retention-days: 1
-
-    - name: Build Uyuni PDFs (English)
-      run: task pdf:uyuni LANGUAGES=en
-
-    - name: Collect Uyuni PDFs
-      run: task pdf-collect:uyuni LANGUAGES=en
-
-    - name: Upload Uyuni PDFs (English)
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1
-      with:
-        name: uyuni-docs-pdf-en
         path: build/pdf/en/
         retention-days: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Sped up CI by building only English, which is all the CI artifacts have ever contained
 - Clarified relationship between custom RBAC and Salt-API access
 - Extracted and relocated general sudo configuration guidelines to a new central page, and added unprivileged onboarding support references for SLE 16 (bsc#1275794)
 - Made JOBS=00 an error, which xargs read as unlimited concurrency


### PR DESCRIPTION
# Description

`publish:uyuni` and `publish:dsc` take the default `LANGUAGES`, so every pull request builds all four languages of HTML and PDFs even though the artifacts CI uploads have only ever been English; they now pass `LANGUAGES=en`, and the separate English PDF steps are gone because `publish:*` already builds, collects and zips exactly those PDFs.

Both products write into `build/en/` and `build/pdf/en/` and nothing cleared it between them, so each product's artifact also shipped the other product's PDFs; both builds now start from a clean tree. Translated PDF builds stay covered by `test_pdf_translations.yml` on master.

# Target branches

- master (this PR)
- https://github.com/uyuni-project/uyuni-docs/pull/5259
- https://github.com/uyuni-project/uyuni-docs/pull/5260
