### PR TITLE
manager-5.2 - Fix the quoting and JOBS validation of the PDF archive tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Made JOBS=00 an error, which xargs read as unlimited concurrency
+- Fixed the PDF archive tasks, which failed when the checkout path contains a space
 - Sped up PDF builds by building the books and applying the translations concurrently. JOBS=<n> caps the number of concurrent jobs
 - Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
 - Fixed the pdf-tar tasks, which produced no archive and packaged both products into each one

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -603,7 +603,7 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/${LANG_CODE}/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip"
           mkdir -p build/${LANG_CODE}
           rm -f "${ARCHIVE}"
           cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
@@ -615,7 +615,7 @@ tasks:
       - for: {var: LANGUAGES}
         cmd: |
           LANG_CODE="{{.ITEM}}"
-          ARCHIVE={{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/${LANG_CODE}/uyuni-docs_${LANG_CODE}-pdf.zip"
           mkdir -p build/${LANG_CODE}
           rm -f "${ARCHIVE}"
           cd build/pdf && zip -r9 "${ARCHIVE}" ${LANG_CODE}/
@@ -644,7 +644,7 @@ tasks:
         cmd: |
           LANG_CODE="{{.ITEM}}"
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product mlm)
-          ARCHIVE={{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/packages/suse-multi-linux-manager-docs_${LANG_CODE}-pdf.zip"
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
             echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:mlm LANGUAGES=${LANG_CODE}' first." >&2
             exit 1
@@ -661,7 +661,7 @@ tasks:
         cmd: |
           LANG_CODE="{{.ITEM}}"
           PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product uyuni)
-          ARCHIVE={{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip
+          ARCHIVE="{{.ROOT_DIR}}/build/packages/uyuni-docs_${LANG_CODE}-pdf.zip"
           if ! ls build/${LANG_CODE}/pdf/${PREFIX}_*.pdf >/dev/null 2>&1 ; then
             echo "No ${PREFIX} PDFs in build/${LANG_CODE}/pdf. Run 'task pdf:uyuni LANGUAGES=${LANG_CODE}' first." >&2
             exit 1

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -630,8 +630,10 @@ tasks:
   # build/{lang}/pdf/ holds the books of the two products. Select the books
   # with the filename prefix of the product. Without the prefix, the two
   # archives get the same content and are different only in the name.
-  # 'pdf-zip:*' prevents this in a different way: it reads build/pdf/{lang}/,
-  # which 'pdf-collect:{product}' fills for one product at a time.
+  #
+  # 'pdf-zip:*' still has this defect. It reads build/pdf/{lang}/, which
+  # 'pdf-collect:{product}' adds to but never empties, thus a run of the two
+  # products in one tree gives each archive the books of both.
   #
   # zip adds files to an archive that exists. Remove the old archive first, or
   # a book that a later run does not build stays in it.

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -48,8 +48,11 @@ if [ -z "${JOBS:-}" ] ; then
     fi
 fi
 
+# 'xargs -P 0' is unlimited concurrency, thus reject every spelling of zero and
+# not only the one digit. '00' passes a '0' test and gives one asciidoctor-pdf
+# for each book of each language at the same time.
 case "${JOBS}" in
-    ''|*[!0-9]*|0)
+    ''|*[!0-9]*|0|0[0-9]*)
         echo "$0: JOBS must be a positive integer, got '${JOBS}'" >&2
         exit 2
         ;;


### PR DESCRIPTION
# Description

Follow-up to #5252: quotes the four `ARCHIVE=` assignments, rejects every spelling of a zero `JOBS`, and corrects a note that claimed `pdf-zip:*` cannot package the two products into one archive.

# Target branches

manager-5.2

# Links

Follow-up to #5252, master counterpart #5254
