### PR TITLE
manager-5.1 - Stop generating antora.yml in gen-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Stopped generating antora.yml in gen-all, where the two products wrote one file in a random order.
+  The `-content-dir` flag of gen-all went to that file alone and is gone as well; gen-antora keeps its own
 - Sped up CI by building only English, which is all the CI artifacts have ever contained
 - Clarified relationship between custom RBAC and Salt-API access
 - Extracted and relocated general sudo configuration guidelines to a new central page, and added unprivileged onboarding support references for SLE 16 (bsc#1275794)

--- a/cmd/docbuild/main.go
+++ b/cmd/docbuild/main.go
@@ -2,9 +2,10 @@
 //
 // Usage:
 //
-//	docbuild gen-all                                     Generate all configs for all languages
+//	docbuild gen-all                                     Generate every config for all languages, except antora.yml
 //	docbuild gen-site  -product P -output O -lang L      Generate one site.yml
-//	docbuild gen-antora -product P -lang L               Generate one antora.yml
+//	docbuild gen-antora -product P -lang L               Generate one antora.yml. One path for the two
+//	                                                     products, so run it for your product before Antora
 //	docbuild gen-entities -product P -lang L             Generate one entities-{product}.adoc
 //	docbuild gen-pdf-nav -book B -lang L -dir D          Generate PDF nav from Antora nav file
 //	docbuild inject-lang-selector -output O              Inject language selector into header-content.hbs
@@ -70,11 +71,10 @@ func main() {
 func runGenAll(repoRoot string, args []string) {
 	fs := flag.NewFlagSet("gen-all", flag.ExitOnError)
 	cfgPath := fs.String("config", defaultConfig, "path to config.yml")
-	contentDir := fs.String("content-dir", defaultContentDir, "Antora modules directory relative to start_path")
 	_ = fs.Parse(args)
 
 	cfg := mustLoad(filepath.Join(repoRoot, *cfgPath))
-	if err := generate.All(cfg, repoRoot, *contentDir); err != nil {
+	if err := generate.All(cfg, repoRoot); err != nil {
 		fatalf("gen-all: %v", err)
 	}
 	fmt.Println("docbuild: generated all configs")
@@ -238,9 +238,10 @@ func usage() {
 	fmt.Print(`docbuild — uyuni-docs build config generator
 
 Subcommands:
-  gen-all                                    Generate all configs for all languages
+  gen-all                                    Generate every config for all languages, except antora.yml
   gen-site  -product P -output O -lang L     Generate translations/{lang}/{output}.site.yml
-  gen-antora -product P -lang L              Generate translations/{lang}/antora.yml
+  gen-antora -product P -lang L              Generate translations/{lang}/antora.yml. One path for the
+                                             two products, so run it for your product before Antora
   gen-entities -product P -lang L            Generate branding/pdf/entities-{product}.adoc
   gen-pdf-nav -book B -lang L -dir D         Generate nav-{book}-guide.pdf.{lang}.adoc from Antora nav
   inject-lang-selector -hbs PATH             Inject language selector into header-content.hbs

--- a/docs/local-toolchain-setup.md
+++ b/docs/local-toolchain-setup.md
@@ -142,7 +142,7 @@ After cloning the repository, run these once:
 
 ```bash
 task setup    # Compiles cmd/docbuild → .bin/docbuild
-task gen      # Generates all Antora/site configs from config.yml
+task gen      # Generates the site configs and xref-converter extension from config.yml
 ```
 
 ---

--- a/docs/toolchain-migration/ARCHITECTURE.md
+++ b/docs/toolchain-migration/ARCHITECTURE.md
@@ -18,7 +18,7 @@ cmd/docbuild/main.go  (Go binary)
     │  renders Go text/templates
     │
     ├──► translations/{lang}/{output}.site.yml   (per output-target, per language)
-    ├──► translations/{lang}/antora.yml          (per product, per language)
+    ├──► translations/{lang}/antora.yml          (gen-antora only, for the product being built)
     ├──► translations/{lang}/branding/pdf/entities-{product}.adoc  (per product, per language)
     ├──► translations/{lang}/modules/{book}/nav-{book}-guide.pdf.{lang}.adoc
     └──► .bin/xref-converter.rb                 (embedded Ruby extension)
@@ -230,10 +230,10 @@ asciidoc_extensions:
 
 | Command | Output | Replaces |
 |---|---|---|
-| `docbuild gen-all [-content-dir <dir>]` | All configs for all languages | `configure` Python script |
+| `docbuild gen-all` | Every config for all languages, except `antora.yml` | `configure` Python script |
 | `docbuild gen-site -product <p> -output <o> -lang <code>` | `translations/{lang}/{output}.site.yml` | `site.yml.j2` + sed block in `Makefile.j2` |
 | `docbuild get-content-dir -lang <code>` | stdout: content source dir (e.g. `zh` for `zh_CN`) | — |
-| `docbuild gen-antora -product <p> -lang <code> [-content-dir <dir>]` | `translations/{lang}/antora.yml` | `antora.yml.j2` |
+| `docbuild gen-antora -product <p> -lang <code> [-content-dir <dir>]` | `translations/{lang}/antora.yml`. Antora requires this name, so the two products share one path. Run it for your product immediately before Antora. | `antora.yml.j2` |
 | `docbuild gen-entities -product <p> -lang <code>` | `translations/{lang}/branding/pdf/entities-{product}.adoc` | `entities.adoc.j2` + `entities.specific.adoc.j2` |
 | `docbuild gen-pdf-nav -book <b> -lang <code> -dir <path>` | `{path}/nav-{book}-guide.pdf.{lang}.adoc` | PDF nav generation in `Makefile.section.functions` |
 | `docbuild inject-lang-selector -hbs <path>` | Modifies `header-content.hbs` in-place with language selector | Language selector inject in `Makefile.j2` |

--- a/docs/toolchain-migration/README.md
+++ b/docs/toolchain-migration/README.md
@@ -66,7 +66,7 @@ task container:shell
 ```bash
 # First-time setup
 task setup    # Build the Go docbuild binary
-task gen      # Regenerate Antora/site configs from config.yml
+task gen      # Regenerate site configs and xref-converter extension from config.yml
 
 # Publish builds
 task publish:dsc          # Full MLM publish — HTML + PDFs + zips

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -93,6 +93,16 @@ func SiteYML(cfg *config.Config, productName, outputName, langCode, repoRoot str
 }
 
 // AntoraYML generates translations/{lang}/antora.yml.
+//
+// Antora requires the component descriptor to carry the name antora.yml at the
+// root of the content start path. SiteYML sets that path to translations/{lang},
+// which holds no product, so the two products overwrite each other. Every caller
+// must therefore run this generator for its own product immediately before it
+// starts Antora. The draft:* and validate:* tasks in Taskfile.yml do this. For
+// the same reason, All does not call this generator: a run for each product
+// leaves one file with the names of whichever product ran last. A per-product
+// start path would end the collision, at the cost of a content tree for each
+// product.
 func AntoraYML(cfg *config.Config, productName, langCode, repoRoot, contentDir string) error {
 	lang, err := cfg.LanguageByCode(langCode)
 	if err != nil {
@@ -182,8 +192,10 @@ func readLocaleAttributes(repoRoot, langCode string) (string, error) {
 	return strings.TrimRight(content, "\n"), nil
 }
 
-// All runs all generators for every language in cfg.
-func All(cfg *config.Config, repoRoot, contentDir string) error {
+// All runs the generators that write to a path of their own, for every
+// language and product in cfg. It does not write antora.yml, which has one
+// path for the two products. See AntoraYML.
+func All(cfg *config.Config, repoRoot string) error {
 	// Write the embedded xref-converter Ruby extension alongside the binary.
 	xrefDest := filepath.Join(repoRoot, ".bin", "xref-converter.rb")
 	if err := WriteXrefExtension(xrefDest); err != nil {
@@ -196,11 +208,6 @@ func All(cfg *config.Config, repoRoot, contentDir string) error {
 			dir := filepath.Join(repoRoot, "translations", lang.Code)
 			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return fmt.Errorf("mkdir %s: %w", dir, err)
-			}
-
-			// antora.yml
-			if err := AntoraYML(cfg, productName, lang.Code, repoRoot, contentDir); err != nil {
-				return fmt.Errorf("gen antora.yml [%s/%s]: %w", productName, lang.Code, err)
 			}
 
 			// entities-{product}.adoc


### PR DESCRIPTION
# Description

`gen-all` wrote `translations/{lang}/antora.yml` one time for each product into one path, in the random order of a Go map, and no build read the result.

# Target branches

- master https://github.com/uyuni-project/uyuni-docs/pull/5261
- manager-5.2 https://github.com/uyuni-project/uyuni-docs/pull/5265
- manager-5.1 (this PR)

# Links

- Follow-up to #5245, which fixed the same last-writer-wins shape for the PDF entities file.

Antora requires the component descriptor to carry the name `antora.yml` at the root of the content start path, so a per-product filename is not available here. Instead, the generator now stands alone: `draft:*` and `validate:*` already run `gen-antora` for their own product on the line before they start Antora, and `task translations` deletes the whole `translations/` tree before that. The doc comment records the constraint so a future caller does not depend on an output with no owner.

The `-content-dir` flag of `gen-all` fed the `antora.yml` template only, so it goes as well. `gen-antora` keeps its own copy.

Backport of the master change. Checked on this branch: every `npx antora` invocation in `Taskfile.yml` is preceded by a `gen-antora` for its own product, no caller passes `-content-dir` to `gen-all`, and `go build ./...` and `go vet ./...` pass.
