### PR TITLE
master - Add a manual trigger to the translation file workflow

### DIFF
--- a/.github/workflows/update_translation_files.yml
+++ b/.github/workflows/update_translation_files.yml
@@ -12,6 +12,10 @@ on:
     - 'manager-5.1-MU-5.1.[0-9][0-9]?'
     - 'manager-5.2'
     - 'manager-5.2-MU-5.2.[0-9][0-9]?'
+  # A push is the only other trigger. Without this, a run that fails leaves the
+  # gettext files stale until the next merge, and a rerun of the failed run
+  # replays the old commit and cannot push.
+  workflow_dispatch:
 
 jobs:
   run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added a manual trigger to the translation file workflow, which ran only on a push
 - Fixed `l10n-weblate/update-cfg-files` failing when invoked from anywhere other than
   the `l10n-weblate/` directory
 - Sped up CI by building only English, which is all the CI artifacts have ever contained


### PR DESCRIPTION
# Description

The translation file workflow ran only on a push, so a failed run left the gettext files stale until the next merge and a rerun of that run replayed the old commit; this adds a manual trigger.

# Target branches

- master (this PR)
- manager-5.2 to follow
- manager-5.1 to follow

# Links
- Related to https://github.com/uyuni-project/uyuni-docs/pull/5031
