### PR TITLE
manager-5.2 - Clarify relationship between custom RBAC and Salt-API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Clarified relationship between custom RBAC and Salt-API access
 - Extracted and relocated general sudo configuration guidelines to a new central page, and added unprivileged onboarding support references for SLE 16 (bsc#1275794)
 - Made JOBS=00 an error, which xargs read as unlimited concurrency
 - Fixed the PDF archive tasks, which failed when the checkout path contains a space

--- a/en/modules/administration/pages/role-based-access-control.adoc
+++ b/en/modules/administration/pages/role-based-access-control.adoc
@@ -1,6 +1,6 @@
 [[rbac]]
 = Role-Based Access Control (RBAC)
-:revdate: 2026-05-13
+:revdate: 2026-09-03
 :page-revdate: {revdate}
 
 Role-Based Access Control (RBAC) is a security method that restricts resources access to authorized users based on their assigned roles. In {productname}, RBAC ensures that users can only perform actions and access resources for which they have explicit authorization, enhancing security and simplifying administration.
@@ -11,6 +11,20 @@ The core principles of RBAC include:
 * *Granular Control:* Providing fine-grained control over specific functionalities.
 * *Separation of Duties:* Preventing a single user from having too much control over critical processes.
 * *Auditability:* Allowing for clear tracking of user actions and permissions.
+
+
+[[rbac-architectural-scope]]
+== Architectural scope
+
+In {productname}, RBAC controls only the {webui} and the {productname} API (XML-RPC and JSON-RPC) layers.
+The RBAC engine controls access to these interfaces.
+
+RBAC does not control the native authentication of the Salt API (`salt-api` or `eauth`) for external users.
+The Salt API is an internal service.
+The system permits access to the Salt API port (port `9080`) only from the internal loopback interface of the {productname} Server.
+Only Tomcat and Taskomatic services on the server can use the Salt API.
+External users cannot log in to the Salt API directly.
+Instead, {productname} authenticates the user, checks their RBAC permissions, and then runs Salt commands on behalf of the user.
 
 
 [[rbac-key-concepts]]

--- a/en/modules/specialized-guides/pages/salt/salt-overview.adoc
+++ b/en/modules/specialized-guides/pages/salt/salt-overview.adoc
@@ -1,6 +1,6 @@
 [[salt-overview]]
 = Salt Guide Overview
-:revdate: 2025-03-27
+:revdate: 2026-09-03
 :page-revdate: {revdate}
 
 Salt is a remote execution engine, configuration management and orchestration system used by {productname} to manage clients.
@@ -12,3 +12,15 @@ This book is designed to be a primer for using Salt with {productname}.
 For more information about Salt, see the Salt documentation at https://docs.saltproject.io/en/latest/contents.html.
 
 The current version of Salt in {productname} is {saltversion}.
+
+
+[[salt-security-boundary]]
+== Security and execution boundary
+
+{productname} protects the Salt master and the Salt API from direct external access.
+The system permits access to the Salt API only from the internal loopback interface of the {productname} Server.
+Only Tomcat and Taskomatic services on the server can use the Salt API.
+
+External user requests must go through the {productname} API or the {webui}.
+{productname} authenticates the user and checks their permissions with Role-Based Access Control (RBAC) before the system runs Salt commands.
+For more information about RBAC, see xref:administration:role-based-access-control.adoc[].


### PR DESCRIPTION
# Description

Backport of #5256 to manager-5.2: Document the architectural boundary and relationship between the custom Role-Based Access Control (RBAC) engine and the `salt-api` daemon. Explains that RBAC governs Tomcat layers (WebUI and API), and that `salt-api` binds strictly to the internal loopback interface of the server.

# Target branches

manager-5.2

# Links

Closes SUSE/spacewalk#31807, master counterpart #5256, 5.1 counterpart #5258