### PR TITLE
manager-5.1 - Give each product its own PDF entities file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Made JOBS=00 an error, which xargs read as unlimited concurrency
 - Fixed the PDF archive tasks, which failed when the checkout path contains a space
 - Sped up PDF builds by building the books concurrently. JOBS=<n> caps the number of concurrent jobs
-- Fixed task pdf:all so the two products no longer overwrite each other's entities.adoc while building at the same time
+- Fixed PDF builds so the two products no longer share one entities file, which could put SUSE Multi-Linux Manager names into Uyuni PDFs and the other way round
 - Fixed the pdf-tar tasks, which produced no archive and packaged both products into each one
 - Made an empty or incorrect LANGUAGES stop the build instead of reporting success with no output
 - Made an exported LANGUAGES set the default language selection

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -351,6 +351,11 @@ tasks:
   # them are not safe. Stage each language one time, then build its books with
   # STAGE=0.
   #
+  # The entities file carries the product in its name. The two products share
+  # the language tree, so one entities.adoc goes to the last writer, and a
+  # build then ships the names of the other product. Each nav file selects its
+  # copy with the entities-product attribute.
+  #
   # 'pdf:mlm' and 'pdf:uyuni' call this in their own process, therefore
   # stage-content can dedupe itself with 'run: once'. The single-book 'pdf'
   # task calls it as a subprocess, which is why this task is not internal. It
@@ -364,8 +369,8 @@ tasks:
     cmds:
       - task: stage-content
       - for: {var: LANGUAGES}
-        # This runs after 'stage-content', so entities.adoc is the later of the
-        # two paths. The STAGE=0 check in 'pdf' examines both.
+        # This runs after 'stage-content', so the entities file is the later of
+        # the two paths. The STAGE=0 check in 'pdf' examines both.
         cmd: "{{.DOCBUILD}} gen-entities -product {{.PRODUCT}} -lang {{.ITEM}}"
 
   # --------------------------------------------------------------------------
@@ -380,10 +385,9 @@ tasks:
     desc: "[Local] Build one PDF book — usage: task pdf BOOK=<book> PRODUCT=<product> LANGUAGES=<langs>"
     # 'setup', not 'gen'. build_pdfs.sh starts one 'task pdf' process for each
     # book, and 'run: once' applies to one process only, so each process
-    # evaluates 'gen' again. 'gen-all' writes
-    # translations/{lang}/branding/pdf/entities.adoc once for each product, to
-    # a path with no product in it, in Go map order. A 'gen' after the staging
-    # therefore replaces the staged entities with those of a different product.
+    # evaluates 'gen' again. That is one full config generation for each book
+    # of each language, and each one writes the same files. The writes are
+    # atomic, so the cost is the reason, not the correctness.
     # 'pdf-stage' keeps the 'gen' dependency for the STAGE=1 path.
     deps: [setup, _guard-lang]
     vars:
@@ -439,22 +443,23 @@ tasks:
           # Resolve PDF filename prefix from config.yml (e.g. suse_multi_linux_manager or uyuni)
           PDF_PREFIX=$({{.DOCBUILD}} get-pdf-prefix -product ${PRODUCT})
 
-          # Stage the content tree and entities.adoc, unless the caller stages
-          # the full language. Asciidoctor reports only an ERROR for a missing
-          # entities.adoc, and --failure-level FATAL ignores an ERROR. The
-          # result is a PDF with unresolved attributes.
+          # Stage the content tree and the entities file, unless the caller
+          # stages the full language. Asciidoctor reports only an ERROR for a
+          # missing entities file, and --failure-level FATAL ignores an ERROR.
+          # The result is a PDF with unresolved attributes.
           #
           # Examine both paths that pdf-stage writes, not only the later one.
-          # Also make sure that entities.adoc has content. An interrupted write
-          # leaves an empty file, and an empty file resolves no attributes.
+          # Also make sure that the entities file has content. An interrupted
+          # write leaves an empty file, which resolves no attributes.
+          ENTITIES="${SRCDIR}/branding/pdf/entities-${PRODUCT}.adoc"
           case "{{.STAGE}}" in
             1)
               task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}
               ;;
             0)
-              if [ ! -s "${SRCDIR}/branding/pdf/entities.adoc" ] || [ ! -d "${SRCDIR}/modules/${BOOK}" ]; then
+              if [ ! -s "${ENTITIES}" ] || [ ! -d "${SRCDIR}/modules/${BOOK}" ]; then
                 echo "STAGE=0 but ${LANG_CODE} is not staged:" >&2
-                echo "  ${SRCDIR}/branding/pdf/entities.adoc is missing or empty," >&2
+                echo "  ${ENTITIES} is missing or empty," >&2
                 echo "  or ${SRCDIR}/modules/${BOOK} is missing." >&2
                 echo "run: task pdf-stage PRODUCT=${PRODUCT} LANGUAGES=${LANG_CODE}" >&2
                 exit 1
@@ -476,6 +481,7 @@ tasks:
             -a lang=${LANG_CODE} \
             -a pdf-themesdir={{.PDF_THEMES_DIR}}/ \
             -a pdf-theme=${THEME} \
+            -a entities-product=${PRODUCT} \
             -a pdf-fontsdir={{.PDF_FONTS_DIR}} \
             -a revdate="${REVDATE}" \
             -a examplesdir=modules/${BOOK}/examples \
@@ -512,10 +518,10 @@ tasks:
         vars: {PRODUCT: uyuni}
       - bash scripts/build_pdfs.sh uyuni "{{.LANGUAGES}}" "{{.BOOKS}}"
 
-  # The products run in sequence, not as parallel deps. Both write
-  # translations/{lang}/branding/pdf/entities.adoc, which has no product in its
-  # path. A parallel run puts one product's entities in the other product's
-  # PDFs. One product usually uses all the cores, so the sequence costs little.
+  # The products run in sequence, not as parallel deps. One product usually
+  # uses all the cores, so the sequence costs little. The two products no
+  # longer share an entities file, therefore this order is a cost decision and
+  # not a correctness one.
   pdf:all:
     desc: "[Local] Build all PDFs — both products, all languages"
     cmds:

--- a/cmd/docbuild/main.go
+++ b/cmd/docbuild/main.go
@@ -5,7 +5,7 @@
 //	docbuild gen-all                                     Generate all configs for all languages
 //	docbuild gen-site  -product P -output O -lang L      Generate one site.yml
 //	docbuild gen-antora -product P -lang L               Generate one antora.yml
-//	docbuild gen-entities -product P -lang L             Generate one entities.adoc
+//	docbuild gen-entities -product P -lang L             Generate one entities-{product}.adoc
 //	docbuild gen-pdf-nav -book B -lang L -dir D          Generate PDF nav from Antora nav file
 //	docbuild inject-lang-selector -output O              Inject language selector into header-content.hbs
 //	docbuild collect-pdfs -product P -src S -dest D      Move PDFs into dest/{lang}/ structure
@@ -241,7 +241,7 @@ Subcommands:
   gen-all                                    Generate all configs for all languages
   gen-site  -product P -output O -lang L     Generate translations/{lang}/{output}.site.yml
   gen-antora -product P -lang L              Generate translations/{lang}/antora.yml
-  gen-entities -product P -lang L            Generate branding/pdf/entities.adoc
+  gen-entities -product P -lang L            Generate branding/pdf/entities-{product}.adoc
   gen-pdf-nav -book B -lang L -dir D         Generate nav-{book}-guide.pdf.{lang}.adoc from Antora nav
   inject-lang-selector -hbs PATH             Inject language selector into header-content.hbs
   get-pdf-prefix -product P                              Print the PDF filename prefix for a product

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -19,7 +19,7 @@ cmd/docbuild/main.go  (Go binary)
     │
     ├──► translations/{lang}/{output}.site.yml   (per output-target, per language)
     ├──► translations/{lang}/antora.yml          (per product, per language)
-    ├──► translations/{lang}/branding/pdf/entities.adoc  (per product, per language)
+    ├──► translations/{lang}/branding/pdf/entities-{product}.adoc  (per product, per language)
     ├──► translations/{lang}/modules/{book}/nav-{book}-guide.pdf.{lang}.adoc
     └──► .bin/xref-converter.rb                 (embedded Ruby extension)
                                   │
@@ -58,7 +58,7 @@ task pdf:mlm
   3. for each LANG × BOOK:
        (per-book staging in task pdf for single-lang calls)
        docbuild gen-pdf-nav           → nav-{book}-guide.pdf.{lang}.adoc
-       docbuild gen-entities          → translations/{lang}/branding/pdf/entities.adoc
+       docbuild gen-entities          → translations/{lang}/branding/pdf/entities-{product}.adoc
        asciidoctor-pdf (theme={lang}) → build/{lang}/pdf/{product}_{book}_guide.pdf
 ```
 
@@ -234,7 +234,7 @@ asciidoc_extensions:
 | `docbuild gen-site -product <p> -output <o> -lang <code>` | `translations/{lang}/{output}.site.yml` | `site.yml.j2` + sed block in `Makefile.j2` |
 | `docbuild get-content-dir -lang <code>` | stdout: content source dir (e.g. `zh` for `zh_CN`) | — |
 | `docbuild gen-antora -product <p> -lang <code> [-content-dir <dir>]` | `translations/{lang}/antora.yml` | `antora.yml.j2` |
-| `docbuild gen-entities -product <p> -lang <code>` | `translations/{lang}/branding/pdf/entities.adoc` | `entities.adoc.j2` + `entities.specific.adoc.j2` |
+| `docbuild gen-entities -product <p> -lang <code>` | `translations/{lang}/branding/pdf/entities-{product}.adoc` | `entities.adoc.j2` + `entities.specific.adoc.j2` |
 | `docbuild gen-pdf-nav -book <b> -lang <code> -dir <path>` | `{path}/nav-{book}-guide.pdf.{lang}.adoc` | PDF nav generation in `Makefile.section.functions` |
 | `docbuild inject-lang-selector -hbs <path>` | Modifies `header-content.hbs` in-place with language selector | Language selector inject in `Makefile.j2` |
 | `docbuild collect-pdfs -product <p> [-src <path>] [-dest <path>] [-langs "<list>"]` | Moves `build/{lang}/pdf/` → `build/pdf/{lang}/` | `cleanup_pdfs.sh` |
@@ -261,10 +261,10 @@ task draft:uyuni-webui             Uyuni HTML — WebUI branding with language s
 task draft:all                     All four HTML output targets (sequential)
 
 task pdf BOOK=<b> PRODUCT=<p> LANGUAGES=<l>  One book PDF, one or more languages
-task pdf-stage PRODUCT=<p>         Per-language shared files: the content tree + entities.adoc
+task pdf-stage PRODUCT=<p>         Per-language shared files: the content tree + entities-{product}.adoc
 task pdf:mlm                       All 8 books × 4 languages — MLM (runs stage-content first, books concurrent)
 task pdf:uyuni                     All 8 books × 4 languages — Uyuni (runs stage-content first, books concurrent)
-task pdf:all                       Both products, in sequence (they share entities.adoc)
+task pdf:all                       Both products, in sequence (one product uses all the cores)
                                    JOBS=<n> caps concurrency; the default is the core count
 
 task publish:dsc                   Full MLM publish — HTML + PDFs + zip archives

--- a/en/modules/administration/nav-administration-guide.adoc
+++ b/en/modules/administration/nav-administration-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Administration Guide
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 3

--- a/en/modules/client-configuration/nav-client-configuration-guide.adoc
+++ b/en/modules/client-configuration/nav-client-configuration-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Client Configuration Guide
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toc: preamble

--- a/en/modules/common-workflows/nav-common-workflows-guide.adoc
+++ b/en/modules/common-workflows/nav-common-workflows-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Common Workflows
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 2

--- a/en/modules/installation-and-upgrade/nav-installation-and-upgrade-guide.adoc
+++ b/en/modules/installation-and-upgrade/nav-installation-and-upgrade-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Installation and Upgrade Guide
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 3

--- a/en/modules/legal/nav-legal-guide.adoc
+++ b/en/modules/legal/nav-legal-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Legal
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :source-highlighter: rouge

--- a/en/modules/reference/nav-reference-guide.adoc
+++ b/en/modules/reference/nav-reference-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Reference Guide
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 5

--- a/en/modules/retail/nav-retail-guide.adoc
+++ b/en/modules/retail/nav-retail-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Retail Guide
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 3

--- a/en/modules/specialized-guides/nav-specialized-guides-guide.adoc
+++ b/en/modules/specialized-guides/nav-specialized-guides-guide.adoc
@@ -1,7 +1,7 @@
 // NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
 ifdef::backend-pdf[]
 = [.title]#{productname} {productnumber}#: Specialized Guides
-include::./branding/pdf/entities.adoc[]
+include::./branding/pdf/entities-{entities-product}.adoc[]
 :doctype: book
 :title-page:
 :toclevels: 5

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -115,9 +115,16 @@ func AntoraYML(cfg *config.Config, productName, langCode, repoRoot, contentDir s
 	return renderTemplate("antora.yml.tmpl", antoraYMLTemplate, data, outPath)
 }
 
-// EntitiesAdoc generates a self-contained translations/{lang}/branding/pdf/entities.adoc
-// for a product/language pair. Locale attributes from branding/locale/attributes-{lang}.adoc
+// EntitiesAdoc generates a self-contained
+// translations/{lang}/branding/pdf/entities-{product}.adoc for a
+// product/language pair. Locale attributes from branding/locale/attributes-{lang}.adoc
 // are inlined so the file has no external dependencies.
+//
+// The filename carries the product because both products share the language
+// tree: a single entities.adoc meant whichever product generated last won, so
+// a build could silently ship the other product's names. The nav files select
+// the right one through the entities-product attribute, which the pdf task
+// passes to asciidoctor-pdf.
 func EntitiesAdoc(cfg *config.Config, productName, langCode, repoRoot string) error {
 	lang, err := cfg.LanguageByCode(langCode)
 	if err != nil {
@@ -148,7 +155,8 @@ func EntitiesAdoc(cfg *config.Config, productName, langCode, repoRoot string) er
 		LocaleAttrs: localeAttrs,
 	}
 
-	outPath := filepath.Join(repoRoot, "translations", langCode, "branding", "pdf", "entities.adoc")
+	outPath := filepath.Join(repoRoot, "translations", langCode, "branding", "pdf",
+		fmt.Sprintf("entities-%s.adoc", productName))
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(outPath), err)
 	}
@@ -195,9 +203,9 @@ func All(cfg *config.Config, repoRoot, contentDir string) error {
 				return fmt.Errorf("gen antora.yml [%s/%s]: %w", productName, lang.Code, err)
 			}
 
-			// entities.adoc
+			// entities-{product}.adoc
 			if err := EntitiesAdoc(cfg, productName, lang.Code, repoRoot); err != nil {
-				return fmt.Errorf("gen entities.adoc [%s/%s]: %w", productName, lang.Code, err)
+				return fmt.Errorf("gen entities-%s.adoc [%s]: %w", productName, lang.Code, err)
 			}
 
 			// site.yml per output

--- a/internal/generate/templates.go
+++ b/internal/generate/templates.go
@@ -58,7 +58,8 @@ nav:
 {{- end}}
 `
 
-// entitiesTemplate is the Go text/template for translations/{lang}/branding/pdf/entities.adoc.
+// entitiesTemplate is the Go text/template for
+// translations/{lang}/branding/pdf/entities-{product}.adoc.
 // It replaces entities.adoc.j2 + entities.specific.adoc.j2.
 // The file is self-contained: product attributes and locale attributes are inlined,
 // so asciidoctor-pdf does not need to resolve any external includes.

--- a/scripts/build_pdfs.sh
+++ b/scripts/build_pdfs.sh
@@ -8,9 +8,9 @@
 # JOBS caps the number of concurrent books. The default is the core count.
 #
 # The caller stages each language first with 'task pdf-stage'. Every book of a
-# language shares one content tree and one entities.adoc, and concurrent writes
-# to them are not safe. The 'pdf' task refuses to build if the caller did not
-# stage, therefore this script does not check.
+# language shares one content tree and one entities-{product}.adoc, and
+# concurrent writes to them are not safe. The 'pdf' task refuses to build if the
+# caller did not stage, therefore this script does not check.
 
 set -u
 


### PR DESCRIPTION
Backport of #5245, adapted to this branch.

# Description

Both products wrote one `translations/{lang}/branding/pdf/entities.adoc`, so a PDF could carry the other product's names and version; the file is now written per product as `entities-{product}.adoc` and each nav file selects its copy through the `entities-product` attribute.

# Target branches

- manager-5.1

# Links

- master: #5245
- manager-5.2: #5262

## Differences from the master change

This branch stages differently, so four hunks needed a hand resolution rather than a copy.

- `manager-5.1` stages the content tree in a separate `stage-content` task with `cp -a` and `run: once`, and `pdf:mlm` / `pdf:uyuni` call `pdf-stage` with `task:`. `master` does the `cp -an` inline in `pdf-stage` and calls it from `build_pdfs.sh`. The staging structure of this branch is kept; only the entities wording and the `ENTITIES` path change.
- `scripts/build_pdfs.sh` on this branch does not call `pdf-stage`, so the master comment change there does not apply. The file header keeps its own wording, updated for the new filename.
- The `pdf:all` comment on master gives concurrent `cp -an` as the reason for the sequence. That reason does not hold here, because `stage-content` dedupes itself with `run: once`. The comment now gives the reason that does hold: one product already uses all the cores.
- CHANGELOG: this branch says "building the books concurrently" where master says "the books and applying the translations concurrently". The branch wording is kept.

Verified on this branch: `task pdf BOOK=legal PRODUCT=mlm` and `PRODUCT=uyuni` both build, `translations/en/branding/pdf/` holds `entities-mlm.adoc` and `entities-uyuni.adoc`, and the two PDFs carry `/Title` `SUSE Multi-Linux Manager 5.1: Legal` and `Uyuni 2025.10: Legal`. `task pdf:mlm LANGUAGES=en BOOKS=legal` exercises the `STAGE=0` guard and passes.