### PR TITLE
master - Stop generating antora.yml in gen-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Stopped generating antora.yml in gen-all, where the two products wrote one file in a random order
+- Stopped generating antora.yml in gen-all, where the two products wrote one file in a random order.
+  The `-content-dir` flag of gen-all went to that file alone and is gone as well; gen-antora keeps its own
 - Added a manual trigger to the translation file workflow, which ran only on a push
 - Fixed `l10n-weblate/update-cfg-files` failing when invoked from anywhere other than
   the `l10n-weblate/` directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Stopped generating antora.yml in gen-all, where the two products wrote one file in a random order
 - Added a manual trigger to the translation file workflow, which ran only on a push
 - Fixed `l10n-weblate/update-cfg-files` failing when invoked from anywhere other than
   the `l10n-weblate/` directory

--- a/cmd/docbuild/main.go
+++ b/cmd/docbuild/main.go
@@ -2,7 +2,7 @@
 //
 // Usage:
 //
-//	docbuild gen-all                                     Generate all configs for all languages
+//	docbuild gen-all                                     Generate every config except antora.yml
 //	docbuild gen-site  -product P -output O -lang L      Generate one site.yml
 //	docbuild gen-antora -product P -lang L               Generate one antora.yml
 //	docbuild gen-entities -product P -lang L             Generate one entities-{product}.adoc
@@ -68,11 +68,10 @@ func main() {
 func runGenAll(repoRoot string, args []string) {
 	fs := flag.NewFlagSet("gen-all", flag.ExitOnError)
 	cfgPath := fs.String("config", defaultConfig, "path to config.yml")
-	contentDir := fs.String("content-dir", defaultContentDir, "relative path to English modules directory")
 	_ = fs.Parse(args)
 
 	cfg := mustLoad(filepath.Join(repoRoot, *cfgPath))
-	if err := generate.All(cfg, repoRoot, *contentDir); err != nil {
+	if err := generate.All(cfg, repoRoot); err != nil {
 		fatalf("gen-all: %v", err)
 	}
 	fmt.Println("docbuild: generated all configs")
@@ -221,9 +220,10 @@ func usage() {
 	fmt.Print(`docbuild — uyuni-docs build config generator
 
 Subcommands:
-  gen-all                                    Generate all configs for all languages
+  gen-all                                    Generate every config for all languages, except antora.yml
   gen-site  -product P -output O -lang L     Generate translations/{lang}/{output}.site.yml
-  gen-antora -product P -lang L              Generate translations/{lang}/antora.yml
+  gen-antora -product P -lang L              Generate translations/{lang}/antora.yml. One path for the
+                                             two products, so run it for your product before Antora
   gen-entities -product P -lang L            Generate branding/pdf/entities-{product}.adoc
   gen-pdf-nav -book B -lang L -dir D         Generate nav-{book}-guide.pdf.{lang}.adoc from Antora nav
   inject-lang-selector -hbs PATH             Inject language selector into header-content.hbs

--- a/cmd/docbuild/main.go
+++ b/cmd/docbuild/main.go
@@ -2,9 +2,10 @@
 //
 // Usage:
 //
-//	docbuild gen-all                                     Generate every config except antora.yml
+//	docbuild gen-all                                     Generate every config for all languages, except antora.yml
 //	docbuild gen-site  -product P -output O -lang L      Generate one site.yml
-//	docbuild gen-antora -product P -lang L               Generate one antora.yml
+//	docbuild gen-antora -product P -lang L               Generate one antora.yml. One path for the two
+//	                                                     products, so run it for your product before Antora
 //	docbuild gen-entities -product P -lang L             Generate one entities-{product}.adoc
 //	docbuild gen-pdf-nav -book B -lang L -dir D          Generate PDF nav from Antora nav file
 //	docbuild inject-lang-selector -output O              Inject language selector into header-content.hbs

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -138,7 +138,7 @@ After cloning the repository, run these once:
 
 ```bash
 task setup    # Compiles cmd/docbuild → .bin/docbuild
-task gen      # Generates all Antora/site configs from config.yml
+task gen      # Generates the site configs and xref-converter extension from config.yml
 ```
 
 ---

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -25,7 +25,7 @@ cmd/docbuild/main.go  (Go binary)
     │  renders Go text/templates
     │
     ├──► translations/{lang}/{output}.site.yml   (per output-target, per language)
-    ├──► translations/{lang}/antora.yml          (per language; the product of the last writer)
+    ├──► translations/{lang}/antora.yml          (gen-antora only, for the product being built)
     ├──► translations/{lang}/branding/pdf/entities-{product}.adoc  (per product, per language)
     ├──► translations/{lang}/modules/{book}/nav-{book}-guide.pdf.{lang}.adoc
     └──► .bin/xref-converter.rb                 (embedded Ruby extension)

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -25,7 +25,7 @@ cmd/docbuild/main.go  (Go binary)
     │  renders Go text/templates
     │
     ├──► translations/{lang}/{output}.site.yml   (per output-target, per language)
-    ├──► translations/{lang}/antora.yml          (per product, per language)
+    ├──► translations/{lang}/antora.yml          (per language; the product of the last writer)
     ├──► translations/{lang}/branding/pdf/entities-{product}.adoc  (per product, per language)
     ├──► translations/{lang}/modules/{book}/nav-{book}-guide.pdf.{lang}.adoc
     └──► .bin/xref-converter.rb                 (embedded Ruby extension)
@@ -235,9 +235,9 @@ asciidoc_extensions:
 
 | Command | Output | Replaces |
 |---|---|---|
-| `docbuild gen-all [-content-dir <dir>]` | All configs for all languages | `configure` Python script |
+| `docbuild gen-all` | Every config for all languages, except `antora.yml` | `configure` Python script |
 | `docbuild gen-site -product <p> -output <o> -lang <code>` | `translations/{lang}/{output}.site.yml` | `site.yml.j2` + sed block in `Makefile.j2` |
-| `docbuild gen-antora -product <p> -lang <code> [-content-dir <dir>]` | `translations/{lang}/antora.yml` | `antora.yml.j2` |
+| `docbuild gen-antora -product <p> -lang <code> [-content-dir <dir>]` | `translations/{lang}/antora.yml`. Antora requires this name, so the two products share one path. Run it for your product immediately before Antora. | `antora.yml.j2` |
 | `docbuild gen-entities -product <p> -lang <code>` | `translations/{lang}/branding/pdf/entities-{product}.adoc` | `entities.adoc.j2` + `entities.specific.adoc.j2` |
 | `docbuild gen-pdf-nav -book <b> -lang <code> -dir <path>` | `{path}/nav-{book}-guide.pdf.{lang}.adoc` | PDF nav generation in `Makefile.section.functions` |
 | `docbuild inject-lang-selector -hbs <path>` | Modifies `header-content.hbs` in-place with language selector | Language selector inject in `Makefile.j2` |

--- a/docs/toolchain-migration/README.md
+++ b/docs/toolchain-migration/README.md
@@ -65,7 +65,7 @@ task container:shell
 ```bash
 # First-time setup
 task setup    # Build the Go docbuild binary
-task gen      # Regenerate Antora/site configs from config.yml
+task gen      # Regenerate site configs and xref-converter extension from config.yml
 
 # Publish builds
 task publish:dsc          # Full MLM publish — HTML + PDFs + zips

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -93,6 +93,14 @@ func SiteYML(cfg *config.Config, productName, outputName, langCode, repoRoot str
 }
 
 // AntoraYML generates translations/{lang}/antora.yml.
+//
+// Antora requires the component descriptor to carry the name antora.yml at the
+// root of the content start path, so the path holds no product and the two
+// products overwrite each other. Every caller must therefore run this
+// generator for its own product immediately before it starts Antora. The
+// draft:* and validate:* tasks in Taskfile.yml do this. For the same reason,
+// All does not call this generator: a run for each product leaves one file
+// with the names of whichever product ran last.
 func AntoraYML(cfg *config.Config, productName, langCode, repoRoot, contentDir string) error {
 	lang, err := cfg.LanguageByCode(langCode)
 	if err != nil {
@@ -182,8 +190,10 @@ func readLocaleAttributes(repoRoot, langCode string) (string, error) {
 	return strings.TrimRight(content, "\n"), nil
 }
 
-// All runs all generators for every language in cfg.
-func All(cfg *config.Config, repoRoot, contentDir string) error {
+// All runs the generators that write to a path of their own, for every
+// language and product in cfg. It does not write antora.yml, which has one
+// path for the two products. See AntoraYML.
+func All(cfg *config.Config, repoRoot string) error {
 	// Write the embedded xref-converter Ruby extension alongside the binary.
 	xrefDest := filepath.Join(repoRoot, ".bin", "xref-converter.rb")
 	if err := WriteXrefExtension(xrefDest); err != nil {
@@ -196,11 +206,6 @@ func All(cfg *config.Config, repoRoot, contentDir string) error {
 			dir := filepath.Join(repoRoot, "translations", lang.Code)
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return fmt.Errorf("mkdir %s: %w", dir, err)
-			}
-
-			// antora.yml
-			if err := AntoraYML(cfg, productName, lang.Code, repoRoot, contentDir); err != nil {
-				return fmt.Errorf("gen antora.yml [%s/%s]: %w", productName, lang.Code, err)
 			}
 
 			// entities-{product}.adoc

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -95,12 +95,14 @@ func SiteYML(cfg *config.Config, productName, outputName, langCode, repoRoot str
 // AntoraYML generates translations/{lang}/antora.yml.
 //
 // Antora requires the component descriptor to carry the name antora.yml at the
-// root of the content start path, so the path holds no product and the two
-// products overwrite each other. Every caller must therefore run this
-// generator for its own product immediately before it starts Antora. The
-// draft:* and validate:* tasks in Taskfile.yml do this. For the same reason,
-// All does not call this generator: a run for each product leaves one file
-// with the names of whichever product ran last.
+// root of the content start path. SiteYML sets that path to translations/{lang},
+// which holds no product, so the two products overwrite each other. Every caller
+// must therefore run this generator for its own product immediately before it
+// starts Antora. The draft:* and validate:* tasks in Taskfile.yml do this. For
+// the same reason, All does not call this generator: a run for each product
+// leaves one file with the names of whichever product ran last. A per-product
+// start path would end the collision, at the cost of a content tree for each
+// product.
 func AntoraYML(cfg *config.Config, productName, langCode, repoRoot, contentDir string) error {
 	lang, err := cfg.LanguageByCode(langCode)
 	if err != nil {


### PR DESCRIPTION
# Description

`gen-all` wrote `translations/{lang}/antora.yml` one time for each product into one path, in the random order of a Go map, and no build read the result.

# Target branches

- master (this PR)
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5265
- manager-5.1 https://github.com/uyuni-project/uyuni-docs/pull/5266

# Links

- Follow-up to #5245, which fixed the same last-writer-wins shape for the PDF entities file.

Antora requires the component descriptor to carry the name `antora.yml` at the root of the content start path, so a per-product filename is not available here. Instead, the generator now stands alone: `draft:*` and `validate:*` already run `gen-antora` for their own product on the line before they start Antora, and `task translations` deletes the whole `translations/` tree before that. The doc comment records the constraint so a future caller does not depend on an output with no owner.

The `-content-dir` flag of `gen-all` fed the `antora.yml` template only, so it goes as well. `gen-antora` keeps its own copy.

Verified: `task gen` writes no `antora.yml`; `task container:draft:mlm-dsc LANGUAGES=en` builds the site and leaves `name: docs` / `title: SUSE Multi-Linux Manager Guides`; `gen-antora -product uyuni` then leaves `name: uyuni`; `task pdf BOOK=legal PRODUCT=mlm` still produces a PDF titled `SUSE Multi-Linux Manager 5.2: Legal`.
