### PR TITLE
manager-5.1 - Select documentation languages with LANGUAGES everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Made every build task select languages with LANGUAGES, so the LANG locale variable no longer silently broke single-book PDF builds
 - Added a CI check for the revision date of changed documentation pages
 - Removed a link to the SSL CA migration guide, which does not apply to this version
 - Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Made every build task select languages with LANGUAGES, so the LANG locale variable no longer silently broke single-book PDF builds
+- Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages
 - Removed a link to the SSL CA migration guide, which does not apply to this version
 - Fixed noindex guards so product-specific pages no longer appear in the other product's documentation search

--- a/L10N-AI-MIGRATION.md
+++ b/L10N-AI-MIGRATION.md
@@ -88,7 +88,7 @@ Missing (filled from English at build time):
 task setup && task gen
 task stage-content
 task draft:mlm-dsc LANGUAGES="en ja ko zh_CN"
-task pdf BOOK=administration PRODUCT=mlm LANG=ja
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=ja
 task pdf:mlm LANGUAGES="ja ko zh_CN"
 task publish:dsc LANGUAGES=en
 task validate:mlm LANGUAGES=en

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -405,7 +405,7 @@ tasks:
   # --------------------------------------------------------------------------
   pdf-collect:mlm:
     desc: "[Dev] Collect MLM PDFs from build/{lang}/pdf/ into build/pdf/{lang}/"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - |
         PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product mlm)
@@ -413,7 +413,7 @@ tasks:
 
   pdf-collect:uyuni:
     desc: "[Dev] Collect Uyuni PDFs from build/{lang}/pdf/ into build/pdf/{lang}/"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - |
         PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product uyuni)
@@ -774,13 +774,15 @@ tasks:
   # OBS packages
   container:obs:mlm:
     desc: "[Container] OBS source packages for MLM"
+    deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:mlm"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:obs:uyuni:
     desc: "[Container] OBS source packages for Uyuni"
+    deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:uyuni"
+      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # Validation
   container:validate:mlm:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,7 +37,6 @@
 #    task container:draft:uyuni-webui               Uyuni HTML — product WebUI (all languages)
 #    task container:draft:all                       All four HTML output targets
 #    (All draft/publish/pdf container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
-#    (It is LANGUAGES, not LANG. LANG is the POSIX locale and selects no documentation language.)
 #    task container:pdf:mlm             All MLM PDFs
 #    task container:pdf:uyuni           All Uyuni PDFs
 #    task container:pdf:all             All PDFs
@@ -114,8 +113,7 @@ tasks:
         echo "    Example:  task container:draft:mlm-dsc LANGUAGES=en"
         echo "    Example:  task draft:uyuni-website LANGUAGES=\"en ja\""
         echo "    Example:  task publish:dsc LANGUAGES=en"
-        echo "    Note:     it is LANGUAGES, not LANG — LANG is the POSIX locale and selects"
-        echo "              nothing here. Every task, including 'task pdf', takes LANGUAGES."
+        echo "    Every task, including 'task pdf', takes LANGUAGES."
         echo ""
         echo "  ── LOCAL  (Go + Task + Antora + asciidoctor-pdf installed locally) ──────────"
         echo "    publish:dsc              Full MLM publish — HTML (d.s.c branding) + PDFs + zips"
@@ -153,30 +151,26 @@ tasks:
         echo ""
 
   # --------------------------------------------------------------------------
-  # Guard — LANGUAGES selects the documentation languages. LANG does not, and
-  # never did: it is the POSIX locale variable, every shell sets it, and Task
-  # exposes the environment as template variables. Nothing here reads LANG as a
-  # documentation code, so a stray LANG= is silently ignored and the build
-  # quietly does every language.
+  # Guard — LANGUAGES selects the documentation languages.
   #
-  # Only bare documentation codes trip this. An inherited locale is
-  # 'en_US.UTF-8' or 'C', never a bare 'en', so a normal shell never trips it.
+  # Matches bare documentation codes only, so an inherited POSIX locale
+  # ('en_US.UTF-8', 'C') passes straight through. The value reaches the script
+  # as an environment variable rather than as templated text, so a LANG holding
+  # shell metacharacters is compared, not executed.
   # --------------------------------------------------------------------------
   _guard-lang:
     internal: true
     silent: true
+    env:
+      GUARD_LANG: '{{.LANG}}'
     cmds:
       - |
         for L in {{.DOC_LANGUAGES}}; do
-          [ "$L" = "{{.LANG}}" ] || continue
-          echo ""                                                       >&2
-          echo "  ERROR: LANG={{.LANG}} does not select a documentation language." >&2
-          echo "         This build would have run every language:"     >&2
-          echo "           {{.LANGUAGES}}"                              >&2
-          echo ""                                                       >&2
-          echo "         Use LANGUAGES instead:"                        >&2
-          echo "           task <target> LANGUAGES={{.LANG}}"           >&2
-          echo ""                                                       >&2
+          [ "$L" = "${GUARD_LANG:-}" ] || continue
+          echo ""                                                          >&2
+          echo "  ERROR: use LANGUAGES to select documentation languages." >&2
+          echo "           task <target> LANGUAGES=${GUARD_LANG}"          >&2
+          echo ""                                                          >&2
           exit 1
         done
 
@@ -283,9 +277,8 @@ tasks:
   # Usage: task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
   #
   # Like every other task, this iterates LANGUAGES and defaults to all of them.
-  # LANG_CODE below is the documentation code; LANG is left alone so it keeps
-  # meaning what it means everywhere else — the POSIX locale, which this task
-  # does set, to the value in LOCALE, for date formatting and asciidoctor-pdf.
+  # LANG_CODE is the documentation code. LANG is the POSIX locale, set from
+  # LOCALE for date formatting and asciidoctor-pdf.
   # --------------------------------------------------------------------------
   pdf:
     desc: "[Local] Build one PDF book — usage: task pdf BOOK=<book> PRODUCT=<product> LANGUAGES=<langs>"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,7 @@
 #    task container:draft:uyuni-webui               Uyuni HTML — product WebUI (all languages)
 #    task container:draft:all                       All four HTML output targets
 #    (All draft/publish/pdf container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
+#    (It is LANGUAGES, not LANG. LANG is the POSIX locale and selects no documentation language.)
 #    task container:pdf:mlm             All MLM PDFs
 #    task container:pdf:uyuni           All Uyuni PDFs
 #    task container:pdf:all             All PDFs
@@ -61,7 +62,11 @@ vars:
   PDF_THEMES_DIR: "{{.ROOT_DIR}}/branding/pdf/themes"
   PDF_FONTS_DIR: "{{.ROOT_DIR}}/branding/pdf/fonts"
   XREF_EXT: "{{.ROOT_DIR}}/.bin/xref-converter.rb"
-  LANGUAGES: "en ja zh_CN ko"
+  # DOC_LANGUAGES is the canonical set and stays fixed; LANGUAGES is what every
+  # task iterates and is what you override on the command line. The _guard-lang
+  # check needs the full set even when LANGUAGES is narrowed.
+  DOC_LANGUAGES: "en ja zh_CN ko"
+  LANGUAGES: "{{.DOC_LANGUAGES}}"
   BOOKS: "installation-and-upgrade client-configuration administration reference retail common-workflows specialized-guides legal"
   CONTAINER_CMD:
     sh: which podman 2>/dev/null || which docker 2>/dev/null || echo "podman"
@@ -109,6 +114,8 @@ tasks:
         echo "    Example:  task container:draft:mlm-dsc LANGUAGES=en"
         echo "    Example:  task draft:uyuni-website LANGUAGES=\"en ja\""
         echo "    Example:  task publish:dsc LANGUAGES=en"
+        echo "    Note:     it is LANGUAGES, not LANG — LANG is the POSIX locale and selects"
+        echo "              nothing here. Every task, including 'task pdf', takes LANGUAGES."
         echo ""
         echo "  ── LOCAL  (Go + Task + Antora + asciidoctor-pdf installed locally) ──────────"
         echo "    publish:dsc              Full MLM publish — HTML (d.s.c branding) + PDFs + zips"
@@ -122,16 +129,16 @@ tasks:
         echo "    obs:uyuni                OBS source packages for Uyuni"
         echo "    (All local tasks accept LANGUAGES=en or LANGUAGES=\"en ja\" to limit languages)"
         echo ""
-        echo "  ── SINGLE BOOK PDF ──────────────────────────────────────────────────────────"
-        echo "    task pdf BOOK=<book> PRODUCT=<product> LANG=<lang>"
+        echo "  ── ONE BOOK PDF ─────────────────────────────────────────────────────────────"
+        echo "    task pdf BOOK=<book> PRODUCT=<product> LANGUAGES=<langs>"
         echo ""
         echo "    Books:    installation-and-upgrade  client-configuration  administration"
         echo "              reference  retail  common-workflows  specialized-guides  legal"
         echo "    Products: mlm  uyuni"
-        echo "    Languages: en  ja  zh_CN  ko"
+        echo "    Languages: en  ja  zh_CN  ko  (all of them unless you narrow it)"
         echo ""
-        echo "    Example:  task pdf BOOK=administration PRODUCT=mlm LANG=en"
-        echo "    Example:  task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANG=ja"
+        echo "    Example:  task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en"
+        echo "    Example:  task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=\"en ja\""
         echo ""
         echo "  ── DEV / TOOLING ────────────────────────────────────────────────────────────"
         echo "    setup              Build the Go toolchain binary (.bin/docbuild)"
@@ -144,6 +151,34 @@ tasks:
         echo ""
         echo "  Run 'task --summary <task>' for details  |  'task --list' for the full index"
         echo ""
+
+  # --------------------------------------------------------------------------
+  # Guard — LANGUAGES selects the documentation languages. LANG does not, and
+  # never did: it is the POSIX locale variable, every shell sets it, and Task
+  # exposes the environment as template variables. Nothing here reads LANG as a
+  # documentation code, so a stray LANG= is silently ignored and the build
+  # quietly does every language.
+  #
+  # Only bare documentation codes trip this. An inherited locale is
+  # 'en_US.UTF-8' or 'C', never a bare 'en', so a normal shell never trips it.
+  # --------------------------------------------------------------------------
+  _guard-lang:
+    internal: true
+    silent: true
+    cmds:
+      - |
+        for L in {{.DOC_LANGUAGES}}; do
+          [ "$L" = "{{.LANG}}" ] || continue
+          echo ""                                                       >&2
+          echo "  ERROR: LANG={{.LANG}} does not select a documentation language." >&2
+          echo "         This build would have run every language:"     >&2
+          echo "           {{.LANGUAGES}}"                              >&2
+          echo ""                                                       >&2
+          echo "         Use LANGUAGES instead:"                        >&2
+          echo "           task <target> LANGUAGES={{.LANG}}"           >&2
+          echo ""                                                       >&2
+          exit 1
+        done
 
   # --------------------------------------------------------------------------
   # Setup — build the Go binary
@@ -180,7 +215,7 @@ tasks:
   # --------------------------------------------------------------------------
   draft:mlm-dsc:
     desc: "[Draft] MLM HTML — documentation.suse.com branding (all languages)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -193,7 +228,7 @@ tasks:
 
   draft:mlm-webui:
     desc: "[Draft] MLM HTML — WebUI branding with language selector (all languages)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -208,7 +243,7 @@ tasks:
 
   draft:uyuni-website:
     desc: "[Draft] Uyuni HTML — website branding (all languages)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -221,7 +256,7 @@ tasks:
 
   draft:uyuni-webui:
     desc: "[Draft] Uyuni HTML — WebUI branding with language selector (all languages)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -236,6 +271,7 @@ tasks:
 
   draft:all:
     desc: "[Draft] All four HTML output targets (sequential)"
+    deps: [_guard-lang]
     cmds:
       - task: draft:mlm-dsc
       - task: draft:mlm-webui
@@ -243,121 +279,120 @@ tasks:
       - task: draft:uyuni-webui
 
   # --------------------------------------------------------------------------
-  # PDF builds — single book
-  # Usage: task pdf BOOK=administration PRODUCT=mlm LANG=en
+  # PDF builds — one book
+  # Usage: task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
+  #
+  # Like every other task, this iterates LANGUAGES and defaults to all of them.
+  # LANG_CODE below is the documentation code; LANG is left alone so it keeps
+  # meaning what it means everywhere else — the POSIX locale, which this task
+  # does set, to the value in LOCALE, for date formatting and asciidoctor-pdf.
   # --------------------------------------------------------------------------
   pdf:
-    desc: "[Local] Build a single PDF book — usage: task pdf BOOK=<book> PRODUCT=<product> LANG=<lang>"
-    deps: [gen, setup]
+    desc: "[Local] Build one PDF book — usage: task pdf BOOK=<book> PRODUCT=<product> LANGUAGES=<langs>"
+    deps: [gen, setup, _guard-lang]
     vars:
       BOOK: '{{default "administration" .BOOK}}'
       PRODUCT: '{{default "mlm" .PRODUCT}}'
-      LANG: '{{default "en" .LANG}}'
     cmds:
-      - |
-        BOOK="{{.BOOK}}"
-        PRODUCT="{{.PRODUCT}}"
-        LANG="{{.LANG}}"
+      - for: {var: LANGUAGES}
+        cmd: |
+          BOOK="{{.BOOK}}"
+          PRODUCT="{{.PRODUCT}}"
+          LANG_CODE="{{.ITEM}}"
 
-        # Resolve PDF theme from config.yml via docbuild (printed to stdout)
-        case "${PRODUCT}:${LANG}" in
-          mlm:ja)    THEME=suse-jp ;;
-          mlm:zh_CN) THEME=suse-sc ;;
-          mlm:ko)    THEME=suse-ko ;;
-          mlm:*)     THEME=suse ;;
-          uyuni:ja)    THEME=uyuni-cjk ;;
-          uyuni:zh_CN) THEME=uyuni-cjk ;;
-          uyuni:ko)    THEME=uyuni-cjk ;;
-          uyuni:*)     THEME=uyuni ;;
-        esac
+          # Resolve PDF theme from config.yml via docbuild (printed to stdout)
+          case "${PRODUCT}:${LANG_CODE}" in
+            mlm:ja)    THEME=suse-jp ;;
+            mlm:zh_CN) THEME=suse-sc ;;
+            mlm:ko)    THEME=suse-ko ;;
+            mlm:*)     THEME=suse ;;
+            uyuni:ja)    THEME=uyuni-cjk ;;
+            uyuni:zh_CN) THEME=uyuni-cjk ;;
+            uyuni:ko)    THEME=uyuni-cjk ;;
+            uyuni:*)     THEME=uyuni ;;
+          esac
 
-        # CJK attributes
-        case "${LANG}" in
-          ja|zh_CN|ko) CJK_ATTR="-a scripts=cjk" ;;
-          *)            CJK_ATTR="" ;;
-        esac
+          # CJK attributes
+          case "${LANG_CODE}" in
+            ja|zh_CN|ko) CJK_ATTR="-a scripts=cjk" ;;
+            *)            CJK_ATTR="" ;;
+          esac
 
-        # Locale for date formatting
-        case "${LANG}" in
-          ja)    LOCALE="ja_JP.UTF-8" ;;
-          zh_CN) LOCALE="zh_CN.UTF-8" ;;
-          ko)    LOCALE="ko_KR.UTF-8" ;;
-          *)     LOCALE="en_US.utf8" ;;
-        esac
+          # Locale for date formatting
+          case "${LANG_CODE}" in
+            ja)    LOCALE="ja_JP.UTF-8" ;;
+            zh_CN) LOCALE="zh_CN.UTF-8" ;;
+            ko)    LOCALE="ko_KR.UTF-8" ;;
+            *)     LOCALE="en_US.utf8" ;;
+          esac
 
-        # Date format
-        case "${LANG}" in
-          ja|zh_CN) DATE_FMT="%Y年%m月%e日" ;;
-          ko)       DATE_FMT="%Y년%m월%e일" ;;
-          *)        DATE_FMT="%B %d %Y" ;;
-        esac
+          # Date format
+          case "${LANG_CODE}" in
+            ja|zh_CN) DATE_FMT="%Y年%m月%e日" ;;
+            ko)       DATE_FMT="%Y년%m월%e일" ;;
+            *)        DATE_FMT="%B %d %Y" ;;
+          esac
 
-        REVDATE=$(LANG=${LOCALE} LC_ALL=${LOCALE} date +"${DATE_FMT}")
-        SRCDIR="translations/${LANG}"
-        OUTDIR="build/${LANG}/pdf"
-        mkdir -p "${OUTDIR}"
+          REVDATE=$(LANG=${LOCALE} LC_ALL=${LOCALE} date +"${DATE_FMT}")
+          SRCDIR="translations/${LANG_CODE}"
+          OUTDIR="build/${LANG_CODE}/pdf"
+          mkdir -p "${OUTDIR}"
 
-        # Stage content for this language (en base + translated overlay)
-        CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang ${LANG})
-        mkdir -p "${SRCDIR}/modules"
-        cp -a en/modules/. "${SRCDIR}/modules/"
-        if [ -d "${CONTENT_DIR}/modules" ]; then
-          cp -a "${CONTENT_DIR}/modules/." "${SRCDIR}/modules/"
-        fi
+          # Stage content for this language (en base + translated overlay)
+          CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang ${LANG_CODE})
+          mkdir -p "${SRCDIR}/modules"
+          cp -a en/modules/. "${SRCDIR}/modules/"
+          if [ -d "${CONTENT_DIR}/modules" ]; then
+            cp -a "${CONTENT_DIR}/modules/." "${SRCDIR}/modules/"
+          fi
 
-        # Resolve PDF filename prefix from config.yml (e.g. suse_multi_linux_manager or uyuni)
-        PDF_PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product ${PRODUCT})
+          # Resolve PDF filename prefix from config.yml (e.g. suse_multi_linux_manager or uyuni)
+          PDF_PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product ${PRODUCT})
 
-        # Generate PDF nav file from Antora nav
-        {{.DOCBUILD}} gen-pdf-nav -book ${BOOK} -lang ${LANG} -dir ${SRCDIR}/modules/${BOOK}
+          # Generate PDF nav file from Antora nav
+          {{.DOCBUILD}} gen-pdf-nav -book ${BOOK} -lang ${LANG_CODE} -dir ${SRCDIR}/modules/${BOOK}
 
-        # Generate self-contained entities.adoc for this product/lang
-        # (written to translations/${LANG}/branding/pdf/entities.adoc)
-        {{.DOCBUILD}} gen-entities -product ${PRODUCT} -lang ${LANG}
+          # Generate self-contained entities.adoc for this product/lang
+          # (written to translations/${LANG_CODE}/branding/pdf/entities.adoc)
+          {{.DOCBUILD}} gen-entities -product ${PRODUCT} -lang ${LANG_CODE}
 
-        cd "${SRCDIR}"
-        LANG=${LOCALE} LC_ALL=${LOCALE} asciidoctor-pdf \
-          -r {{.XREF_EXT}} \
-          -a lang=${LANG} \
-          -a pdf-themesdir={{.PDF_THEMES_DIR}}/ \
-          -a pdf-theme=${THEME} \
-          -a pdf-fontsdir={{.PDF_FONTS_DIR}} \
-          -a revdate="${REVDATE}" \
-          -a examplesdir=modules/${BOOK}/examples \
-          -a imagesdir=modules/${BOOK}/assets/images \
-          ${CJK_ATTR} \
-          --base-dir . \
-          --out-file {{.ROOT_DIR}}/${OUTDIR}/${PDF_PREFIX}_${BOOK}_guide.pdf \
-          modules/${BOOK}/nav-${BOOK}-guide.pdf.${LANG}.adoc \
-          --failure-level FATAL \
-          --trace
+          cd "${SRCDIR}"
+          LANG=${LOCALE} LC_ALL=${LOCALE} asciidoctor-pdf \
+            -r {{.XREF_EXT}} \
+            -a lang=${LANG_CODE} \
+            -a pdf-themesdir={{.PDF_THEMES_DIR}}/ \
+            -a pdf-theme=${THEME} \
+            -a pdf-fontsdir={{.PDF_FONTS_DIR}} \
+            -a revdate="${REVDATE}" \
+            -a examplesdir=modules/${BOOK}/examples \
+            -a imagesdir=modules/${BOOK}/assets/images \
+            ${CJK_ATTR} \
+            --base-dir . \
+            --out-file {{.ROOT_DIR}}/${OUTDIR}/${PDF_PREFIX}_${BOOK}_guide.pdf \
+            modules/${BOOK}/nav-${BOOK}-guide.pdf.${LANG_CODE}.adoc \
+            --failure-level FATAL \
+            --trace
 
   # --------------------------------------------------------------------------
   # PDF builds — all books for a product
   # --------------------------------------------------------------------------
+  # Only the book loop lives here — 'pdf' iterates LANGUAGES itself, so the
+  # language loop exists in exactly one place.
   pdf:mlm:
     desc: "[Local] Build all MLM PDFs — all books, all languages"
-    deps: [gen]
+    deps: [gen, _guard-lang]
     cmds:
       - task: stage-content
-      - for: {var: LANGUAGES}
-        cmd: |
-          LANG_CODE="{{.ITEM}}"
-          for BOOK in {{.BOOKS}}; do
-            task pdf BOOK=${BOOK} PRODUCT=mlm LANG=${LANG_CODE}
-          done
+      - for: {var: BOOKS}
+        cmd: task pdf BOOK={{.ITEM}} PRODUCT=mlm LANGUAGES="{{.LANGUAGES}}"
 
   pdf:uyuni:
     desc: "[Local] Build all Uyuni PDFs — all books, all languages"
-    deps: [gen]
+    deps: [gen, _guard-lang]
     cmds:
       - task: stage-content
-      - for: {var: LANGUAGES}
-        cmd: |
-          LANG_CODE="{{.ITEM}}"
-          for BOOK in {{.BOOKS}}; do
-            task pdf BOOK=${BOOK} PRODUCT=uyuni LANG=${LANG_CODE}
-          done
+      - for: {var: BOOKS}
+        cmd: task pdf BOOK={{.ITEM}} PRODUCT=uyuni LANGUAGES="{{.LANGUAGES}}"
 
   pdf:all:
     desc: "[Local] Build all PDFs — both products, all languages"
@@ -389,7 +424,7 @@ tasks:
   # --------------------------------------------------------------------------
   publish:dsc:
     desc: "[Local] Full MLM publish — HTML (d.s.c branding) + PDFs + zip archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:mlm-dsc
       - task: pdf:mlm
@@ -398,7 +433,7 @@ tasks:
 
   publish:uyuni:
     desc: "[Local] Full Uyuni publish — HTML (website branding) + PDFs + zip archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:uyuni-website
       - task: pdf:uyuni
@@ -407,7 +442,7 @@ tasks:
 
   publish:webui-mlm:
     desc: "[Local] MLM WebUI publish — HTML (with language selector) + PDFs + zip archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:mlm-webui
       - task: pdf:mlm
@@ -416,7 +451,7 @@ tasks:
 
   publish:webui-uyuni:
     desc: "[Local] Uyuni WebUI publish — HTML (with language selector) + PDFs + zip archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:uyuni-webui
       - task: pdf:uyuni
@@ -430,91 +465,93 @@ tasks:
   # --------------------------------------------------------------------------
   pdf-zip:mlm:
     desc: "[Dev] Zip collected MLM PDFs into per-language archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
-          mkdir -p build/${LANG}
-          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG}/suse-multi-linux-manager-docs_${LANG}-pdf.zip ${LANG}/
+          LANG_CODE="{{.ITEM}}"
+          mkdir -p build/${LANG_CODE}
+          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/
 
   pdf-zip:uyuni:
     desc: "[Dev] Zip collected Uyuni PDFs into per-language archives"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
-          mkdir -p build/${LANG}
-          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG}/uyuni-docs_${LANG}-pdf.zip ${LANG}/
+          LANG_CODE="{{.ITEM}}"
+          mkdir -p build/${LANG_CODE}
+          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/
 
   # --------------------------------------------------------------------------
   # PDF tarballs — zip of all PDFs per product/language
   # --------------------------------------------------------------------------
   pdf-tar:mlm:
     desc: "[Dev] Create OBS-style PDF tarballs for MLM"
+    deps: [_guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
-          mkdir -p build/${LANG}
-          cd build && zip -r9 suse-multi-linux-manager-docs_${LANG}-pdf.zip ${LANG}/pdf/
-          mv build/suse-multi-linux-manager-docs_${LANG}-pdf.zip build/${LANG}/
+          LANG_CODE="{{.ITEM}}"
+          mkdir -p build/${LANG_CODE}
+          cd build && zip -r9 suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
+          mv build/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip build/${LANG_CODE}/
           mkdir -p build/packages
-          mv build/${LANG}/suse-multi-linux-manager-docs_${LANG}-pdf.zip build/packages/
+          mv build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip build/packages/
 
   pdf-tar:uyuni:
     desc: "[Dev] Create OBS-style PDF tarballs for Uyuni"
+    deps: [_guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
-          mkdir -p build/${LANG}
-          cd build && zip -r9 uyuni-docs_${LANG}-pdf.zip ${LANG}/pdf/
-          mv build/uyuni-docs_${LANG}-pdf.zip build/${LANG}/
+          LANG_CODE="{{.ITEM}}"
+          mkdir -p build/${LANG_CODE}
+          cd build && zip -r9 uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
+          mv build/uyuni-docs_${LANG_CODE}-pdf.zip build/${LANG_CODE}/
           mkdir -p build/packages
-          mv build/${LANG}/uyuni-docs_${LANG}-pdf.zip build/packages/
+          mv build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip build/packages/
 
   # --------------------------------------------------------------------------
   # OBS packages — HTML tar.gz + PDF tar.gz → build/packages/
   # --------------------------------------------------------------------------
   obs:mlm:
     desc: "[Local] Generate OBS packages for MLM (HTML + PDF tarballs)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:mlm-webui
       - task: pdf:mlm
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
+          LANG_CODE="{{.ITEM}}"
           # Rename PDFs to match legacy OBS filename convention:
           # mlm_{book}_guide.pdf → suse_multi_linux_manager_{book}_guide.pdf
-          for f in build/${LANG}/pdf/mlm_*.pdf; do
+          for f in build/${LANG_CODE}/pdf/mlm_*.pdf; do
             [ -f "$f" ] || continue
             mv "$f" "$(dirname "$f")/suse_multi_linux_manager_$(basename "$f" | sed 's/^mlm_//')"
           done
           mkdir -p build/packages
-          tar --exclude="build/${LANG}/pdf" \
-              -czvf build/packages/susemanager-docs_${LANG}.tar.gz \
-              -C {{.ROOT_DIR}} build/${LANG}
-          tar -czvf build/packages/susemanager-docs_${LANG}-pdf.tar.gz \
-              -C {{.ROOT_DIR}} build/${LANG}/pdf
+          tar --exclude="build/${LANG_CODE}/pdf" \
+              -czvf build/packages/susemanager-docs_${LANG_CODE}.tar.gz \
+              -C {{.ROOT_DIR}} build/${LANG_CODE}
+          tar -czvf build/packages/susemanager-docs_${LANG_CODE}-pdf.tar.gz \
+              -C {{.ROOT_DIR}} build/${LANG_CODE}/pdf
 
   obs:uyuni:
     desc: "[Local] Generate OBS packages for Uyuni (HTML + PDF tarballs)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: draft:uyuni-website
       - task: pdf:uyuni
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
+          LANG_CODE="{{.ITEM}}"
           mkdir -p build/packages
-          tar --exclude="build/${LANG}/pdf" \
-              -czvf build/packages/uyuni-docs_${LANG}.tar.gz \
-              -C {{.ROOT_DIR}} build/${LANG}
-          tar -czvf build/packages/uyuni-docs_${LANG}-pdf.tar.gz \
-              -C {{.ROOT_DIR}} build/${LANG}/pdf
+          tar --exclude="build/${LANG_CODE}/pdf" \
+              -czvf build/packages/uyuni-docs_${LANG_CODE}.tar.gz \
+              -C {{.ROOT_DIR}} build/${LANG_CODE}
+          tar -czvf build/packages/uyuni-docs_${LANG_CODE}-pdf.tar.gz \
+              -C {{.ROOT_DIR}} build/${LANG_CODE}/pdf
 
   # --------------------------------------------------------------------------
   # Validation
@@ -531,7 +568,7 @@ tasks:
 
   validate:mlm:
     desc: "[Local] Antora xref validation — MLM"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -544,7 +581,7 @@ tasks:
 
   validate:uyuni:
     desc: "[Local] Antora xref validation — Uyuni"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
@@ -560,21 +597,21 @@ tasks:
   # --------------------------------------------------------------------------
   stage-content:
     desc: "[Dev] Stage translated content for build (en base + lang overlay → translations/{lang}/modules/)"
-    deps: [setup]
+    deps: [setup, _guard-lang]
     # Stage once per run: pdf:all invokes pdf:mlm and pdf:uyuni as parallel deps,
     # and a concurrent removal of the tree makes the other invocation's cp fail.
     run: once
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
-          LANG="{{.ITEM}}"
-          CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang "${LANG}")
-          echo "==> Staging content for ${LANG} (source: ${CONTENT_DIR}/modules/)"
-          rm -rf translations/${LANG}/modules
-          mkdir -p translations/${LANG}/modules
-          cp -a en/modules/. translations/${LANG}/modules/
+          LANG_CODE="{{.ITEM}}"
+          CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang "${LANG_CODE}")
+          echo "==> Staging content for ${LANG_CODE} (source: ${CONTENT_DIR}/modules/)"
+          rm -rf translations/${LANG_CODE}/modules
+          mkdir -p translations/${LANG_CODE}/modules
+          cp -a en/modules/. translations/${LANG_CODE}/modules/
           if [ -d "${CONTENT_DIR}/modules" ]; then
-            cp -a "${CONTENT_DIR}/modules/." translations/${LANG}/modules/
+            cp -a "${CONTENT_DIR}/modules/." translations/${LANG_CODE}/modules/
           fi
 
   # --------------------------------------------------------------------------
@@ -662,63 +699,75 @@ tasks:
   # HTML builds
   container:draft:mlm-dsc:
     desc: "[Draft] MLM HTML — documentation.suse.com branding, via container (all languages; override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:mlm-webui:
     desc: "[Draft] MLM HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-website:
     desc: "[Draft] Uyuni HTML — website branding, via container (all languages; override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-website LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-webui:
     desc: "[Draft] Uyuni HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:all:
     desc: "[Draft] All four HTML output targets, via container (sequential; override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:all LANGUAGES='{{.LANGUAGES}}'"
 
   # PDF builds
   container:pdf:mlm:
     desc: "[Container] All MLM PDFs — all books, all languages (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:uyuni:
     desc: "[Container] All Uyuni PDFs — all books, all languages (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:all:
     desc: "[Container] All PDFs — both products, all languages (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:all LANGUAGES='{{.LANGUAGES}}'"
 
   # Publish targets
   container:publish:dsc:
     desc: "[Container] Full MLM publish — HTML (d.s.c branding) + PDFs + zips (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:uyuni:
     desc: "[Container] Full Uyuni publish — HTML (website branding) + PDFs + zips (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-mlm:
     desc: "[Container] MLM WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-uyuni:
     desc: "[Container] Uyuni WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-uyuni LANGUAGES='{{.LANGUAGES}}'"
 
@@ -736,11 +785,13 @@ tasks:
   # Validation
   container:validate:mlm:
     desc: "[Container] Antora xref validation — MLM"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:uyuni:
     desc: "[Container] Antora xref validation — Uyuni"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
@@ -753,12 +804,14 @@ tasks:
   # Content staging
   container:stage-content:
     desc: "[Container] Stage translated content for build"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task stage-content LANGUAGES='{{.LANGUAGES}}'"
 
   # Translations (deprecated)
   container:translations:
     desc: "[DEPRECATED] Use container:stage-content instead"
+    deps: [_guard-lang]
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task translations LANGUAGES='{{.LANGUAGES}}'"
 

--- a/docs/backport-plan-ai-localization-toolchain.md
+++ b/docs/backport-plan-ai-localization-toolchain.md
@@ -152,11 +152,11 @@ but the PDF backport is incomplete without them already present on the target br
 
 ```bash
 # English smoke test
-task pdf BOOK=client-configuration PRODUCT=mlm LANG=en
+task pdf BOOK=client-configuration PRODUCT=mlm LANGUAGES=en
 
 # CJK — requires translation trees on the branch (or English fallback where missing)
 task stage-content LANGUAGES="ja ko zh_CN"
-task pdf BOOK=client-configuration PRODUCT=mlm LANG=zh_CN
+task pdf BOOK=client-configuration PRODUCT=mlm LANGUAGES=zh_CN
 task pdf:mlm LANGUAGES="ja ko zh_CN"
 task pdf-collect:mlm LANGUAGES="ja ko zh_CN"
 ```
@@ -430,7 +430,7 @@ Repeat for suspect files under `{ja,ko,zh}/modules/` if present.
 ```bash
 task setup && task gen
 task stage-content LANGUAGES=zh_CN
-task pdf BOOK=client-configuration PRODUCT=mlm LANG=zh_CN
+task pdf BOOK=client-configuration PRODUCT=mlm LANGUAGES=zh_CN
 ```
 
 **3. Compare structure to English** when a localized page exists for the same path:
@@ -511,7 +511,7 @@ Run on the target branch after applying toolchain changes (English-only smoke te
 task setup && task gen
 task stage-content LANGUAGES=en
 task draft:mlm-dsc LANGUAGES=en
-task pdf BOOK=administration PRODUCT=mlm LANG=en
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
 task validate:mlm LANGUAGES=en
 ```
 
@@ -520,7 +520,7 @@ When translation directories are present on the branch:
 ```bash
 task stage-content
 task draft:mlm-dsc LANGUAGES="ja ko zh_CN"
-task pdf BOOK=administration PRODUCT=mlm LANG=ja
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=ja
 task container:publish:dsc    # full container smoke test
 task obs:mlm LANGUAGES="ja ko zh_CN"
 task obs:uyuni LANGUAGES="ja ko zh_CN"
@@ -549,7 +549,7 @@ Use when opening backport PRs to `master` or `manager-5.2`:
 - [ ] `docbuild get-content-dir -lang zh_CN` prints `zh`
 - [ ] `task stage-content LANGUAGES=en` succeeds
 - [ ] English HTML + PDF build succeeds
-- [ ] CJK PDF smoke test: `task pdf BOOK=administration PRODUCT=mlm LANG=zh_CN`
+- [ ] CJK PDF smoke test: `task pdf BOOK=administration PRODUCT=mlm LANGUAGES=zh_CN`
 - [ ] OBS smoke test: `task obs:mlm LANGUAGES=en` and `task obs:uyuni LANGUAGES=en` (CJK when translation trees present)
 - [ ] `test_pdf_translations.yml` passes (Uyuni theme consolidation: delete `uyuni-{jp,ko,sc}-theme.yml` if present)
 - [ ] CI workflows updated for correct branch names

--- a/docs/backport-plan-legacy-branches.md
+++ b/docs/backport-plan-legacy-branches.md
@@ -161,7 +161,7 @@ Also diff the shared `asciidoc:` attributes block against `manager-5.1` `paramet
 ```bash
 task setup && task gen
 task draft:mlm-dsc
-task pdf BOOK=administration PRODUCT=mlm LANG=en
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
 ```
 
 ---
@@ -252,7 +252,7 @@ Replace with the correct SUSE Manager / `suma` URL patterns for this branch.
 ```bash
 task setup && task gen
 task draft:suma-dsc
-task pdf BOOK=administration PRODUCT=suma LANG=en
+task pdf BOOK=administration PRODUCT=suma LANGUAGES=en
 ```
 
 ---
@@ -286,7 +286,7 @@ Check the `[po4a_langs]` header in any `l10n-weblate/*.cfg` file. If manager-4.3
 ```bash
 task setup && task gen
 task draft:suma-dsc
-task pdf BOOK=administration PRODUCT=suma LANG=en
+task pdf BOOK=administration PRODUCT=suma LANGUAGES=en
 ```
 
 ---
@@ -316,6 +316,6 @@ Do not push to any branch until the local smoke test passes.
 [ ] GHA build/test workflows updated: uyuni-docs-helper removed, podman + task added
 [ ] task setup && task gen runs without error
 [ ] task draft:<product>-dsc produces valid HTML output
-[ ] task pdf BOOK=administration PRODUCT=<product> LANG=en produces a PDF
+[ ] task pdf BOOK=administration PRODUCT=<product> LANGUAGES=en produces a PDF
 [ ] cd l10n-weblate && bash update-cfg-files → no unexpected diff
 ```

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -112,17 +112,24 @@ task container:pdf:uyuni              # All Uyuni PDFs — all books, all langua
 task container:pdf:all                # All PDFs
 ```
 
-### Build a single PDF book
+### Build one PDF book
 
-Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANG=` variables:
+Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:
 
 ```bash
 # Build the Administration Guide for MLM in English
-task pdf BOOK=administration PRODUCT=mlm LANG=en
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
 
 # Build the Installation and Upgrade Guide for Uyuni in Japanese
-task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANG=ja
+task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
+
+# Build one book in several languages
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
 ```
+
+Without `LANGUAGES=` this builds the book in every language. It is `LANGUAGES`,
+not `LANG`: `LANG` is the POSIX locale variable, every shell sets it, and no
+task reads it as a documentation language.
 
 Available books: `installation-and-upgrade` `client-configuration` `administration` `reference` `retail` `common-workflows` `specialized-guides` `legal`
 

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -127,9 +127,7 @@ task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
 task pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
 ```
 
-Without `LANGUAGES=` this builds the book in every language. It is `LANGUAGES`,
-not `LANG`: `LANG` is the POSIX locale variable, every shell sets it, and no
-task reads it as a documentation language.
+Without `LANGUAGES=` this builds the book in every language.
 
 Available books: `installation-and-upgrade` `client-configuration` `administration` `reference` `retail` `common-workflows` `specialized-guides` `legal`
 

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -190,9 +190,7 @@ task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
 task pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
 ```
 
-Without `LANGUAGES=` this builds the book in every language. It is `LANGUAGES`,
-not `LANG`: `LANG` is the POSIX locale variable, every shell sets it, and no
-task reads it as a documentation language.
+Without `LANGUAGES=` this builds the book in every language.
 
 Available books: `installation-and-upgrade` `client-configuration` `administration` `reference` `retail` `common-workflows` `specialized-guides` `legal`
 

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -175,17 +175,24 @@ task validate:uyuni         # Antora xref validation — Uyuni
 task clean                  # Remove build/, translations/, .cache/
 ```
 
-### Build a single PDF book
+### Build one PDF book
 
-Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANG=` variables:
+Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:
 
 ```bash
 # Build the Administration Guide for MLM in English
-task pdf BOOK=administration PRODUCT=mlm LANG=en
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
 
 # Build the Installation and Upgrade Guide for Uyuni in Japanese
-task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANG=ja
+task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
+
+# Build one book in several languages
+task pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
 ```
+
+Without `LANGUAGES=` this builds the book in every language. It is `LANGUAGES`,
+not `LANG`: `LANG` is the POSIX locale variable, every shell sets it, and no
+task reads it as a documentation language.
 
 Available books: `installation-and-upgrade` `client-configuration` `administration` `reference` `retail` `common-workflows` `specialized-guides` `legal`
 

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -260,7 +260,7 @@ task draft:uyuni-website           Uyuni HTML — website branding (all language
 task draft:uyuni-webui             Uyuni HTML — WebUI branding with language selector (all languages)
 task draft:all                     All four HTML output targets (sequential)
 
-task pdf BOOK=<b> PRODUCT=<p> LANG=<l>   Single book PDF
+task pdf BOOK=<b> PRODUCT=<p> LANGUAGES=<l>  One book PDF, one or more languages
 task pdf:mlm                       All 8 books × 4 languages — MLM (runs stage-content first)
 task pdf:uyuni                     All 8 books × 4 languages — Uyuni (runs stage-content first)
 task pdf:all                       Both products


### PR DESCRIPTION
# Description

Backport of #5246: the pdf task now iterates LANGUAGES like every other task, so the POSIX LANG locale variable no longer shadows the documentation language and silently breaks one-book PDF builds.

Re-derived rather than cherry-picked, because 5.1's pdf task has diverged from master — it keeps its own deps, a single uyuni-cjk theme instead of three per-language themes, and get-content-dir staging with a translated overlay — and taking master's version wholesale would have regressed all three. Dry-run output was compared against 5.1's pre-change Taskfile: every leaf task emits byte-identical commands apart from the shell-local LANG to LANG_CODE rename, and pdf:mlm and pdf:uyuni cover the same 32 book and language pairs in a book-only loop.

# Target branches

manager-5.1

# Links

https://github.com/uyuni-project/uyuni-docs/pull/5246