### PR TITLE
manager-5.1 - Build PDFs concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 - Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
-- Fixed the pdf-tar tasks, which never produced an archive and packaged both products into each one
-- Made an empty or misspelled LANGUAGES stop the build instead of producing nothing and reporting success
+- Fixed the pdf-tar tasks, which produced no archive and packaged both products into each one
+- Made an empty or incorrect LANGUAGES stop the build instead of reporting success with no output
 - Made an exported LANGUAGES set the default language selection
 - Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 - Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
-- Fixed the pdf-tar tasks, which never produced an archive
+- Fixed the pdf-tar tasks, which never produced an archive and packaged both products into each one
 - Made an empty or misspelled LANGUAGES stop the build instead of producing nothing and reporting success
+- Made an exported LANGUAGES set the default language selection
 - Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages
 - Removed a link to the SSL CA migration guide, which does not apply to this version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Sped up PDF builds by building books concurrently; cap concurrency with JOBS=<n>
+- Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
 - Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages
 - Removed a link to the SSL CA migration guide, which does not apply to this version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 - Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
+- Fixed the pdf-tar tasks, which never produced an archive
+- Made an empty or misspelled LANGUAGES stop the build instead of producing nothing and reporting success
 - Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages
 - Removed a link to the SSL CA migration guide, which does not apply to this version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Sped up PDF builds by building books concurrently; cap concurrency with JOBS=<n>
+- Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
 - Made every build task select languages with LANGUAGES
 - Added a CI check for the revision date of changed documentation pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Made JOBS=00 an error, which xargs read as unlimited concurrency
+- Fixed the PDF archive tasks, which failed when the checkout path contains a space
 - Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
 - Fixed the pdf-tar tasks, which produced no archive and packaged both products into each one

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,9 +64,7 @@ vars:
   XREF_EXT: "{{.ROOT_DIR}}/.bin/xref-converter.rb"
   # DOC_LANGUAGES is the canonical set and stays fixed. LANGUAGES is the set
   # that each build task iterates, and the one you override on the command
-  # line. The 'translations' task is the exception: po4a reads the .po files
-  # directly and processes every language. _guard-lang needs the full set even
-  # when LANGUAGES is narrow.
+  # line. _guard-lang needs the full set even when LANGUAGES is narrow.
   DOC_LANGUAGES: "en ja zh_CN ko"
   # A Taskfile 'vars' entry has a higher precedence than the OS environment.
   # Read the environment here, or 'export LANGUAGES=en' does nothing and the

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -624,8 +624,10 @@ tasks:
   # build/{lang}/pdf/ holds the books of the two products. Select the books
   # with the filename prefix of the product. Without the prefix, the two
   # archives get the same content and are different only in the name.
-  # 'pdf-zip:*' prevents this in a different way: it reads build/pdf/{lang}/,
-  # which 'pdf-collect:{product}' fills for one product at a time.
+  #
+  # 'pdf-zip:*' still has this defect. It reads build/pdf/{lang}/, which
+  # 'pdf-collect:{product}' adds to but never empties, thus a run of the two
+  # products in one tree gives each archive the books of both.
   #
   # zip adds files to an archive that exists. Remove the old archive first, or
   # a book that a later run does not build stays in it.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -844,8 +844,12 @@ tasks:
 
   container:run:
     desc: "[Container] Run any task inside the container (escape hatch: task container:run -- <target>)"
+    # Carries the same two variables as every other container task. The named
+    # tasks put LANGUAGES on the inner command line; this one cannot, because
+    # the caller owns that line, so it goes through the environment. A
+    # 'LANGUAGES=' inside CLI_ARGS is a higher precedence and still wins.
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task {{.CLI_ARGS}}"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -e LANGUAGES='{{.LANGUAGES}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task {{.CLI_ARGS}}"
 
   # HTML builds
   container:draft:mlm-dsc:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -597,7 +597,7 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip"
           mkdir -p build/${LANG_CODE}
           rm -f "${ARCHIVE}"
           cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
@@ -609,7 +609,7 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip"
           mkdir -p build/${LANG_CODE}
           rm -f "${ARCHIVE}"
           cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
@@ -638,7 +638,7 @@ tasks:
         cmd: |
           LANG_CODE="{{.ITEM}}"
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product mlm)
-          ARCHIVE={{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip"
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
             echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:mlm LANGUAGES=${LANG_CODE}' first." >&2
             exit 1
@@ -655,7 +655,7 @@ tasks:
         cmd: |
           LANG_CODE="{{.ITEM}}"
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product uyuni)
-          ARCHIVE={{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip"
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
             echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:uyuni LANGUAGES=${LANG_CODE}' first." >&2
             exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -62,18 +62,17 @@ vars:
   PDF_THEMES_DIR: "{{.ROOT_DIR}}/branding/pdf/themes"
   PDF_FONTS_DIR: "{{.ROOT_DIR}}/branding/pdf/fonts"
   XREF_EXT: "{{.ROOT_DIR}}/.bin/xref-converter.rb"
-  # DOC_LANGUAGES is the canonical set and stays fixed; LANGUAGES is what every
-  # build task iterates and is what you override on the command line. The
-  # 'translations' task is the exception: po4a reads the .po files directly and
-  # always processes every language. The _guard-lang check needs the full set
-  # even when LANGUAGES is narrowed.
+  # DOC_LANGUAGES is the canonical set and stays fixed. LANGUAGES is the set
+  # that each build task iterates, and the one you override on the command
+  # line. The 'translations' task is the exception: po4a reads the .po files
+  # directly and processes every language. _guard-lang needs the full set even
+  # when LANGUAGES is narrow.
   DOC_LANGUAGES: "en ja zh_CN ko"
-  # A Taskfile 'vars' entry beats the OS environment, so a plain
-  # 'LANGUAGES: "{{.DOC_LANGUAGES}}"' makes 'export LANGUAGES=en' do nothing at
-  # all: the caller narrows the build and gets every language, without a
-  # message. Read the environment here instead. A command-line 'LANGUAGES=' is
-  # a higher precedence than this whole entry and still wins. _guard-lang
-  # validates the result, whichever of the three it came from.
+  # A Taskfile 'vars' entry has a higher precedence than the OS environment.
+  # Read the environment here, or 'export LANGUAGES=en' does nothing and the
+  # caller gets every language without a message. A command-line 'LANGUAGES='
+  # has a higher precedence than this entry and wins. _guard-lang validates the
+  # result from all three sources.
   LANGUAGES: '{{default .DOC_LANGUAGES (env "LANGUAGES")}}'
   BOOKS: "installation-and-upgrade client-configuration administration reference retail common-workflows specialized-guides legal"
   CONTAINER_CMD:
@@ -174,29 +173,29 @@ tasks:
   # --------------------------------------------------------------------------
   # Guard — LANGUAGES selects the documentation languages.
   #
-  # The first check matches bare documentation codes only, so an inherited POSIX
-  # locale ('en_US.UTF-8', 'C') passes straight through.
+  # Check 1 matches bare documentation codes only, so an inherited POSIX locale
+  # ('en_US.UTF-8', 'C') passes.
   #
-  # The second and third checks are what makes LANGUAGES safe to trust. A
-  # 'for: {var: LANGUAGES}' loop over an empty value runs zero iterations and
-  # exits 0, so 'task pdf:mlm LANGUAGES=$LANGS' with LANGS unset builds no PDFs
-  # and reports success, and the pdf-collect, pdf-zip and obs steps then package
-  # and publish an empty tree. An unknown code such as 'jp' is the same failure
-  # with a different cause. Every task that loops over LANGUAGES depends on this
-  # guard, so one check here covers all of them.
+  # Checks 2 and 3 make LANGUAGES safe to trust. A 'for: {var: LANGUAGES}' loop
+  # over an empty value runs no iterations and exits 0: the build makes no
+  # PDFs, reports success, and the pdf-collect, pdf-zip and obs steps then
+  # publish an empty tree. An unknown code such as 'jp' has the same result.
+  # Every task that iterates LANGUAGES depends on this guard, so one check
+  # covers all of them.
   #
   # The checks are 'preconditions', not 'cmds'. Task skips the commands of a
-  # dependency under '--dry' but still evaluates its preconditions, so this is
-  # the only form that catches a bad selection in a dry run. It also keeps the
-  # message out of the printed command list.
+  # dependency under '--dry' but evaluates its preconditions, so only this form
+  # catches a bad selection in a dry run. It also keeps the message out of the
+  # printed command list.
   #
-  # Both values reach the test scripts as environment variables rather than as
-  # templated text, so a value holding shell metacharacters is compared, not
-  # executed. A precondition inherits the task's 'env' block.
+  # Both values reach the test scripts as environment variables, not as
+  # templated text. A check therefore compares a value that holds shell
+  # metacharacters and does not execute it. A precondition inherits the task's
+  # 'env' block.
   #
-  # 'msg' cannot name the offending code, because Task renders it from the
-  # template context and not from the script. Each message prints the whole
-  # value instead, which is as much as the reader needs.
+  # Task renders 'msg' from the template context and not from the script, so a
+  # message cannot name the code that failed. Each message prints the full
+  # value.
   # --------------------------------------------------------------------------
   _guard-lang:
     internal: true
@@ -217,21 +216,21 @@ tasks:
                    Use LANGUAGES instead:
                      task <target> LANGUAGES={{.LANG}}
 
-      # Unquoted, so the word split drops the whitespace. An empty result means
-      # LANGUAGES held nothing but spaces, tabs or newlines.
+      # Unquoted, so the word split removes the whitespace. An empty result
+      # means that LANGUAGES contains only spaces, tabs or newlines.
       - sh: |
           set -- ${GUARD_LANGUAGES:-}
           test $# -gt 0
         msg: |2
 
-            ERROR: LANGUAGES is empty, so this build would produce nothing
-                   and still report success.
+            ERROR: LANGUAGES is empty. This build makes no output and
+                   reports success.
                      task <target> LANGUAGES="{{.DOC_LANGUAGES}}"
 
       - sh: |
           for want in ${GUARD_LANGUAGES:-} ; do
-            # A flag, not 'break 2'. Under errexit a failing '[ ] &&' list at
-            # the end of a loop body ends the whole check.
+            # A flag, not 'break 2'. Under errexit, a failed '[ ] &&' list at
+            # the end of a loop body stops the whole check.
             known=0
             for have in {{.DOC_LANGUAGES}} ; do
               if [ "$want" = "$have" ] ; then
@@ -245,7 +244,7 @@ tasks:
           done
         msg: |2
 
-            ERROR: LANGUAGES="{{.LANGUAGES}}" names something that is not a
+            ERROR: LANGUAGES="{{.LANGUAGES}}" contains a value that is not a
                    documentation language.
                      choose from: {{.DOC_LANGUAGES}}
 
@@ -518,7 +517,7 @@ tasks:
   # The products run in sequence, not as parallel deps. Both write
   # translations/{lang}/branding/pdf/entities.adoc, which has no product in its
   # path. A parallel run puts one product's entities in the other product's
-  # PDFs. One product usually saturates the cores, so the sequence costs little.
+  # PDFs. One product usually uses all the cores, so the sequence costs little.
   pdf:all:
     desc: "[Local] Build all PDFs — both products, all languages"
     cmds:
@@ -588,9 +587,10 @@ tasks:
   # Zips land at build/{lang}/{product}_{lang}-pdf.zip so the index page link
   # "../{product}_{lang}-pdf.zip" resolves correctly from the HTML output dir.
   #
-  # zip adds to an archive that already exists. Remove the old one, or a book
-  # that a later run no longer builds stays in it, and a renamed book ships
-  # twice. 'task clean' hides this; a repeat build in place does not.
+  # zip adds files to an archive that exists. Remove the old archive first, or
+  # a book that a later run does not build stays in it, and a renamed book is
+  # present with the old name and the new name. 'task clean' hides this. A
+  # repeat build in place does not.
   # --------------------------------------------------------------------------
   pdf-zip:mlm:
     desc: "[Dev] Zip collected MLM PDFs into per-language archives"
@@ -619,19 +619,18 @@ tasks:
   # --------------------------------------------------------------------------
   # PDF archives — one zip of all PDFs for each product and language
   #
-  # Task runs one interpreter for each multi-line 'cmd', so the 'cd' holds for
+  # Task runs one interpreter for each multi-line 'cmd', so the 'cd' applies to
   # the rest of the block. Give zip an absolute destination, as 'pdf-zip:*'
-  # does, rather than a 'build/' path that resolves one level too deep after
-  # the 'cd'.
+  # does. A 'build/' path resolves one level too deep after the 'cd'.
   #
-  # build/{lang}/pdf/ holds the books of both products, so select by the
-  # product's filename prefix. Without that, both archives get the same content
-  # and differ only in name. 'pdf-zip:*' avoids this a different way: it reads
-  # build/pdf/{lang}/, which 'pdf-collect:{product}' fills one product at a
-  # time.
+  # build/{lang}/pdf/ holds the books of the two products. Select the books
+  # with the filename prefix of the product. Without the prefix, the two
+  # archives get the same content and are different only in the name.
+  # 'pdf-zip:*' prevents this in a different way: it reads build/pdf/{lang}/,
+  # which 'pdf-collect:{product}' fills for one product at a time.
   #
-  # zip adds to an archive that already exists. Remove the old one, or a book
-  # that a later run no longer builds stays in it.
+  # zip adds files to an archive that exists. Remove the old archive first, or
+  # a book that a later run does not build stays in it.
   # --------------------------------------------------------------------------
   pdf-tar:mlm:
     desc: "[Dev] Create OBS-style PDF zip archives for MLM"
@@ -643,7 +642,7 @@ tasks:
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product mlm)
           ARCHIVE={{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
-            echo "no ${PREFIX} PDFs in build/${LANG_CODE}/pdf; run 'task pdf:mlm LANGUAGES=${LANG_CODE}' first" >&2
+            echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:mlm LANGUAGES=${LANG_CODE}' first." >&2
             exit 1
           fi
           mkdir -p build/packages
@@ -660,7 +659,7 @@ tasks:
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product uyuni)
           ARCHIVE={{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
-            echo "no ${PREFIX} PDFs in build/${LANG_CODE}/pdf; run 'task pdf:uyuni LANGUAGES=${LANG_CODE}' first" >&2
+            echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:uyuni LANGUAGES=${LANG_CODE}' first." >&2
             exit 1
           fi
           mkdir -p build/packages
@@ -852,10 +851,10 @@ tasks:
 
   container:run:
     desc: "[Container] Run any task inside the container (escape hatch: task container:run -- <target>)"
-    # Carries the same two variables as every other container task. The named
-    # tasks put LANGUAGES on the inner command line; this one cannot, because
-    # the caller owns that line, so it goes through the environment. A
-    # 'LANGUAGES=' inside CLI_ARGS is a higher precedence and still wins.
+    # This task carries the same two variables as the other container tasks.
+    # The named tasks put LANGUAGES on the inner command line. This task cannot,
+    # because the caller owns that line, thus LANGUAGES goes through the
+    # environment. A 'LANGUAGES=' in CLI_ARGS has a higher precedence and wins.
     cmds:
       - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -e LANGUAGES='{{.LANGUAGES}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task {{.CLI_ARGS}}"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -168,16 +168,27 @@ tasks:
   # --------------------------------------------------------------------------
   # Guard — LANGUAGES selects the documentation languages.
   #
-  # Matches bare documentation codes only, so an inherited POSIX locale
-  # ('en_US.UTF-8', 'C') passes straight through. The value reaches the script
-  # as an environment variable rather than as templated text, so a LANG holding
-  # shell metacharacters is compared, not executed.
+  # The first check matches bare documentation codes only, so an inherited POSIX
+  # locale ('en_US.UTF-8', 'C') passes straight through.
+  #
+  # The second and third checks are what makes LANGUAGES safe to trust. A
+  # 'for: {var: LANGUAGES}' loop over an empty value runs zero iterations and
+  # exits 0, so 'task pdf:mlm LANGUAGES=$LANGS' with LANGS unset builds no PDFs
+  # and reports success, and the pdf-collect, pdf-zip and obs steps then package
+  # and publish an empty tree. An unknown code such as 'jp' is the same failure
+  # with a different cause. Every task that loops over LANGUAGES depends on this
+  # guard, so one check here covers all of them.
+  #
+  # Both values reach the script as environment variables rather than as
+  # templated text, so a value holding shell metacharacters is compared, not
+  # executed.
   # --------------------------------------------------------------------------
   _guard-lang:
     internal: true
     silent: true
     env:
       GUARD_LANG: '{{.LANG}}'
+      GUARD_LANGUAGES: '{{.LANGUAGES}}'
     cmds:
       - |
         for L in {{.DOC_LANGUAGES}}; do
@@ -186,6 +197,39 @@ tasks:
           echo "  ERROR: use LANGUAGES to select documentation languages." >&2
           echo "           task <target> LANGUAGES=${GUARD_LANG}"          >&2
           echo ""                                                          >&2
+          exit 1
+        done
+
+        # Unquoted, so the word split drops the whitespace. An empty result
+        # means LANGUAGES held nothing but spaces, tabs or newlines.
+        set -- ${GUARD_LANGUAGES:-}
+        if [ $# -eq 0 ] ; then
+          echo ""                                                              >&2
+          echo "  ERROR: LANGUAGES is empty, so this build would produce"      >&2
+          echo "         nothing and still report success."                    >&2
+          echo "           task <target> LANGUAGES=\"{{.DOC_LANGUAGES}}\""     >&2
+          echo ""                                                              >&2
+          exit 1
+        fi
+
+        for want in "$@" ; do
+          # A flag, not 'break 2'. Under errexit a failing '[ ] &&' list at the
+          # end of a loop body ends the whole guard.
+          known=0
+          for have in {{.DOC_LANGUAGES}} ; do
+            if [ "$want" = "$have" ] ; then
+              known=1
+              break
+            fi
+          done
+          if [ "$known" -eq 1 ] ; then
+            continue
+          fi
+          echo ""                                                              >&2
+          echo "  ERROR: LANGUAGES contains '${want}', which is not a"         >&2
+          echo "         documentation language."                              >&2
+          echo "           choose from: {{.DOC_LANGUAGES}}"                    >&2
+          echo ""                                                              >&2
           exit 1
         done
 
@@ -549,6 +593,11 @@ tasks:
 
   # --------------------------------------------------------------------------
   # PDF archives — one zip of all PDFs for each product and language
+  #
+  # Task runs one interpreter for each multi-line 'cmd', so the 'cd' holds for
+  # the rest of the block. Give zip an absolute destination, as 'pdf-zip:*'
+  # does, rather than a 'build/' path that resolves one level too deep after
+  # the 'cd'.
   # --------------------------------------------------------------------------
   pdf-tar:mlm:
     desc: "[Dev] Create OBS-style PDF zip archives for MLM"
@@ -557,11 +606,8 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          mkdir -p build/${LANG_CODE}
-          cd build && zip -r9 suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
-          mv build/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip build/${LANG_CODE}/
           mkdir -p build/packages
-          mv build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip build/packages/
+          cd build && zip -r9 {{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
 
   pdf-tar:uyuni:
     desc: "[Dev] Create OBS-style PDF zip archives for Uyuni"
@@ -570,11 +616,8 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          mkdir -p build/${LANG_CODE}
-          cd build && zip -r9 uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
-          mv build/uyuni-docs_${LANG_CODE}-pdf.zip build/${LANG_CODE}/
           mkdir -p build/packages
-          mv build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip build/packages/
+          cd build && zip -r9 {{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
 
   # --------------------------------------------------------------------------
   # OBS packages — HTML tar.gz + PDF tar.gz → build/packages/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -68,7 +68,13 @@ vars:
   # always processes every language. The _guard-lang check needs the full set
   # even when LANGUAGES is narrowed.
   DOC_LANGUAGES: "en ja zh_CN ko"
-  LANGUAGES: "{{.DOC_LANGUAGES}}"
+  # A Taskfile 'vars' entry beats the OS environment, so a plain
+  # 'LANGUAGES: "{{.DOC_LANGUAGES}}"' makes 'export LANGUAGES=en' do nothing at
+  # all: the caller narrows the build and gets every language, without a
+  # message. Read the environment here instead. A command-line 'LANGUAGES=' is
+  # a higher precedence than this whole entry and still wins. _guard-lang
+  # validates the result, whichever of the three it came from.
+  LANGUAGES: '{{default .DOC_LANGUAGES (env "LANGUAGES")}}'
   BOOKS: "installation-and-upgrade client-configuration administration reference retail common-workflows specialized-guides legal"
   CONTAINER_CMD:
     sh: which podman 2>/dev/null || which docker 2>/dev/null || echo "podman"
@@ -179,9 +185,18 @@ tasks:
   # with a different cause. Every task that loops over LANGUAGES depends on this
   # guard, so one check here covers all of them.
   #
-  # Both values reach the script as environment variables rather than as
+  # The checks are 'preconditions', not 'cmds'. Task skips the commands of a
+  # dependency under '--dry' but still evaluates its preconditions, so this is
+  # the only form that catches a bad selection in a dry run. It also keeps the
+  # message out of the printed command list.
+  #
+  # Both values reach the test scripts as environment variables rather than as
   # templated text, so a value holding shell metacharacters is compared, not
-  # executed.
+  # executed. A precondition inherits the task's 'env' block.
+  #
+  # 'msg' cannot name the offending code, because Task renders it from the
+  # template context and not from the script. Each message prints the whole
+  # value instead, which is as much as the reader needs.
   # --------------------------------------------------------------------------
   _guard-lang:
     internal: true
@@ -189,49 +204,51 @@ tasks:
     env:
       GUARD_LANG: '{{.LANG}}'
       GUARD_LANGUAGES: '{{.LANGUAGES}}'
-    cmds:
-      - |
-        for L in {{.DOC_LANGUAGES}}; do
-          [ "$L" = "${GUARD_LANG:-}" ] || continue
-          echo ""                                                          >&2
-          echo "  ERROR: use LANGUAGES to select documentation languages." >&2
-          echo "           task <target> LANGUAGES=${GUARD_LANG}"          >&2
-          echo ""                                                          >&2
-          exit 1
-        done
-
-        # Unquoted, so the word split drops the whitespace. An empty result
-        # means LANGUAGES held nothing but spaces, tabs or newlines.
-        set -- ${GUARD_LANGUAGES:-}
-        if [ $# -eq 0 ] ; then
-          echo ""                                                              >&2
-          echo "  ERROR: LANGUAGES is empty, so this build would produce"      >&2
-          echo "         nothing and still report success."                    >&2
-          echo "           task <target> LANGUAGES=\"{{.DOC_LANGUAGES}}\""     >&2
-          echo ""                                                              >&2
-          exit 1
-        fi
-
-        for want in "$@" ; do
-          # A flag, not 'break 2'. Under errexit a failing '[ ] &&' list at the
-          # end of a loop body ends the whole guard.
-          known=0
-          for have in {{.DOC_LANGUAGES}} ; do
-            if [ "$want" = "$have" ] ; then
-              known=1
-              break
+    preconditions:
+      - sh: |
+          for L in {{.DOC_LANGUAGES}} ; do
+            if [ "$L" = "${GUARD_LANG:-}" ] ; then
+              exit 1
             fi
           done
-          if [ "$known" -eq 1 ] ; then
-            continue
-          fi
-          echo ""                                                              >&2
-          echo "  ERROR: LANGUAGES contains '${want}', which is not a"         >&2
-          echo "         documentation language."                              >&2
-          echo "           choose from: {{.DOC_LANGUAGES}}"                    >&2
-          echo ""                                                              >&2
-          exit 1
-        done
+        msg: |2
+
+            ERROR: LANG={{.LANG}} does not select a documentation language.
+                   Use LANGUAGES instead:
+                     task <target> LANGUAGES={{.LANG}}
+
+      # Unquoted, so the word split drops the whitespace. An empty result means
+      # LANGUAGES held nothing but spaces, tabs or newlines.
+      - sh: |
+          set -- ${GUARD_LANGUAGES:-}
+          test $# -gt 0
+        msg: |2
+
+            ERROR: LANGUAGES is empty, so this build would produce nothing
+                   and still report success.
+                     task <target> LANGUAGES="{{.DOC_LANGUAGES}}"
+
+      - sh: |
+          for want in ${GUARD_LANGUAGES:-} ; do
+            # A flag, not 'break 2'. Under errexit a failing '[ ] &&' list at
+            # the end of a loop body ends the whole check.
+            known=0
+            for have in {{.DOC_LANGUAGES}} ; do
+              if [ "$want" = "$have" ] ; then
+                known=1
+                break
+              fi
+            done
+            if [ "$known" -eq 0 ] ; then
+              exit 1
+            fi
+          done
+        msg: |2
+
+            ERROR: LANGUAGES="{{.LANGUAGES}}" names something that is not a
+                   documentation language.
+                     choose from: {{.DOC_LANGUAGES}}
+
 
   # --------------------------------------------------------------------------
   # Setup — build the Go binary
@@ -598,26 +615,49 @@ tasks:
   # the rest of the block. Give zip an absolute destination, as 'pdf-zip:*'
   # does, rather than a 'build/' path that resolves one level too deep after
   # the 'cd'.
+  #
+  # build/{lang}/pdf/ holds the books of both products, so select by the
+  # product's filename prefix. Without that, both archives get the same content
+  # and differ only in name. 'pdf-zip:*' avoids this a different way: it reads
+  # build/pdf/{lang}/, which 'pdf-collect:{product}' fills one product at a
+  # time.
+  #
+  # zip adds to an archive that already exists. Remove the old one, or a book
+  # that a later run no longer builds stays in it.
   # --------------------------------------------------------------------------
   pdf-tar:mlm:
     desc: "[Dev] Create OBS-style PDF zip archives for MLM"
-    deps: [_guard-lang]
+    deps: [setup, _guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
+          PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product mlm)
+          ARCHIVE={{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
+          if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
+            echo "no ${PREFIX} PDFs in build/${LANG_CODE}/pdf; run 'task pdf:mlm LANGUAGES=${LANG_CODE}' first" >&2
+            exit 1
+          fi
           mkdir -p build/packages
-          cd build && zip -r9 {{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
+          rm -f "${ARCHIVE}"
+          cd build && zip -r9 "${ARCHIVE}" ${LANG_CODE}/pdf/${PREFIX}_*.pdf
 
   pdf-tar:uyuni:
     desc: "[Dev] Create OBS-style PDF zip archives for Uyuni"
-    deps: [_guard-lang]
+    deps: [setup, _guard-lang]
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
+          PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product uyuni)
+          ARCHIVE={{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip
+          if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
+            echo "no ${PREFIX} PDFs in build/${LANG_CODE}/pdf; run 'task pdf:uyuni LANGUAGES=${LANG_CODE}' first" >&2
+            exit 1
+          fi
           mkdir -p build/packages
-          cd build && zip -r9 {{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/pdf/
+          rm -f "${ARCHIVE}"
+          cd build && zip -r9 "${ARCHIVE}" ${LANG_CODE}/pdf/${PREFIX}_*.pdf
 
   # --------------------------------------------------------------------------
   # OBS packages — HTML tar.gz + PDF tar.gz → build/packages/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,8 +63,10 @@ vars:
   PDF_FONTS_DIR: "{{.ROOT_DIR}}/branding/pdf/fonts"
   XREF_EXT: "{{.ROOT_DIR}}/.bin/xref-converter.rb"
   # DOC_LANGUAGES is the canonical set and stays fixed; LANGUAGES is what every
-  # task iterates and is what you override on the command line. The _guard-lang
-  # check needs the full set even when LANGUAGES is narrowed.
+  # build task iterates and is what you override on the command line. The
+  # 'translations' task is the exception: po4a reads the .po files directly and
+  # always processes every language. The _guard-lang check needs the full set
+  # even when LANGUAGES is narrowed.
   DOC_LANGUAGES: "en ja zh_CN ko"
   LANGUAGES: "{{.DOC_LANGUAGES}}"
   BOOKS: "installation-and-upgrade client-configuration administration reference retail common-workflows specialized-guides legal"
@@ -79,7 +81,10 @@ vars:
 
 # 'task pdf:mlm JOBS=4' sets a Task variable. Templates can read it, but the
 # command shell cannot. build_pdfs.sh reads JOBS from the environment. This
-# block exports it there.
+# block exports it to every task.
+#
+# An unset JOBS becomes an empty string here, not an absent variable. The
+# script therefore tests for an empty value and then uses the core count.
 env:
   JOBS: '{{.JOBS}}'
 
@@ -301,6 +306,8 @@ tasks:
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
+        # This runs after 'stage-content', so entities.adoc is the later of the
+        # two paths. The STAGE=0 check in 'pdf' examines both.
         cmd: "{{.DOCBUILD}} gen-entities -product {{.PRODUCT}} -lang {{.ITEM}}"
 
   # --------------------------------------------------------------------------
@@ -313,7 +320,14 @@ tasks:
   # --------------------------------------------------------------------------
   pdf:
     desc: "[Local] Build one PDF book — usage: task pdf BOOK=<book> PRODUCT=<product> LANGUAGES=<langs>"
-    deps: [gen, setup, _guard-lang]
+    # 'setup', not 'gen'. build_pdfs.sh starts one 'task pdf' process for each
+    # book, and 'run: once' applies to one process only, so each process
+    # evaluates 'gen' again. 'gen-all' writes
+    # translations/{lang}/branding/pdf/entities.adoc once for each product, to
+    # a path with no product in it, in Go map order. A 'gen' after the staging
+    # therefore replaces the staged entities with those of a different product.
+    # 'pdf-stage' keeps the 'gen' dependency for the STAGE=1 path.
+    deps: [setup, _guard-lang]
     vars:
       BOOK: '{{default "administration" .BOOK}}'
       PRODUCT: '{{default "mlm" .PRODUCT}}'
@@ -370,22 +384,32 @@ tasks:
           # Stage the content tree and entities.adoc, unless the caller stages
           # the full language. Asciidoctor reports only an ERROR for a missing
           # entities.adoc, and --failure-level FATAL ignores an ERROR. The
-          # result is a PDF with unresolved attributes. Therefore, check both
-          # of the trees that pdf-stage writes; they are separate.
-          if [ "{{.STAGE}}" = "1" ]; then
-            task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}
-          else
-            for staged in "${SRCDIR}/branding/pdf/entities.adoc" "${SRCDIR}/modules/${BOOK}"; do
-              if [ ! -e "${staged}" ]; then
-                echo "STAGE=0 but ${staged} is missing;" >&2
+          # result is a PDF with unresolved attributes.
+          #
+          # Examine both paths that pdf-stage writes, not only the later one.
+          # Also make sure that entities.adoc has content. An interrupted write
+          # leaves an empty file, and an empty file resolves no attributes.
+          case "{{.STAGE}}" in
+            1)
+              task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}
+              ;;
+            0)
+              if [ ! -s "${SRCDIR}/branding/pdf/entities.adoc" ] || [ ! -d "${SRCDIR}/modules/${BOOK}" ]; then
+                echo "STAGE=0 but ${LANG_CODE} is not staged:" >&2
+                echo "  ${SRCDIR}/branding/pdf/entities.adoc is missing or empty," >&2
+                echo "  or ${SRCDIR}/modules/${BOOK} is missing." >&2
                 echo "run: task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}" >&2
                 exit 1
               fi
-            done
-          fi
+              ;;
+            *)
+              echo "STAGE must be 0 or 1, got '{{.STAGE}}'." >&2
+              exit 2
+              ;;
+          esac
 
-          # Make the PDF nav file from the Antora nav. One file for each book,
-          # therefore parallel builds are safe.
+          # Make the PDF nav file from the Antora nav. There is one file for
+          # each book and language. Concurrent builds do not share it.
           {{.DOCBUILD}} gen-pdf-nav -book ${BOOK} -lang ${LANG_CODE} -dir ${SRCDIR}/modules/${BOOK}
 
           cd "${SRCDIR}"
@@ -408,9 +432,9 @@ tasks:
   # --------------------------------------------------------------------------
   # PDF builds — all books for a product
   # --------------------------------------------------------------------------
-  # Books build concurrently. asciidoctor-pdf has one thread, therefore this
-  # is the only step that uses more than one core. JOBS=<n> caps the count.
-  # The default is nproc.
+  # Books build concurrently. asciidoctor-pdf runs on one core, so concurrent
+  # books are the only way to use more than one core in this step. JOBS=<n>
+  # caps the count. The default is the core count.
   pdf:mlm:
     desc: "[Local] Build all MLM PDFs — all books, all languages (JOBS=<n> caps concurrency)"
     deps: [gen, _guard-lang]
@@ -433,7 +457,7 @@ tasks:
   # The products run in sequence, not as parallel deps. Both write
   # translations/{lang}/branding/pdf/entities.adoc, which has no product in its
   # path. A parallel run puts one product's entities in the other product's
-  # PDFs. Each product uses all cores alone, therefore the sequence is free.
+  # PDFs. One product usually saturates the cores, so the sequence costs little.
   pdf:all:
     desc: "[Local] Build all PDFs — both products, all languages"
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -587,6 +587,10 @@ tasks:
   # PDF zip archives — package collected PDFs for the index download link.
   # Zips land at build/{lang}/{product}_{lang}-pdf.zip so the index page link
   # "../{product}_{lang}-pdf.zip" resolves correctly from the HTML output dir.
+  #
+  # zip adds to an archive that already exists. Remove the old one, or a book
+  # that a later run no longer builds stays in it, and a renamed book ships
+  # twice. 'task clean' hides this; a repeat build in place does not.
   # --------------------------------------------------------------------------
   pdf-zip:mlm:
     desc: "[Dev] Zip collected MLM PDFs into per-language archives"
@@ -595,8 +599,10 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
+          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
           mkdir -p build/${LANG_CODE}
-          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/
+          rm -f "${ARCHIVE}"
+          cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
 
   pdf-zip:uyuni:
     desc: "[Dev] Zip collected Uyuni PDFs into per-language archives"
@@ -605,8 +611,10 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
+          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip
           mkdir -p build/${LANG_CODE}
-          cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/
+          rm -f "${ARCHIVE}"
+          cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
 
   # --------------------------------------------------------------------------
   # PDF archives — one zip of all PDFs for each product and language

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -288,11 +288,13 @@ tasks:
   # them are not safe. Stage each language one time, then build its books with
   # STAGE=0.
   #
-  # This task is not internal, because build_pdfs.sh and 'pdf' call it as a
-  # subprocess. It has no 'desc', which keeps it out of 'task --list'.
+  # 'pdf:mlm' and 'pdf:uyuni' call this in their own process, therefore
+  # stage-content can dedupe itself with 'run: once'. The single-book 'pdf'
+  # task calls it as a subprocess, which is why this task is not internal. It
+  # has no 'desc', which keeps it out of 'task --list'.
   # --------------------------------------------------------------------------
   pdf-stage:
-    deps: [gen, setup, _guard-lang]
+    deps: [gen, _guard-lang]
     # PRODUCT has no default. Without this, gen-entities gets an empty product.
     requires:
       vars: [PRODUCT]
@@ -368,13 +370,18 @@ tasks:
           # Stage the content tree and entities.adoc, unless the caller stages
           # the full language. Asciidoctor reports only an ERROR for a missing
           # entities.adoc, and --failure-level FATAL ignores an ERROR. The
-          # result is a PDF with unresolved attributes. Therefore, check.
+          # result is a PDF with unresolved attributes. Therefore, check both
+          # of the trees that pdf-stage writes; they are separate.
           if [ "{{.STAGE}}" = "1" ]; then
             task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}
-          elif [ ! -f "${SRCDIR}/branding/pdf/entities.adoc" ]; then
-            echo "STAGE=0 but ${SRCDIR}/branding/pdf/entities.adoc is missing;" >&2
-            echo "run: task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}" >&2
-            exit 1
+          else
+            for staged in "${SRCDIR}/branding/pdf/entities.adoc" "${SRCDIR}/modules/${BOOK}"; do
+              if [ ! -e "${staged}" ]; then
+                echo "STAGE=0 but ${staged} is missing;" >&2
+                echo "run: task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}" >&2
+                exit 1
+              fi
+            done
           fi
 
           # Make the PDF nav file from the Antora nav. One file for each book,
@@ -408,12 +415,19 @@ tasks:
     desc: "[Local] Build all MLM PDFs — all books, all languages (JOBS=<n> caps concurrency)"
     deps: [gen, _guard-lang]
     cmds:
+      # Stage here, not in build_pdfs.sh. A task that the script starts runs in
+      # a second process, where 'run: once' knows nothing about this one and
+      # stage-content repeats its 'rm -rf'.
+      - task: pdf-stage
+        vars: {PRODUCT: mlm}
       - bash scripts/build_pdfs.sh mlm "{{.LANGUAGES}}" "{{.BOOKS}}"
 
   pdf:uyuni:
     desc: "[Local] Build all Uyuni PDFs — all books, all languages (JOBS=<n> caps concurrency)"
     deps: [gen, _guard-lang]
     cmds:
+      - task: pdf-stage
+        vars: {PRODUCT: uyuni}
       - bash scripts/build_pdfs.sh uyuni "{{.LANGUAGES}}" "{{.BOOKS}}"
 
   # The products run in sequence, not as parallel deps. Both write
@@ -624,9 +638,12 @@ tasks:
   stage-content:
     desc: "[Dev] Stage translated content for build (en base + lang overlay → translations/{lang}/modules/)"
     deps: [setup, _guard-lang]
-    # Run one time for each invocation. Several tasks reach this one through
-    # different paths, and a second run does 'rm -rf translations/{lang}/modules'
-    # and deletes the tree that the first run writes.
+    # Run one time for each invocation. 'publish:*' reaches this task through
+    # both 'draft:*' and 'pdf:*', and a second run does
+    # 'rm -rf translations/{lang}/modules' and deletes the tree that the first
+    # run writes. This holds inside one process only. A task that a script
+    # starts gets a second process with its own bookkeeping, therefore call
+    # this task, or 'pdf-stage', with 'task:' and not from a command.
     run: once
     cmds:
       - for: {var: LANGUAGES}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,7 @@
 #    task container:draft:uyuni-webui               Uyuni HTML — product WebUI (all languages)
 #    task container:draft:all                       All four HTML output targets
 #    (All draft/publish/pdf container tasks accept LANGUAGES=en or LANGUAGES="en ja" to limit languages)
+#    (PDF tasks build books concurrently, one for each core. JOBS=<n> caps this.)
 #    task container:pdf:mlm             All MLM PDFs
 #    task container:pdf:uyuni           All Uyuni PDFs
 #    task container:pdf:all             All PDFs
@@ -76,6 +77,12 @@ vars:
   # The builder image has no Python.
   PYTHON_IMAGE: "registry.suse.com/bci/python:3.11"
 
+# 'task pdf:mlm JOBS=4' sets a Task variable. Templates can read it, but the
+# command shell cannot. build_pdfs.sh reads JOBS from the environment. This
+# block exports it there.
+env:
+  JOBS: '{{.JOBS}}'
+
 tasks:
   # --------------------------------------------------------------------------
   # Default — human-friendly help (runs when you type just: task)
@@ -114,6 +121,9 @@ tasks:
         echo "    Example:  task draft:uyuni-website LANGUAGES=\"en ja\""
         echo "    Example:  task publish:dsc LANGUAGES=en"
         echo "    Every task, including 'task pdf', takes LANGUAGES."
+        echo ""
+        echo "  Tip: PDF builds run books concurrently, one for each core. JOBS=<n> caps this."
+        echo "    Example:  task container:pdf:mlm LANGUAGES=en JOBS=4"
         echo ""
         echo "  ── LOCAL  (Go + Task + Antora + asciidoctor-pdf installed locally) ──────────"
         echo "    publish:dsc              Full MLM publish — HTML (d.s.c branding) + PDFs + zips"
@@ -273,6 +283,25 @@ tasks:
       - task: draft:uyuni-webui
 
   # --------------------------------------------------------------------------
+  # PDF staging — the content tree and the entities file for one product and
+  # language. Every book of a language shares both, and concurrent writes to
+  # them are not safe. Stage each language one time, then build its books with
+  # STAGE=0.
+  #
+  # This task is not internal, because build_pdfs.sh and 'pdf' call it as a
+  # subprocess. It has no 'desc', which keeps it out of 'task --list'.
+  # --------------------------------------------------------------------------
+  pdf-stage:
+    deps: [gen, setup, _guard-lang]
+    # PRODUCT has no default. Without this, gen-entities gets an empty product.
+    requires:
+      vars: [PRODUCT]
+    cmds:
+      - task: stage-content
+      - for: {var: LANGUAGES}
+        cmd: "{{.DOCBUILD}} gen-entities -product {{.PRODUCT}} -lang {{.ITEM}}"
+
+  # --------------------------------------------------------------------------
   # PDF builds — one book
   # Usage: task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
   #
@@ -286,6 +315,8 @@ tasks:
     vars:
       BOOK: '{{default "administration" .BOOK}}'
       PRODUCT: '{{default "mlm" .PRODUCT}}'
+      # STAGE=0 tells this task that the caller stages the language.
+      STAGE: '{{default "1" .STAGE}}'
     cmds:
       - for: {var: LANGUAGES}
         cmd: |
@@ -293,7 +324,7 @@ tasks:
           PRODUCT="{{.PRODUCT}}"
           LANG_CODE="{{.ITEM}}"
 
-          # Resolve PDF theme from config.yml via docbuild (printed to stdout)
+          # PDF theme for the product and language
           case "${PRODUCT}:${LANG_CODE}" in
             mlm:ja)    THEME=suse-jp ;;
             mlm:zh_CN) THEME=suse-sc ;;
@@ -331,23 +362,24 @@ tasks:
           OUTDIR="build/${LANG_CODE}/pdf"
           mkdir -p "${OUTDIR}"
 
-          # Stage content for this language (en base + translated overlay)
-          CONTENT_DIR=$({{.DOCBUILD}} get-content-dir -lang ${LANG_CODE})
-          mkdir -p "${SRCDIR}/modules"
-          cp -a en/modules/. "${SRCDIR}/modules/"
-          if [ -d "${CONTENT_DIR}/modules" ]; then
-            cp -a "${CONTENT_DIR}/modules/." "${SRCDIR}/modules/"
-          fi
-
           # Resolve PDF filename prefix from config.yml (e.g. suse_multi_linux_manager or uyuni)
           PDF_PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product ${PRODUCT})
 
-          # Generate PDF nav file from Antora nav
-          {{.DOCBUILD}} gen-pdf-nav -book ${BOOK} -lang ${LANG_CODE} -dir ${SRCDIR}/modules/${BOOK}
+          # Stage the content tree and entities.adoc, unless the caller stages
+          # the full language. Asciidoctor reports only an ERROR for a missing
+          # entities.adoc, and --failure-level FATAL ignores an ERROR. The
+          # result is a PDF with unresolved attributes. Therefore, check.
+          if [ "{{.STAGE}}" = "1" ]; then
+            task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}
+          elif [ ! -f "${SRCDIR}/branding/pdf/entities.adoc" ]; then
+            echo "STAGE=0 but ${SRCDIR}/branding/pdf/entities.adoc is missing;" >&2
+            echo "run: task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}" >&2
+            exit 1
+          fi
 
-          # Generate self-contained entities.adoc for this product/lang
-          # (written to translations/${LANG_CODE}/branding/pdf/entities.adoc)
-          {{.DOCBUILD}} gen-entities -product ${PRODUCT} -lang ${LANG_CODE}
+          # Make the PDF nav file from the Antora nav. One file for each book,
+          # therefore parallel builds are safe.
+          {{.DOCBUILD}} gen-pdf-nav -book ${BOOK} -lang ${LANG_CODE} -dir ${SRCDIR}/modules/${BOOK}
 
           cd "${SRCDIR}"
           LANG=${LOCALE} LC_ALL=${LOCALE} asciidoctor-pdf \
@@ -369,29 +401,30 @@ tasks:
   # --------------------------------------------------------------------------
   # PDF builds — all books for a product
   # --------------------------------------------------------------------------
-  # Only the book loop lives here — 'pdf' iterates LANGUAGES itself, so the
-  # language loop exists in exactly one place.
+  # Books build concurrently. asciidoctor-pdf has one thread, therefore this
+  # is the only step that uses more than one core. JOBS=<n> caps the count.
+  # The default is nproc.
   pdf:mlm:
-    desc: "[Local] Build all MLM PDFs — all books, all languages"
+    desc: "[Local] Build all MLM PDFs — all books, all languages (JOBS=<n> caps concurrency)"
     deps: [gen, _guard-lang]
     cmds:
-      - task: stage-content
-      - for: {var: BOOKS}
-        cmd: task pdf BOOK={{.ITEM}} PRODUCT=mlm LANGUAGES="{{.LANGUAGES}}"
+      - bash scripts/build_pdfs.sh mlm "{{.LANGUAGES}}" "{{.BOOKS}}"
 
   pdf:uyuni:
-    desc: "[Local] Build all Uyuni PDFs — all books, all languages"
+    desc: "[Local] Build all Uyuni PDFs — all books, all languages (JOBS=<n> caps concurrency)"
     deps: [gen, _guard-lang]
     cmds:
-      - task: stage-content
-      - for: {var: BOOKS}
-        cmd: task pdf BOOK={{.ITEM}} PRODUCT=uyuni LANGUAGES="{{.LANGUAGES}}"
+      - bash scripts/build_pdfs.sh uyuni "{{.LANGUAGES}}" "{{.BOOKS}}"
 
+  # The products run in sequence, not as parallel deps. Both write
+  # translations/{lang}/branding/pdf/entities.adoc, which has no product in its
+  # path. A parallel run puts one product's entities in the other product's
+  # PDFs. Each product uses all cores alone, therefore the sequence is free.
   pdf:all:
     desc: "[Local] Build all PDFs — both products, all languages"
-    deps:
-      - pdf:mlm
-      - pdf:uyuni
+    cmds:
+      - task: pdf:mlm
+      - task: pdf:uyuni
 
   # --------------------------------------------------------------------------
   # PDF collection — gather scattered build/{lang}/pdf/ into build/pdf/{lang}/
@@ -477,10 +510,10 @@ tasks:
           cd build/pdf && zip -r9 {{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip ${LANG_CODE}/
 
   # --------------------------------------------------------------------------
-  # PDF tarballs — zip of all PDFs per product/language
+  # PDF archives — one zip of all PDFs for each product and language
   # --------------------------------------------------------------------------
   pdf-tar:mlm:
-    desc: "[Dev] Create OBS-style PDF tarballs for MLM"
+    desc: "[Dev] Create OBS-style PDF zip archives for MLM"
     deps: [_guard-lang]
     cmds:
       - for: {var: LANGUAGES}
@@ -493,7 +526,7 @@ tasks:
           mv build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip build/packages/
 
   pdf-tar:uyuni:
-    desc: "[Dev] Create OBS-style PDF tarballs for Uyuni"
+    desc: "[Dev] Create OBS-style PDF zip archives for Uyuni"
     deps: [_guard-lang]
     cmds:
       - for: {var: LANGUAGES}
@@ -591,8 +624,9 @@ tasks:
   stage-content:
     desc: "[Dev] Stage translated content for build (en base + lang overlay → translations/{lang}/modules/)"
     deps: [setup, _guard-lang]
-    # Stage once per run: pdf:all invokes pdf:mlm and pdf:uyuni as parallel deps,
-    # and a concurrent removal of the tree makes the other invocation's cp fail.
+    # Run one time for each invocation. Several tasks reach this one through
+    # different paths, and a second run does 'rm -rf translations/{lang}/modules'
+    # and deletes the tree that the first run writes.
     run: once
     cmds:
       - for: {var: LANGUAGES}
@@ -687,108 +721,108 @@ tasks:
   container:run:
     desc: "[Container] Run any task inside the container (escape hatch: task container:run -- <target>)"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task {{.CLI_ARGS}}"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task {{.CLI_ARGS}}"
 
   # HTML builds
   container:draft:mlm-dsc:
     desc: "[Draft] MLM HTML — documentation.suse.com branding, via container (all languages; override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-dsc LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:mlm-webui:
     desc: "[Draft] MLM HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-webui LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:mlm-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-website:
     desc: "[Draft] Uyuni HTML — website branding, via container (all languages; override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-website LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-website LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:uyuni-webui:
     desc: "[Draft] Uyuni HTML — WebUI branding with language selector, via container (all languages; override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-webui LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:uyuni-webui LANGUAGES='{{.LANGUAGES}}'"
 
   container:draft:all:
     desc: "[Draft] All four HTML output targets, via container (sequential; override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:all LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task draft:all LANGUAGES='{{.LANGUAGES}}'"
 
   # PDF builds
   container:pdf:mlm:
     desc: "[Container] All MLM PDFs — all books, all languages (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:mlm LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:uyuni:
     desc: "[Container] All Uyuni PDFs — all books, all languages (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:uyuni LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:pdf:all:
     desc: "[Container] All PDFs — both products, all languages (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:all LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pdf:all LANGUAGES='{{.LANGUAGES}}'"
 
   # Publish targets
   container:publish:dsc:
     desc: "[Container] Full MLM publish — HTML (d.s.c branding) + PDFs + zips (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:dsc LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:dsc LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:uyuni:
     desc: "[Container] Full Uyuni publish — HTML (website branding) + PDFs + zips (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:uyuni LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-mlm:
     desc: "[Container] MLM WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-mlm LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:publish:webui-uyuni:
     desc: "[Container] Uyuni WebUI publish — HTML (with language selector) + PDFs + zips (override with LANGUAGES=en)"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-uyuni LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task publish:webui-uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # OBS packages
   container:obs:mlm:
     desc: "[Container] OBS source packages for MLM"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:mlm LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:obs:uyuni:
     desc: "[Container] OBS source packages for Uyuni"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:uyuni LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task obs:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   # Validation
   container:validate:mlm:
     desc: "[Container] Antora xref validation — MLM"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:mlm LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:uyuni:
     desc: "[Container] Antora xref validation — Uyuni"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task validate:uyuni LANGUAGES='{{.LANGUAGES}}'"
 
   container:validate:revdate:
     desc: "[Container] Check :revdate: on changed AsciiDoc pages"
@@ -801,17 +835,17 @@ tasks:
     desc: "[Container] Stage translated content for build"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task stage-content LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task stage-content LANGUAGES='{{.LANGUAGES}}'"
 
   # Translations (deprecated)
   container:translations:
     desc: "[DEPRECATED] Use container:stage-content instead"
     deps: [_guard-lang]
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task translations LANGUAGES='{{.LANGUAGES}}'"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task translations LANGUAGES='{{.LANGUAGES}}'"
 
   container:pot:
     desc: "[DEPRECATED] po4a template update — no longer used in builds"
     cmds:
-      - "{{.CONTAINER_CMD}} run --rm -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pot"
+      - "{{.CONTAINER_CMD}} run --rm -e JOBS='{{.JOBS}}' -v {{.ROOT_DIR}}:/docs:Z -w /docs {{.BUILDER_IMAGE}} task pot"
 

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -121,27 +121,27 @@ task container:pdf:mlm LANGUAGES=en
 task container:publish:uyuni LANGUAGES="en ja"
 ```
 
-`LANGUAGES=` selects the languages that are built. The `translations` step
-always processes every language, because po4a reads the `.po` files directly.
+`LANGUAGES=` selects the languages to build. The `translations` step always
+processes all the languages, because po4a reads the `.po` files directly.
 
-`LANGUAGES=` must name at least one language, and every name must be one of
-`en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
-producing nothing and reporting success. `task --dry` makes the same check.
+`LANGUAGES=` must give one language or more, and each name must be `en`, `ja`,
+`zh_CN` or `ko`. An empty or incorrect value stops the build. `task --dry`
+makes the same check.
 
-`export LANGUAGES=en` sets the default for every later command. A `LANGUAGES=`
-on the command line still wins over it.
+`export LANGUAGES=en` sets the default for the subsequent commands. A
+`LANGUAGES=` on the command line has a higher precedence.
 
 ### Controlling concurrency
 
-PDF books build in parallel, one job for each core. `JOBS=` caps the count:
+PDF books run concurrently, one job for each core. `JOBS=` caps the count:
 
 ```bash
 task container:pdf:mlm LANGUAGES=en JOBS=4
 ```
 
-Each concurrent book is a separate asciidoctor-pdf process with its own fonts
-in memory. Lower `JOBS=` if a build runs out of memory. The default already
-follows a `--cpus` limit on the container.
+Each concurrent book is a different asciidoctor-pdf process with its own fonts
+in memory. Decrease `JOBS=` if a build runs out of memory. The default obeys a
+`--cpus` limit on the container.
 
 ### Build one PDF book
 

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -121,8 +121,8 @@ task container:pdf:mlm LANGUAGES=en
 task container:publish:uyuni LANGUAGES="en ja"
 ```
 
-`LANGUAGES=` selects the languages to build. The `translations` step always
-processes all the languages, because po4a reads the `.po` files directly.
+`LANGUAGES=` selects the languages to build. The `stage-content` step stages
+the same set.
 
 `LANGUAGES=` must give one language or more, and each name must be `en`, `ja`,
 `zh_CN` or `ko`. An empty or incorrect value stops the build. `task --dry`

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -126,7 +126,10 @@ always processes every language, because po4a reads the `.po` files directly.
 
 `LANGUAGES=` must name at least one language, and every name must be one of
 `en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
-producing nothing and reporting success.
+producing nothing and reporting success. `task --dry` makes the same check.
+
+`export LANGUAGES=en` sets the default for every later command. A `LANGUAGES=`
+on the command line still wins over it.
 
 ### Controlling concurrency
 

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -138,17 +138,18 @@ follows a `--cpus` limit on the container.
 
 ### Build one PDF book
 
-Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:
+There is no `container:pdf` task for one book. Use `container:run` with the
+`pdf` task and the `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:
 
 ```bash
 # Build the Administration Guide for MLM in English
-task pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
+task container:run -- pdf BOOK=administration PRODUCT=mlm LANGUAGES=en
 
 # Build the Installation and Upgrade Guide for Uyuni in Japanese
-task pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
+task container:run -- pdf BOOK=installation-and-upgrade PRODUCT=uyuni LANGUAGES=ja
 
 # Build one book in several languages
-task pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
+task container:run -- pdf BOOK=administration PRODUCT=mlm LANGUAGES="en ja"
 ```
 
 Without `LANGUAGES=` this builds the book in every language.

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -121,6 +121,9 @@ task container:pdf:mlm LANGUAGES=en
 task container:publish:uyuni LANGUAGES="en ja"
 ```
 
+`LANGUAGES=` selects the languages that are built. The `translations` step
+always processes every language, because po4a reads the `.po` files directly.
+
 ### Controlling concurrency
 
 PDF books build in parallel, one job for each core. `JOBS=` caps the count:
@@ -128,6 +131,10 @@ PDF books build in parallel, one job for each core. `JOBS=` caps the count:
 ```bash
 task container:pdf:mlm LANGUAGES=en JOBS=4
 ```
+
+Each concurrent book is a separate asciidoctor-pdf process with its own fonts
+in memory. Lower `JOBS=` if a build runs out of memory. The default already
+follows a `--cpus` limit on the container.
 
 ### Build one PDF book
 

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -124,6 +124,10 @@ task container:publish:uyuni LANGUAGES="en ja"
 `LANGUAGES=` selects the languages that are built. The `translations` step
 always processes every language, because po4a reads the `.po` files directly.
 
+`LANGUAGES=` must name at least one language, and every name must be one of
+`en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
+producing nothing and reporting success.
+
 ### Controlling concurrency
 
 PDF books build in parallel, one job for each core. `JOBS=` caps the count:

--- a/docs/container-setup.md
+++ b/docs/container-setup.md
@@ -112,6 +112,23 @@ task container:pdf:uyuni              # All Uyuni PDFs — all books, all langua
 task container:pdf:all                # All PDFs
 ```
 
+### Limiting languages
+
+Each task builds all four languages by default. `LANGUAGES=` selects fewer:
+
+```bash
+task container:pdf:mlm LANGUAGES=en
+task container:publish:uyuni LANGUAGES="en ja"
+```
+
+### Controlling concurrency
+
+PDF books build in parallel, one job for each core. `JOBS=` caps the count:
+
+```bash
+task container:pdf:mlm LANGUAGES=en JOBS=4
+```
+
 ### Build one PDF book
 
 Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -184,6 +184,9 @@ task pdf:mlm LANGUAGES=en
 task publish:uyuni LANGUAGES="en ja"
 ```
 
+`LANGUAGES=` selects the languages that are built. The `translations` step
+always processes every language, because po4a reads the `.po` files directly.
+
 ### Controlling concurrency
 
 PDF books build in parallel, one job for each core. `JOBS=` caps the count:

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -175,6 +175,23 @@ task validate:uyuni         # Antora xref validation — Uyuni
 task clean                  # Remove build/, translations/, .cache/
 ```
 
+### Limiting languages
+
+Each task builds all four languages by default. `LANGUAGES=` selects fewer:
+
+```bash
+task pdf:mlm LANGUAGES=en
+task publish:uyuni LANGUAGES="en ja"
+```
+
+### Controlling concurrency
+
+PDF books build in parallel, one job for each core. `JOBS=` caps the count:
+
+```bash
+task pdf:mlm LANGUAGES=en JOBS=4
+```
+
 ### Build one PDF book
 
 Use the `pdf` task with `BOOK=`, `PRODUCT=`, and `LANGUAGES=` variables:

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -184,8 +184,8 @@ task pdf:mlm LANGUAGES=en
 task publish:uyuni LANGUAGES="en ja"
 ```
 
-`LANGUAGES=` selects the languages to build. The `translations` step always
-processes all the languages, because po4a reads the `.po` files directly.
+`LANGUAGES=` selects the languages to build. The `stage-content` step stages
+the same set.
 
 `LANGUAGES=` must give one language or more, and each name must be `en`, `ja`,
 `zh_CN` or `ko`. An empty or incorrect value stops the build. `task --dry`

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -189,7 +189,10 @@ always processes every language, because po4a reads the `.po` files directly.
 
 `LANGUAGES=` must name at least one language, and every name must be one of
 `en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
-producing nothing and reporting success.
+producing nothing and reporting success. `task --dry` makes the same check.
+
+`export LANGUAGES=en` sets the default for every later command. A `LANGUAGES=`
+on the command line still wins over it.
 
 ### Controlling concurrency
 

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -187,6 +187,10 @@ task publish:uyuni LANGUAGES="en ja"
 `LANGUAGES=` selects the languages that are built. The `translations` step
 always processes every language, because po4a reads the `.po` files directly.
 
+`LANGUAGES=` must name at least one language, and every name must be one of
+`en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
+producing nothing and reporting success.
+
 ### Controlling concurrency
 
 PDF books build in parallel, one job for each core. `JOBS=` caps the count:

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -184,19 +184,19 @@ task pdf:mlm LANGUAGES=en
 task publish:uyuni LANGUAGES="en ja"
 ```
 
-`LANGUAGES=` selects the languages that are built. The `translations` step
-always processes every language, because po4a reads the `.po` files directly.
+`LANGUAGES=` selects the languages to build. The `translations` step always
+processes all the languages, because po4a reads the `.po` files directly.
 
-`LANGUAGES=` must name at least one language, and every name must be one of
-`en` `ja` `zh_CN` `ko`. An empty or misspelled value stops the build instead of
-producing nothing and reporting success. `task --dry` makes the same check.
+`LANGUAGES=` must give one language or more, and each name must be `en`, `ja`,
+`zh_CN` or `ko`. An empty or incorrect value stops the build. `task --dry`
+makes the same check.
 
-`export LANGUAGES=en` sets the default for every later command. A `LANGUAGES=`
-on the command line still wins over it.
+`export LANGUAGES=en` sets the default for the subsequent commands. A
+`LANGUAGES=` on the command line has a higher precedence.
 
 ### Controlling concurrency
 
-PDF books build in parallel, one job for each core. `JOBS=` caps the count:
+PDF books run concurrently, one job for each core. `JOBS=` caps the count:
 
 ```bash
 task pdf:mlm LANGUAGES=en JOBS=4

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -261,9 +261,11 @@ task draft:uyuni-webui             Uyuni HTML — WebUI branding with language s
 task draft:all                     All four HTML output targets (sequential)
 
 task pdf BOOK=<b> PRODUCT=<p> LANGUAGES=<l>  One book PDF, one or more languages
-task pdf:mlm                       All 8 books × 4 languages — MLM (runs stage-content first)
-task pdf:uyuni                     All 8 books × 4 languages — Uyuni (runs stage-content first)
-task pdf:all                       Both products
+task pdf-stage PRODUCT=<p>         Per-language shared files: the content tree + entities.adoc
+task pdf:mlm                       All 8 books × 4 languages — MLM (runs stage-content first, books concurrent)
+task pdf:uyuni                     All 8 books × 4 languages — Uyuni (runs stage-content first, books concurrent)
+task pdf:all                       Both products, in sequence (they share entities.adoc)
+                                   JOBS=<n> caps concurrency; the default is the core count
 
 task publish:dsc                   Full MLM publish — HTML + PDFs + zip archives
 task publish:uyuni                 Full Uyuni publish — HTML + PDFs + zip archives

--- a/internal/generate/atomic.go
+++ b/internal/generate/atomic.go
@@ -2,20 +2,25 @@ package generate
 
 // Atomic file writes.
 //
-// The PDF matrix builds books in parallel, and more than one book of a
-// language writes the same shared files, primarily entities.adoc. A write to a
-// temporary file, then a rename, keeps each write atomic for other processes:
-// a reader gets the previous complete file or the new complete file. These
-// functions do not fsync, because 'task gen' makes all these files again.
+// build_pdfs.sh runs one 'task pdf' process for each book, and books of one
+// language read the same generated files. A developer can also run 'task gen'
+// in a second terminal during a build. A write to a temporary file, then a
+// rename, keeps each write atomic for other processes: a reader gets the
+// previous complete file or the new complete file, never a truncated one.
+//
+// This function does not fsync. Every file it writes is a build artifact that
+// the build makes again.
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 )
 
 // atomicWriteFile writes data to path through a temporary file and a rename.
-// The temporary file is in the destination directory, therefore the rename
+// The temporary file is in the destination directory. The rename therefore
 // stays in one filesystem.
 func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	dir := filepath.Dir(path)
@@ -29,22 +34,32 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		tmpName string
 		err     error
 	)
-	for i := 0; tmp == nil && i < 100; i++ {
+	// The name holds the process ID, so two processes never pick the same one.
+	// The index handles a leftover temporary file from a process that was
+	// killed before its cleanup ran and whose process ID has been reused.
+	const maxAttempts = 100
+	for i := 0; tmp == nil && i < maxAttempts; i++ {
 		tmpName = filepath.Join(dir, fmt.Sprintf(".%s.tmp%d-%d", base, os.Getpid(), i))
 		tmp, err = os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
-		if err != nil && !os.IsExist(err) {
-			return fmt.Errorf("create temp file in %s: %w", dir, err)
+		if err != nil && !errors.Is(err, fs.ErrExist) {
+			return fmt.Errorf("create temp file for %s: %w", path, err)
 		}
 	}
 	if tmp == nil {
-		return fmt.Errorf("create temp file in %s: %w", dir, err)
+		return fmt.Errorf("create temp file for %s: every name from .%s.tmp%d-0 to -%d is taken, "+
+			"remove the stale .%s.tmp* files in %s: %w",
+			path, base, os.Getpid(), maxAttempts-1, base, dir, err)
 	}
 
 	// An empty tmpName disables this cleanup after a successful rename.
 	defer func() {
 		if tmpName != "" {
 			tmp.Close()
-			os.Remove(tmpName)
+			// Report a leftover temporary file. Enough of them make every
+			// later write to this path fail with the message above.
+			if err := os.Remove(tmpName); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: cannot remove temp file %s: %v\n", tmpName, err)
+			}
 		}
 	}()
 

--- a/internal/generate/atomic.go
+++ b/internal/generate/atomic.go
@@ -2,11 +2,11 @@ package generate
 
 // Atomic file writes.
 //
-// build_pdfs.sh runs one 'task pdf' process for each book, and books of one
-// language read the same generated files. A developer can also run 'task gen'
-// in a second terminal during a build. A write to a temporary file, then a
-// rename, keeps each write atomic for other processes: a reader gets the
-// previous complete file or the new complete file, never a truncated one.
+// build_pdfs.sh starts one 'task pdf' process for each book, and the books of
+// one language read the same generated files. A developer can also run 'task
+// gen' in a second terminal during a build. A write to a temporary file, then
+// a rename, keeps each write atomic for other processes: a reader gets the
+// previous complete file or the new complete file, never a truncated file.
 //
 // This function does not fsync. Every file it writes is a build artifact that
 // the build makes again.
@@ -34,9 +34,9 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 		tmpName string
 		err     error
 	)
-	// The name holds the process ID, so two processes never pick the same one.
-	// The index handles a leftover temporary file from a process that was
-	// killed before its cleanup ran and whose process ID has been reused.
+	// The name holds the process ID, thus two processes do not select the same
+	// name. The index prevents a conflict with a leftover temporary file: the
+	// system uses a process ID again after a kill stops the cleanup.
 	const maxAttempts = 100
 	for i := 0; tmp == nil && i < maxAttempts; i++ {
 		tmpName = filepath.Join(dir, fmt.Sprintf(".%s.tmp%d-%d", base, os.Getpid(), i))
@@ -55,8 +55,8 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 	defer func() {
 		if tmpName != "" {
 			tmp.Close()
-			// Report a leftover temporary file. Enough of them make every
-			// later write to this path fail with the message above.
+			// Report a leftover temporary file. Sufficient leftover files
+			// make all later writes to this path fail with the message above.
 			if err := os.Remove(tmpName); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: cannot remove temp file %s: %v\n", tmpName, err)
 			}

--- a/internal/generate/atomic.go
+++ b/internal/generate/atomic.go
@@ -1,0 +1,62 @@
+package generate
+
+// Atomic file writes.
+//
+// The PDF matrix builds books in parallel, and more than one book of a
+// language writes the same shared files, primarily entities.adoc. A write to a
+// temporary file, then a rename, keeps each write atomic for other processes:
+// a reader gets the previous complete file or the new complete file. These
+// functions do not fsync, because 'task gen' makes all these files again.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// atomicWriteFile writes data to path through a temporary file and a rename.
+// The temporary file is in the destination directory, therefore the rename
+// stays in one filesystem.
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	// os.CreateTemp is not usable here. It creates the file 0600 and needs a
+	// subsequent chmod to perm, and chmod ignores the umask. O_CREATE|O_EXCL
+	// with perm applies the umask, like os.WriteFile.
+	var (
+		tmp     *os.File
+		tmpName string
+		err     error
+	)
+	for i := 0; tmp == nil && i < 100; i++ {
+		tmpName = filepath.Join(dir, fmt.Sprintf(".%s.tmp%d-%d", base, os.Getpid(), i))
+		tmp, err = os.OpenFile(tmpName, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("create temp file in %s: %w", dir, err)
+		}
+	}
+	if tmp == nil {
+		return fmt.Errorf("create temp file in %s: %w", dir, err)
+	}
+
+	// An empty tmpName disables this cleanup after a successful rename.
+	defer func() {
+		if tmpName != "" {
+			tmp.Close()
+			os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		return fmt.Errorf("write %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmpName, path, err)
+	}
+	tmpName = ""
+	return nil
+}

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -223,5 +223,5 @@ func renderTemplate(name, tmplText string, data any, outPath string) error {
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return err
 	}
-	return os.WriteFile(outPath, buf.Bytes(), 0o644)
+	return atomicWriteFile(outPath, buf.Bytes(), 0o644)
 }

--- a/internal/generate/pdfnav.go
+++ b/internal/generate/pdfnav.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -43,20 +44,20 @@ func PDFNav(srcDir, book, lang string) error {
 	}
 	defer in.Close()
 
-	out, err := os.Create(outPath)
-	if err != nil {
-		return fmt.Errorf("pdf-nav: create %s: %w", outPath, err)
-	}
-	defer out.Close()
-
+	// Collect the result in a buffer and write it atomically. An error during
+	// the scan then leaves no incomplete nav file for the next build.
+	var out bytes.Buffer
 	scanner := bufio.NewScanner(in)
 	for scanner.Scan() {
 		line := scanner.Text()
 		transformed := transformNavLine(line, book)
-		fmt.Fprintln(out, transformed)
+		fmt.Fprintln(&out, transformed)
 	}
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("pdf-nav: read %s: %w", inPath, err)
+	}
+	if err := atomicWriteFile(outPath, out.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("pdf-nav: write %s: %w", outPath, err)
 	}
 	return nil
 }

--- a/internal/generate/xrefext.go
+++ b/internal/generate/xrefext.go
@@ -84,7 +84,9 @@ func WriteXrefExtension(destPath string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return fmt.Errorf("xref-converter: mkdir: %w", err)
 	}
-	if err := os.WriteFile(destPath, []byte(xrefConverterRuby), 0o644); err != nil {
+	// The write is atomic, because each concurrent book loads this file with
+	// the asciidoctor -r option. An incomplete file must not be visible.
+	if err := atomicWriteFile(destPath, []byte(xrefConverterRuby), 0o644); err != nil {
 		return fmt.Errorf("xref-converter: write %s: %w", destPath, err)
 	}
 	return nil

--- a/internal/generate/xrefext.go
+++ b/internal/generate/xrefext.go
@@ -84,8 +84,9 @@ func WriteXrefExtension(destPath string) error {
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
 		return fmt.Errorf("xref-converter: mkdir: %w", err)
 	}
-	// The write is atomic, because each concurrent book loads this file with
-	// the asciidoctor -r option. An incomplete file must not be visible.
+	// Concurrent books load this file with the asciidoctor -r option. The
+	// write is atomic so that a 'gen' running at the same time cannot truncate
+	// the file while a book reads it.
 	if err := atomicWriteFile(destPath, []byte(xrefConverterRuby), 0o644); err != nil {
 		return fmt.Errorf("xref-converter: write %s: %w", destPath, err)
 	}

--- a/internal/generate/xrefext.go
+++ b/internal/generate/xrefext.go
@@ -85,8 +85,8 @@ func WriteXrefExtension(destPath string) error {
 		return fmt.Errorf("xref-converter: mkdir: %w", err)
 	}
 	// Concurrent books load this file with the asciidoctor -r option. The
-	// write is atomic so that a 'gen' running at the same time cannot truncate
-	// the file while a book reads it.
+	// write is atomic, thus a concurrent 'gen' cannot truncate the file while
+	// a book reads it.
 	if err := atomicWriteFile(destPath, []byte(xrefConverterRuby), 0o644); err != nil {
 		return fmt.Errorf("xref-converter: write %s: %w", destPath, err)
 	}

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Build all the language x book PDFs for one product, more than one at a time.
+#
+# asciidoctor-pdf has one thread. Concurrent books are therefore the only way
+# to make this build use more than one core.
+#
+# Usage: build_pdfs.sh <product> "<languages>" "<books>"
+# JOBS caps the number of concurrent books. The default is nproc.
+
+set -u
+
+if [ $# -ne 3 ] ; then
+    echo "usage: $0 <product> \"<languages>\" \"<books>\"" >&2
+    exit 2
+fi
+
+PRODUCT="$1"
+LANGUAGES="$2"
+BOOKS="$3"
+
+if [ -z "${JOBS:-}" ] ; then
+    JOBS=$(nproc 2>/dev/null || echo 4)
+fi
+
+case "${JOBS}" in
+    ''|*[!0-9]*|0)
+        echo "usage: JOBS must be a positive integer, got '${JOBS}'" >&2
+        exit 2
+        ;;
+esac
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "${WORKDIR}"' EXIT
+: > "${WORKDIR}/lock"
+
+export WORKDIR PRODUCT
+
+# Build one book. Each job writes to its own log and prints it under a lock.
+# Concurrent books therefore do not mix their output.
+build_one() {
+    local book="$1"
+    local lang="$2"
+    local log="${WORKDIR}/${lang}-${book}.log"
+    local rc
+
+    # STAGE=0: the shared files for this language are in place (see below).
+    # A second staging operation from each book is not safe.
+    task pdf BOOK="${book}" PRODUCT="${PRODUCT}" LANGUAGES="${lang}" STAGE=0 > "${log}" 2>&1
+    rc=$?
+
+    {
+        flock 9
+        cat "${log}"
+        if [ ${rc} -ne 0 ] ; then
+            # The same stream as the log, therefore the two stay together.
+            echo "==> FAILED: ${PRODUCT} / ${lang} / ${book} (exit ${rc})"
+        fi
+    } 9< "${WORKDIR}/lock"
+
+    rm -f "${log}"
+    return ${rc}
+}
+export -f build_one
+
+echo "==> ${PRODUCT} PDFs — languages: ${LANGUAGES} — ${JOBS} at a time"
+
+# Stage each language one time, before the first book starts. Staging in each
+# book makes all the books of a language copy the same tree and write the same
+# entities.adoc at the same time.
+task pdf-stage PRODUCT="${PRODUCT}" LANGUAGES="${LANGUAGES}" || exit 1
+
+for lang in ${LANGUAGES}; do
+    for book in ${BOOKS}; do
+        printf '%s %s\n' "${book}" "${lang}"
+    done
+done | xargs -r -P "${JOBS}" -L 1 bash -c 'build_one "$1" "$2"' bash
+rc=$?
+
+# xargs returns 123 if an invocation failed. Report a plain failure.
+if [ ${rc} -ne 0 ] ; then
+    echo "==> One or more ${PRODUCT} PDFs failed to build." >&2
+    exit 1
+fi

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Build all the language x book PDFs for one product, more than one at a time.
+# Build all the language x book PDFs for one product, concurrently.
 #
-# asciidoctor-pdf has one thread. Concurrent books are therefore the only way
+# asciidoctor-pdf runs on one core. Concurrent books are therefore the only way
 # to make this build use more than one core.
 #
 # Usage: build_pdfs.sh <product> "<languages>" "<books>"
-# JOBS caps the number of concurrent books. The default is nproc.
+# JOBS caps the number of concurrent books. The default is the core count.
 #
 # The caller stages each language first with 'task pdf-stage'. Every book of a
 # language shares one content tree and one entities.adoc, and concurrent writes
@@ -23,37 +23,73 @@ PRODUCT="$1"
 LANGUAGES="$2"
 BOOKS="$3"
 
+# An empty list builds no PDFs. Without this check the script prints a normal
+# summary and exits 0, and a publish pipeline ships no PDFs and stays green.
+if [ -z "${LANGUAGES// /}" ] || [ -z "${BOOKS// /}" ] ; then
+    echo "$0: LANGUAGES and BOOKS must both be non-empty (got '${LANGUAGES}' and '${BOOKS}')" >&2
+    exit 2
+fi
+
+# flock keeps the logs of concurrent books apart. Without it the output of a
+# failed build is unreadable, which is when it matters most.
+if ! command -v flock >/dev/null 2>&1 ; then
+    echo "$0: flock is required (package util-linux)." >&2
+    exit 2
+fi
+
+# Read the cgroup CPU quota first. nproc reports the CPU affinity mask, not the
+# quota, so a container limited with --cpus sees every core of the host. One
+# asciidoctor-pdf for each host core exhausts the memory of a small runner, and
+# the OOM kill appears only as an exit 137.
 if [ -z "${JOBS:-}" ] ; then
     JOBS=$(nproc 2>/dev/null || echo 4)
+    if [ -r /sys/fs/cgroup/cpu.max ] ; then
+        read -r quota period < /sys/fs/cgroup/cpu.max || true
+        if [ "${quota:-max}" != "max" ] && [ "${period:-0}" -gt 0 ] ; then
+            cpus=$(( (quota + period - 1) / period ))
+            [ "${cpus}" -lt 1 ] && cpus=1
+            [ "${cpus}" -lt "${JOBS}" ] && JOBS=${cpus}
+        fi
+    fi
 fi
 
 case "${JOBS}" in
     ''|*[!0-9]*|0)
-        echo "usage: JOBS must be a positive integer, got '${JOBS}'" >&2
+        echo "$0: JOBS must be a positive integer, got '${JOBS}'" >&2
         exit 2
         ;;
 esac
 
-WORKDIR=$(mktemp -d)
+WORKDIR=$(mktemp -d) || { echo "$0: mktemp -d failed; set TMPDIR to a writable directory." >&2; exit 1; }
+if [ ! -d "${WORKDIR}" ] ; then
+    echo "$0: mktemp -d returned no usable directory." >&2
+    exit 1
+fi
 trap 'rm -rf "${WORKDIR}"' EXIT
-: > "${WORKDIR}/lock"
+: > "${WORKDIR}/lock" || exit 1
 
 export WORKDIR PRODUCT
 
 # Build one book. Each job writes to its own log and prints it under a lock.
 # Concurrent books therefore do not mix their output.
 build_one() {
-    local book="$1"
-    local lang="$2"
+    # xargs starts a new shell, and shell options are not inherited. Without
+    # this, a short input line makes book or lang an empty string, and 'task
+    # pdf' then builds the default book or no language at all and exits 0.
+    set -u
+    local book="${1:?build_one: no book}"
+    local lang="${2:?build_one: no lang}"
     local log="${WORKDIR}/${lang}-${book}.log"
     local rc
 
-    # STAGE=0: the shared files for this language are in place (see below).
+    # STAGE=0: the caller staged the shared files of this language already.
     # A second staging operation from each book is not safe.
     task pdf BOOK="${book}" PRODUCT="${PRODUCT}" LANGUAGES="${lang}" STAGE=0 > "${log}" 2>&1
     rc=$?
 
-    {
+    # A failed redirect skips the whole group, so print the log unlocked rather
+    # than lose it. The log is the only record of why a book failed.
+    if ! {
         flock 9
         cat "${log}"
         if [ ${rc} -ne 0 ] ; then
@@ -61,6 +97,11 @@ build_one() {
             echo "==> FAILED: ${PRODUCT} / ${lang} / ${book} (exit ${rc})"
         fi
     } 9< "${WORKDIR}/lock"
+    then
+        echo "==> ${PRODUCT} / ${lang} / ${book}: cannot lock ${WORKDIR}/lock; output follows unserialized" >&2
+        cat "${log}" >&2
+        [ ${rc} -eq 0 ] || echo "==> FAILED: ${PRODUCT} / ${lang} / ${book} (exit ${rc})" >&2
+    fi
 
     rm -f "${log}"
     return ${rc}
@@ -76,8 +117,29 @@ for lang in ${LANGUAGES}; do
 done | xargs -r -P "${JOBS}" -L 1 bash -c 'build_one "$1" "$2"' bash
 rc=$?
 
-# xargs returns 123 if an invocation failed. Report a plain failure.
-if [ ${rc} -ne 0 ] ; then
-    echo "==> One or more ${PRODUCT} PDFs failed to build." >&2
-    exit 1
-fi
+# Every non-zero status is a failure, but they do not mean the same thing.
+# Only 123 means the other books still ran to completion.
+case ${rc} in
+    0)
+        ;;
+    123)
+        echo "==> One or more ${PRODUCT} PDFs failed to build. See the FAILED lines above." >&2
+        exit 1
+        ;;
+    124)
+        echo "==> ${PRODUCT} build stopped: a book exited 255, and xargs did not start the books that remained." >&2
+        exit 1
+        ;;
+    125)
+        echo "==> ${PRODUCT} build stopped: a book was killed by a signal. Out of memory, or interrupted." >&2
+        exit 1
+        ;;
+    126|127)
+        echo "==> ${PRODUCT} build did not start: xargs cannot run bash or import build_one (exit ${rc}). No PDFs were built." >&2
+        exit 1
+        ;;
+    *)
+        echo "==> ${PRODUCT} build failed: unexpected xargs exit ${rc}." >&2
+        exit 1
+        ;;
+esac

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -23,24 +23,24 @@ PRODUCT="$1"
 LANGUAGES="$2"
 BOOKS="$3"
 
-# An empty list builds no PDFs. Without this check the script prints a normal
-# summary and exits 0, and a publish pipeline ships no PDFs and stays green.
+# An empty list builds no PDFs. Without this check, the script prints a summary
+# and exits 0, and the publish steps then package an empty tree.
 if [ -z "${LANGUAGES// /}" ] || [ -z "${BOOKS// /}" ] ; then
     echo "$0: LANGUAGES and BOOKS must both be non-empty (got '${LANGUAGES}' and '${BOOKS}')" >&2
     exit 2
 fi
 
-# flock keeps the logs of concurrent books apart. Without it the output of a
-# failed build is unreadable, which is when it matters most.
+# flock keeps the logs of concurrent books separate. Without flock, the output
+# of a failed build mixes with the output of the other books.
 if ! command -v flock >/dev/null 2>&1 ; then
     echo "$0: flock is required (package util-linux)." >&2
     exit 2
 fi
 
-# Read the cgroup CPU quota first. nproc reports the CPU affinity mask, not the
-# quota, so a container limited with --cpus sees every core of the host. One
-# asciidoctor-pdf for each host core exhausts the memory of a small runner, and
-# the OOM kill appears only as an exit 137.
+# Read the cgroup CPU quota first. nproc reports the CPU affinity mask and not
+# the quota, so a container with a --cpus limit sees all the cores of the host.
+# One asciidoctor-pdf for each host core uses all the memory of a small runner,
+# and the OOM kill shows only as exit 137.
 if [ -z "${JOBS:-}" ] ; then
     JOBS=$(nproc 2>/dev/null || echo 4)
     if [ -r /sys/fs/cgroup/cpu.max ] ; then
@@ -73,22 +73,22 @@ export WORKDIR PRODUCT
 # Build one book. Each job writes to its own log and prints it under a lock.
 # Concurrent books therefore do not mix their output.
 build_one() {
-    # xargs starts a new shell, and shell options are not inherited. Without
-    # this, a short input line makes book or lang an empty string, and 'task
-    # pdf' then builds the default book or no language at all and exits 0.
+    # xargs starts a new shell, and a new shell does not inherit shell options.
+    # Without 'set -u', a short input line makes book or lang an empty string.
+    # 'task pdf' then builds the default book or no language, and exits 0.
     set -u
     local book="${1:?build_one: no book}"
     local lang="${2:?build_one: no lang}"
     local log="${WORKDIR}/${lang}-${book}.log"
     local rc
 
-    # STAGE=0: the caller staged the shared files of this language already.
-    # A second staging operation from each book is not safe.
+    # STAGE=0: the caller stages the shared files of this language. A second
+    # staging operation from each book is not safe.
     task pdf BOOK="${book}" PRODUCT="${PRODUCT}" LANGUAGES="${lang}" STAGE=0 > "${log}" 2>&1
     rc=$?
 
-    # A failed redirect skips the whole group, so print the log unlocked rather
-    # than lose it. The log is the only record of why a book failed.
+    # A failed redirect skips the full group. Print the log without the lock, or
+    # you lose it. The log is the only record of the failure.
     if ! {
         flock 9
         cat "${log}"
@@ -117,8 +117,8 @@ for lang in ${LANGUAGES}; do
 done | xargs -r -P "${JOBS}" -L 1 bash -c 'build_one "$1" "$2"' bash
 rc=$?
 
-# Every non-zero status is a failure, but they do not mean the same thing.
-# Only 123 means the other books still ran to completion.
+# All non-zero statuses are failures, but they have different causes. Only 123
+# tells you that the other books completed.
 case ${rc} in
     0)
         ;;
@@ -131,11 +131,11 @@ case ${rc} in
         exit 1
         ;;
     125)
-        echo "==> ${PRODUCT} build stopped: a book was killed by a signal. Out of memory, or interrupted." >&2
+        echo "==> ${PRODUCT} build stopped: a signal killed a book. Out of memory, or interrupted." >&2
         exit 1
         ;;
     126|127)
-        echo "==> ${PRODUCT} build did not start: xargs cannot run bash or import build_one (exit ${rc}). No PDFs were built." >&2
+        echo "==> ${PRODUCT} build did not start: xargs cannot run bash or import build_one (exit ${rc}). The build made no PDFs." >&2
         exit 1
         ;;
     *)

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -53,8 +53,11 @@ if [ -z "${JOBS:-}" ] ; then
     fi
 fi
 
+# 'xargs -P 0' is unlimited concurrency, thus reject every spelling of zero and
+# not only the one digit. '00' passes a '0' test and gives one asciidoctor-pdf
+# for each book of each language at the same time.
 case "${JOBS}" in
-    ''|*[!0-9]*|0)
+    ''|*[!0-9]*|0|0[0-9]*)
         echo "$0: JOBS must be a positive integer, got '${JOBS}'" >&2
         exit 2
         ;;

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -6,6 +6,11 @@
 #
 # Usage: build_pdfs.sh <product> "<languages>" "<books>"
 # JOBS caps the number of concurrent books. The default is nproc.
+#
+# The caller stages each language first with 'task pdf-stage'. Every book of a
+# language shares one content tree and one entities.adoc, and concurrent writes
+# to them are not safe. The 'pdf' task refuses to build if the caller did not
+# stage, therefore this script does not check.
 
 set -u
 
@@ -63,11 +68,6 @@ build_one() {
 export -f build_one
 
 echo "==> ${PRODUCT} PDFs — languages: ${LANGUAGES} — ${JOBS} at a time"
-
-# Stage each language one time, before the first book starts. Staging in each
-# book makes all the books of a language copy the same tree and write the same
-# entities.adoc at the same time.
-task pdf-stage PRODUCT="${PRODUCT}" LANGUAGES="${LANGUAGES}" || exit 1
 
 for lang in ${LANGUAGES}; do
     for book in ${BOOKS}; do

--- a/scripts/use_po.sh
+++ b/scripts/use_po.sh
@@ -3,7 +3,8 @@
 # There is no need of system-wide installation of po4a
 # Usage: PERLLIB=/path/to/po4a/lib use_po.sh
 # you may set following variables
-# PO_DIR place where the po files are
+# SRCDIR root of the documentation repository
+# PODIR place where to create the po
 # PUB_DIR place where to publish localized files
 
 # USER-CONFIGURABLE VARIABLES
@@ -51,30 +52,9 @@ fi
 # GENERATE TRANSLATED ASCIIDOC FROM .PO FILES, WITHOUT UPDATING .POT/PO
 #######################################################################
 
-# There is one .cfg file for each module, and each one writes only to its own
-# translations/<lang>/modules/<module>/ subtree. The configs are independent
-# and run in parallel. The number of configs, not the number of cores, is
-# therefore the limit. JOBS=1 runs them in sequence.
-if [ -z "$JOBS" ] ; then
-	JOBS=$(nproc 2>/dev/null || echo 4)
-fi
-
-case "$JOBS" in
-    ''|*[!0-9]*|0)
-        echo "ERROR: JOBS must be a positive integer, got '$JOBS'." >&2
-        exit 2
-        ;;
-esac
-
-ls $CURRENT_DIR/$PO_DIR/*.cfg | xargs -P "$JOBS" -I{} \
-    po4a --srcdir $CURRENT_DIR --destdir $CURRENT_DIR -k $TRANSLATION_THRESHOLD_PERCENTAGE -M UTF-8 -L UTF-8 --no-update -o nolinting {}
-
-# Stop if po4a failed. A run that reports success after a partial failure
-# leaves an incomplete translations tree, and the caller cannot see this.
-if [ $? -ne 0 ] ; then
-    echo "ERROR: at least one po4a invocation failed; translations are incomplete." >&2
-    exit 1
-fi
+for f in $(ls $CURRENT_DIR/$PO_DIR/*.cfg); do
+    po4a --srcdir $CURRENT_DIR --destdir $CURRENT_DIR -k $TRANSLATION_THRESHOLD_PERCENTAGE -M UTF-8 -L UTF-8 --no-update -o nolinting $f
+done
 
 
 

--- a/scripts/use_po.sh
+++ b/scripts/use_po.sh
@@ -3,8 +3,7 @@
 # There is no need of system-wide installation of po4a
 # Usage: PERLLIB=/path/to/po4a/lib use_po.sh
 # you may set following variables
-# SRCDIR root of the documentation repository
-# PODIR place where to create the po
+# PO_DIR place where the po files are
 # PUB_DIR place where to publish localized files
 
 # USER-CONFIGURABLE VARIABLES
@@ -52,9 +51,30 @@ fi
 # GENERATE TRANSLATED ASCIIDOC FROM .PO FILES, WITHOUT UPDATING .POT/PO
 #######################################################################
 
-for f in $(ls $CURRENT_DIR/$PO_DIR/*.cfg); do
-    po4a --srcdir $CURRENT_DIR --destdir $CURRENT_DIR -k $TRANSLATION_THRESHOLD_PERCENTAGE -M UTF-8 -L UTF-8 --no-update -o nolinting $f
-done
+# There is one .cfg file for each module, and each one writes only to its own
+# translations/<lang>/modules/<module>/ subtree. The configs are independent
+# and run in parallel. The number of configs, not the number of cores, is
+# therefore the limit. JOBS=1 runs them in sequence.
+if [ -z "$JOBS" ] ; then
+	JOBS=$(nproc 2>/dev/null || echo 4)
+fi
+
+case "$JOBS" in
+    ''|*[!0-9]*|0)
+        echo "ERROR: JOBS must be a positive integer, got '$JOBS'." >&2
+        exit 2
+        ;;
+esac
+
+ls $CURRENT_DIR/$PO_DIR/*.cfg | xargs -P "$JOBS" -I{} \
+    po4a --srcdir $CURRENT_DIR --destdir $CURRENT_DIR -k $TRANSLATION_THRESHOLD_PERCENTAGE -M UTF-8 -L UTF-8 --no-update -o nolinting {}
+
+# Stop if po4a failed. A run that reports success after a partial failure
+# leaves an incomplete translations tree, and the caller cannot see this.
+if [ $? -ne 0 ] ; then
+    echo "ERROR: at least one po4a invocation failed; translations are incomplete." >&2
+    exit 1
+fi
 
 
 


### PR DESCRIPTION
# Description

`task pdf:mlm` and its siblings built the language x book matrix one PDF at a time, so a full MLM build used a single core for over five minutes; books and po4a configs now run concurrently, capped with `JOBS=<n>` and defaulting to `nproc`. The en + ja MLM matrix goes from 2m48s to 37s on a 16-core desktop.

Building books at the same time exposed two files that were written once per book but shared by every book of a language: the English fallback module tree and `entities.adoc`. A new `pdf-stage` task writes both once per language before the books fan out, and the matrix builds books with `STAGE=0` so they skip it. Generated files are now written to a temporary file and renamed, so a concurrent reader can never see a half-written one.

Separately, `pdf:all` ran both products as parallel deps even though `translations/{lang}/branding/pdf/entities.adoc` is not product-scoped, so Uyuni PDFs could ship MLM entities; the two products now run in sequence, which costs nothing since each one saturates the cores on its own.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5243
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5252
- manager-5.1 (this PR)
