### PR TITLE
Manager 5.1: Add Multi-Linux Manager MCP Server book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added Multi-Linux Manager MCP Server book
 - Stopped generating antora.yml in gen-all, where the two products wrote one file in a random order.
   The `-content-dir` flag of gen-all went to that file alone and is gone as well; gen-antora keeps its own
 - Sped up CI by building only English, which is all the CI artifacts have ever contained

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -72,7 +72,7 @@ vars:
   # has a higher precedence than this entry and wins. _guard-lang validates the
   # result from all three sources.
   LANGUAGES: '{{default .DOC_LANGUAGES (env "LANGUAGES")}}'
-  BOOKS: "installation-and-upgrade client-configuration administration reference retail common-workflows specialized-guides legal"
+  BOOKS: "installation-and-upgrade client-configuration administration reference retail mcp-server common-workflows specialized-guides legal"
   CONTAINER_CMD:
     sh: which podman 2>/dev/null || which docker 2>/dev/null || echo "podman"
   # Use uv if it is present.

--- a/config.yml
+++ b/config.yml
@@ -187,6 +187,7 @@ products:
     - administration
     - reference
     - retail
+    - mcp-server
     - common-workflows
     - specialized-guides
     - legal
@@ -247,6 +248,7 @@ products:
     - administration
     - reference
     - retail
+    - mcp-server
     - common-workflows
     - specialized-guides
     - legal

--- a/en/modules/mcp-server/_attributes.adoc
+++ b/en/modules/mcp-server/_attributes.adoc
@@ -1,0 +1,4 @@
+:attachmentsdir: {moduledir}/assets/attachments
+:examplesdir: {moduledir}/examples
+:imagesdir: {moduledir}/assets/images
+:partialsdir: {moduledir}/pages/_partials

--- a/en/modules/mcp-server/nav-mcp-server-guide.adoc
+++ b/en/modules/mcp-server/nav-mcp-server-guide.adoc
@@ -1,0 +1,22 @@
+// NO COMMENTS ALLOWED IN NAV LIST FILES EXCEPT THIS ONE!
+ifdef::backend-pdf[]
+= [.title]#{productname} {productnumber}#: MCP Server Guide
+include::./branding/pdf/entities.adoc[]
+:doctype: book
+:title-page:
+:toclevels: 3
+:source-highlighter: rouge
+endif::[]
+
+* xref:mcp-server-overview.adoc[MCP Server Guide]
+** xref:mcp-server-concepts.adoc[Concepts and Architecture]
+** xref:mcp-server-installation.adoc[Installation and Deployment]
+** xref:mcp-server-configuration.adoc[Server Configuration]
+** xref:mcp-server-client-configuration.adoc[MCP Client Configuration]
+** xref:mcp-server-security.adoc[Security]
+** xref:mcp-server-tools.adoc[Tool Reference]
+** xref:mcp-server-troubleshooting.adoc[Troubleshooting]
+
+ifdef::backend-pdf[]
+include::modules/ROOT/pages/common_gfdl1.2_i.adoc[leveloffset=+1]
+endif::[]

--- a/en/modules/mcp-server/pages/mcp-server-client-configuration.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-client-configuration.adoc
@@ -1,0 +1,77 @@
+[[mcp-server-client-configuration]]
+= MCP Client Configuration
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter provides example stdio and HTTP client configurations and explains how to verify the integration.
+
+MCP configuration formats differ across various clients.
+Use the examples in this chapter as a template and consult the client documentation for the exact property names and configuration file location.
+
+[[client-stdio]]
+== Configure a stdio client
+
+The following generic configuration starts a container for each MCP client session:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "mcp-server-uyuni": {
+      "command": "podman",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "--env-file",
+        "/absolute/path/to/mcp.env",
+        "registry.suse.com/suse/agentic/mcp/multi-linux-manager:<version>"
+      ]
+    }
+  }
+}
+----
+
+The `-i` option is required because MCP uses the container's standard input and output.
+Use an absolute path to the environment file.
+
+== Configure an HTTP client
+
+After deploying the standalone server, configure the client with its streamable HTTP endpoint:
+
+[source,json]
+----
+{
+  "mcpServers": {
+    "mcp-server-uyuni": {
+      "url": "https://mcp.example.com/mcp",
+      "type": "http"
+    }
+  }
+}
+----
+
+The client must be able to complete OAuth authorization against the issuer configured with `UYUNI_AUTH_SERVER`.
+The exact transport name in a client configuration can be `http` or `streamable-http`, depending on the client.
+
+== Verify the integration
+
+Restart the MCP client after changing its configuration.
+Then make low-risk, read-only requests, for example:
+
+* "List the first five active systems."
+* "Find systems with `web` in the hostname."
+* "List the first ten systems that need a reboot."
+
+Confirm that the returned system names and IDs are aligned with the {productname} {webui}.
+
+== Use tools efficiently
+
+MCP tool output consumes AI context.
+When explicitly selecting tools, directing an assistant to use a particular tool, or implementing an agent workflow, apply these practices:
+
+* Start with `summarize_system_updates` or `summarize_fleet_updates`.
+* Use pagination parameters and follow `meta.next_offset`.
+* Set `include_cves` or `include_updates` only when details are required.
+* Use `find_systems_by_name` before a tool call when a hostname is ambiguous.
+* Ask the assistant to show the target system ID, action ID, or erratum ID before a state-changing call.

--- a/en/modules/mcp-server/pages/mcp-server-concepts.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-concepts.adoc
@@ -1,0 +1,80 @@
+[[mcp-server-concepts]]
+= Concepts and Architecture
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter introduces the components, request flow, deployment models, and capabilities of the {productname} MCP Server.
+
+The Model Context Protocol (MCP) is an open protocol that allows an AI application to discover and call tools exposed by an external server.
+The {productname} MCP Server implements MCP tools that translate structured tool calls into {productname} HTTP API requests.
+
+The MCP Server integrates with the existing {productname} authorization model.
+The authenticated account determines which content is visible and which operations are permitted.
+
+== Components
+
+An MCP integration contains the following components:
+
+MCP host::
+The AI application in which the user works.
+
+MCP client::
+The protocol client maintained by the host.
+It discovers tools, sends tool calls, displays progress and results, and can request user approval.
+
+{productname} MCP Server::
+The process that exposes tools over stdio or streamable HTTP and calls the {productname} API.
+
+{productname} Server::
+The managed infrastructure service and authorization boundary.
+
+Identity provider::
+An optional OAuth 2.0/OpenID Connect provider used for a shared HTTP deployment.
+
+== Request flow
+
+For a read-only request, the flow is:
+
+. The user asks the AI assistant to retrieve information from {productname}.
+. The AI assistant selects an MCP tool and supplies structured arguments.
+. The MCP client sends the tool call to the MCP Server.
+. The MCP Server authenticates to {productname}, calls the corresponding API, and normalizes the response.
+. The MCP client returns the structured result to the AI assistant.
+
+State-changing tools add an approval step when the MCP client supports MCP elicitation.
+For more information, see xref:mcp-server-security.adoc#write-tool-controls[Write tool controls].
+
+== Deployment models
+
+[cols="1,2,2", options="header"]
+|===
+|Model
+|Use case
+|Characteristics
+
+|Client-managed stdio
+|One user or one local AI application
+|The MCP client starts one server process. Communication remains on stdin and stdout. {productname} credentials are normally supplied to that process.
+
+|Standalone HTTP
+|A persistent service shared by multiple users or clients
+|Clients connect to `/mcp` over streamable HTTP. OAuth is strongly recommended. Production deployments should expose the endpoint only over TLS.
+|===
+
+Use client-managed stdio unless the MCP Server must be shared or centrally operated.
+The smaller network surface and process lifetime make stdio easier to secure.
+
+== Capabilities and limitations
+
+The server exposes MCP tools for systems, updates, CVEs, actions, activation keys, and system groups.
+Write tools are disabled by default.
+The server does not expose MCP resources or prompts.
+
+Tool results can be paginated to reduce context usage.
+For fleet-wide questions, use summary tools first and request detailed update or CVE data only when required.
+
+[IMPORTANT]
+====
+An AI-generated explanation is not an authoritative record of system state.
+Review the structured tool result and confirm important changes in the {productname} {webui}, especially after scheduling updates, rebooting, bootstrapping, or removing systems.
+====

--- a/en/modules/mcp-server/pages/mcp-server-configuration.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-configuration.adoc
@@ -22,7 +22,7 @@ This chapter describes the environment variables for configuring the {productnam
 |`UYUNI_USER`
 |For basic auth
 |-
-|{productname} user name. Use with `UYUNI_PASS` for stdio or another trusted local deployment.
+|{productname} user name. Use with `UYUNI_PASS` when `UYUNI_AUTH_SERVER` is not set.
 
 |`UYUNI_PASS`
 |For basic auth
@@ -137,6 +137,8 @@ Prefer a protected environment file or a secrets-management system.
 ====
 
 == Example read-only configuration
+
+The following example uses basic authentication with `UYUNI_USER` and `UYUNI_PASS`.
 
 [source,ini,subs="attributes"]
 ----

--- a/en/modules/mcp-server/pages/mcp-server-configuration.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-configuration.adoc
@@ -1,0 +1,151 @@
+[[mcp-server-configuration]]
+= Server Configuration
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter describes the environment variables for configuring the {productname} connection, transport, tools, logging, and system bootstrap.
+
+== {productname} connection
+
+[cols="2,1,1,4", options="header"]
+|===
+|Variable
+|Required
+|Default
+|Description
+
+|`UYUNI_SERVER`
+|Yes
+|-
+|Base URL of the {productname} Server. If the scheme is omitted, `https` is used. A path, query, or fragment is not allowed.
+
+|`UYUNI_USER`
+|For basic auth
+|-
+|{productname} user name. Use with `UYUNI_PASS` for stdio or another trusted local deployment.
+
+|`UYUNI_PASS`
+|For basic auth
+|-
+|Password for `UYUNI_USER`.
+
+|`UYUNI_MCP_SSL_VERIFY`
+|No
+|`true`
+|Verifies the TLS certificate presented by the {productname} Server. Values `false`, `0`, and `no` disable verification.
+
+|`UYUNI_MCP_TIMEOUT`
+|No
+|`30`
+|HTTP request timeout in seconds. The connection timeout remains 10 seconds.
+|===
+
+[WARNING]
+====
+Do not disable certificate verification in production.
+Install the issuing CA certificate in the container or host trust store instead.
+====
+
+== Transport and service
+
+[cols="2,1,1,4", options="header"]
+|===
+|Variable
+|Required
+|Default
+|Description
+
+|`UYUNI_MCP_TRANSPORT`
+|No
+|`stdio`
+|Transport mode. Valid values are `stdio` and `http`.
+
+|`UYUNI_MCP_HOST`
+|HTTP only
+|`127.0.0.1`
+|Address on which the HTTP server listens.
+
+|`UYUNI_MCP_PORT`
+|HTTP only
+|`8000`
+|Port on which the HTTP server listens.
+
+|`UYUNI_MCP_PUBLIC_URL`
+|OAuth HTTP deployment
+|Derived from host and port
+|External base URL advertised to OAuth-capable clients. Set the client-facing URL, without `/mcp`.
+
+|`UYUNI_AUTH_SERVER`
+|Recommended for HTTP
+|-
+|OpenID Connect issuer URL. A path is allowed. When omitted, the MCP HTTP endpoint does not authenticate clients.
+|===
+
+== Tools and logging
+
+[cols="2,1,1,4", options="header"]
+|===
+|Variable
+|Required
+|Default
+|Description
+
+|`UYUNI_MCP_WRITE_TOOLS_ENABLED`
+|No
+|`false`
+|Registers tools that modify {productname}. Values `true`, `1`, and `yes` enable them.
+
+|`UYUNI_MCP_LOG_FILE_PATH`
+|No
+|Console
+|Path to the server log file.
+
+|`UYUNI_MCP_LOG_LEVEL`
+|No
+|`INFO`
+|Logging level, for example `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+|===
+
+[NOTE]
+====
+Changing `UYUNI_MCP_WRITE_TOOLS_ENABLED` requires a process restart because the server registers tools during startup.
+====
+
+== System bootstrap
+
+The `add_system` tool requires these additional variables:
+
+[cols="2,1,4", options="header"]
+|===
+|Variable
+|Required
+|Description
+
+|`UYUNI_SSH_PRIV_KEY`
+|For `add_system`
+|Private SSH key used to bootstrap the target. Store the key as one line with each newline represented by the literal `\n` sequence.
+
+|`UYUNI_SSH_PRIV_KEY_PASS`
+|No
+|Passphrase for the private SSH key.
+|===
+
+[WARNING]
+====
+Do not place the key directly in an MCP client configuration that is synchronized or shared.
+Prefer a protected environment file or a secrets-management system.
+====
+
+== Example read-only configuration
+
+[source,ini,subs="attributes"]
+----
+UYUNI_SERVER=https://server.example.com
+UYUNI_USER=mcp-reader
+UYUNI_PASS=replace-me
+UYUNI_MCP_SSL_VERIFY=true
+UYUNI_MCP_TIMEOUT=30
+UYUNI_MCP_TRANSPORT=stdio
+UYUNI_MCP_WRITE_TOOLS_ENABLED=false
+UYUNI_MCP_LOG_LEVEL=INFO
+----

--- a/en/modules/mcp-server/pages/mcp-server-installation.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-installation.adoc
@@ -1,0 +1,91 @@
+[[mcp-server-installation]]
+= Installation and Deployment
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter describes the requirements and procedures for deploying the {productname} MCP Server as a client-managed stdio container or a standalone HTTP service.
+
+The MCP Server is available as a container image from the SUSE Container Registry.
+
+== Requirements
+
+Before deployment, ensure that:
+
+* The deployment environment allows outbound HTTPS connections to the {productname} Server.
+* The {productname} account used by the MCP Server has only the permissions required for the intended tools.
+* A supported MCP client is installed.
+* The MCP client supports streamable HTTP and OAuth when these features are required.
+
+Create a protected environment file for the server configuration:
+
+[source,ini,subs="attributes"]
+----
+UYUNI_SERVER=https://server.example.com
+UYUNI_USER=mcp-reader
+UYUNI_PASS=replace-me
+UYUNI_MCP_SSL_VERIFY=true
+UYUNI_MCP_WRITE_TOOLS_ENABLED=false
+----
+
+Restrict access to this file because it contains credentials.
+See xref:mcp-server-configuration.adoc[Server Configuration] for all settings.
+
+== Client-managed container with stdio
+
+In this model, the MCP client starts the container and communicates with it over stdio.
+No host port is published.
+
+Configure the MCP client to run:
+
+----
+podman run -i --rm \
+  --env-file /absolute/path/to/mcp.env \
+  registry.suse.com/suse/agentic/mcp/multi-linux-manager:<version>
+----
+
+Replace `<version>` with a tested release tag.
+Pin a release tag instead of using `latest` in a production configuration.
+
+Continue with xref:mcp-server-client-configuration.adoc#client-stdio[stdio client configuration].
+
+== Standalone HTTP server
+
+Use HTTP mode when a persistent service must support multiple clients.
+
+. Add these settings to the environment file:
++
+----
+UYUNI_MCP_TRANSPORT=http
+UYUNI_MCP_HOST=0.0.0.0
+UYUNI_MCP_PORT=8000
+UYUNI_MCP_PUBLIC_URL=https://mcp.example.com
+UYUNI_AUTH_SERVER=https://idp.example.com/realms/mcp
+----
+
+. Start the container:
++
+----
+podman run --rm \
+  --env-file /absolute/path/to/mcp.env \
+  -p 8000:8000 \
+  registry.suse.com/suse/agentic/mcp/multi-linux-manager:<version>
+----
+
+. Configure TLS termination for `https://mcp.example.com` and route requests to port `8000`.
+
+. Connect the MCP client to:
++
+----
+https://mcp.example.com/mcp
+----
+
+The application serves plain HTTP itself.
+Do not expose it directly to an untrusted network.
+
+[WARNING]
+====
+If `UYUNI_AUTH_SERVER` is not set, HTTP requests are unauthenticated.
+Only omit authentication for temporary testing on an isolated interface or network.
+====
+
+Complete the OAuth configuration described in xref:mcp-server-security.adoc#oauth-configuration[OAuth configuration] before allowing user access.

--- a/en/modules/mcp-server/pages/mcp-server-installation.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-installation.adoc
@@ -16,8 +16,13 @@ Before deployment, ensure that:
 * A supported MCP client is installed.
 * The MCP client supports streamable HTTP and OAuth when these features are required.
 
-Create a protected environment file for the server configuration:
+== Client-managed container with stdio
 
+In this model, the MCP client starts the container and communicates with it over stdio.
+No host port is published.
+
+. Create a protected environment file for the server configuration:
++
 [source,ini,subs="attributes"]
 ----
 UYUNI_SERVER=https://server.example.com
@@ -26,23 +31,18 @@ UYUNI_PASS=replace-me
 UYUNI_MCP_SSL_VERIFY=true
 UYUNI_MCP_WRITE_TOOLS_ENABLED=false
 ----
-
++
 Restrict access to this file because it contains credentials.
 See xref:mcp-server-configuration.adoc[Server Configuration] for all settings.
 
-== Client-managed container with stdio
-
-In this model, the MCP client starts the container and communicates with it over stdio.
-No host port is published.
-
-Configure the MCP client to run:
-
+. Configure the MCP client to run:
++
 ----
 podman run -i --rm \
   --env-file /absolute/path/to/mcp.env \
   registry.suse.com/suse/agentic/mcp/multi-linux-manager:<version>
 ----
-
++
 Replace `<version>` with a tested release tag.
 Pin a release tag instead of using `latest` in a production configuration.
 
@@ -52,15 +52,21 @@ Continue with xref:mcp-server-client-configuration.adoc#client-stdio[stdio clien
 
 Use HTTP mode when a persistent service must support multiple clients.
 
-. Add these settings to the environment file:
+. Create a protected environment file for the server configuration:
 +
 ----
+UYUNI_SERVER=https://server.example.com
+UYUNI_MCP_SSL_VERIFY=true
+UYUNI_MCP_WRITE_TOOLS_ENABLED=false
 UYUNI_MCP_TRANSPORT=http
 UYUNI_MCP_HOST=0.0.0.0
 UYUNI_MCP_PORT=8000
 UYUNI_MCP_PUBLIC_URL=https://mcp.example.com
 UYUNI_AUTH_SERVER=https://idp.example.com/realms/mcp
 ----
++
+When `UYUNI_AUTH_SERVER` is set, the MCP Server uses each client's OAuth token to authenticate to the {productname} API.
+In this configuration, `UYUNI_USER` and `UYUNI_PASS` are not required.
 
 . Start the container:
 +
@@ -84,7 +90,7 @@ Do not expose it directly to an untrusted network.
 
 [WARNING]
 ====
-If `UYUNI_AUTH_SERVER` is not set, HTTP requests are unauthenticated.
+If `UYUNI_AUTH_SERVER` is not set, HTTP requests to the MCP Server are unauthenticated.
 Only omit authentication for temporary testing on an isolated interface or network.
 ====
 

--- a/en/modules/mcp-server/pages/mcp-server-overview.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-overview.adoc
@@ -1,0 +1,93 @@
+ifndef::backend-pdf[]
+[[mcp-server-overview]]
+= MCP Server Guide
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+**Publication Date:** {docdate}
+
+== Preface
+
+The {productname} MCP Server connects Model Context Protocol (MCP) clients and AI assistants to the {productname} API.
+It provides tools for inspecting systems, assessing patches and CVEs, reviewing scheduled actions, and, when explicitly enabled, changing managed systems.
+
+This guide explains how to:
+
+* Select a local standard input/output (stdio) or network HTTP deployment.
+* Configure the connection to {productname}.
+* Connect an MCP client.
+* Configure authentication and apply security controls.
+* Use the available read-only and state-changing tools.
+* Diagnose common configuration, connectivity, and authorization problems.
+
+== Copyright Notice
+
+ifeval::[{mlm-content} == true]
+Copyright © {copyrightdate} SUSE LLC and contributors. All rights reserved.
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or (at your option) version 1.3; with the Invariant Section being this copyright
+notice and license. A copy of the license version 1.2 is included in the section entitled xref:legal:license.adoc[GNU Free Documentation License].
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+Copyright © 2011–2026 Uyuni contributors. All rights reserved.
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or (at your option) version 1.3; with the Invariant Section being this copyright
+notice and license. A copy of the license version 1.2 is included in the section entitled xref:legal:license.adoc[GNU Free Documentation License].
+endif::[]
+
+== Trademarks
+
+For SUSE trademarks, see https://www.suse.com/company/legal/ .
+All third-party trademarks are the property of their respective owners.
+Trademark symbols (®, ™ etc.) denote trademarks of SUSE and its affiliates.
+Asterisks (*) denote third-party trademarks.
+All information found in this book has been compiled with utmost attention to detail.
+However, this does not guarantee complete accuracy.
+Neither SUSE LLC, its affiliates, the authors nor the translators shall be held liable for possible errors or the consequences thereof.
+endif::[]
+
+ifdef::backend-pdf[]
+
+<<<
+
+:!sectnums:
+
+[preface]
+== Preface
+
+MCP Server Guide |
+{productname} {productnumber}
+
+The {productname} MCP Server connects Model Context Protocol (MCP) clients and AI assistants to the {productname} API.
+It provides tools for inspecting systems, assessing patches and CVEs, reviewing scheduled actions, and, when explicitly enabled, changing managed systems.
+
+This guide covers deployment, configuration, client integration, security, available tools, and troubleshooting.
+
+**Publication Date:** {docdate}
+
+ifeval::[{mlm-content} == true]
+Copyright © {copyrightdate} SUSE LLC and contributors. All rights reserved.
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or (at your option) version 1.3; with the Invariant Section being this copyright
+notice and license. A copy of the license version 1.2 is included in the section entitled xref:legal:license.adoc[GNU Free Documentation License].
+endif::[]
+
+ifeval::[{uyuni-content} == true]
+Copyright © 2011–2026 Uyuni contributors. All rights reserved.
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or (at your option) version 1.3; with the Invariant Section being this copyright
+notice and license. A copy of the license version 1.2 is included in the section entitled xref:legal:license.adoc[GNU Free Documentation License].
+endif::[]
+
+For SUSE trademarks, see https://www.suse.com/company/legal/ .
+All third-party trademarks are the property of their respective owners.
+Trademark symbols (®, ™ etc.) denote trademarks of SUSE and its affiliates.
+Asterisks (*) denote third-party trademarks.
+All information found in this book has been compiled with utmost attention to detail.
+However, this does not guarantee complete accuracy.
+Neither SUSE LLC, its affiliates, the authors nor the translators shall be held liable for possible errors or the consequences thereof.
+
+<<<
+
+toc::[]
+
+:sectnums:
+
+endif::[]

--- a/en/modules/mcp-server/pages/mcp-server-security.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-security.adoc
@@ -1,0 +1,120 @@
+[[mcp-server-security]]
+= Security
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter describes authentication, write-tool controls, deployment hardening, and security considerations for AI-assisted operations.
+
+The MCP Server can query and modify managed infrastructure.
+Treat it as a privileged administrative interface.
+
+== Security model
+
+The server supports two authentication paths:
+
+Basic {productname} authentication::
+In a stdio or trusted deployment, the server logs in with `UYUNI_USER` and `UYUNI_PASS`.
+All MCP clients that use that process receive the permissions of this account.
+
+OAuth bearer token::
+In an authenticated HTTP deployment, the MCP Server validates the caller's token and forwards it to the {productname} OIDC login endpoint.
+{productname} then maps the token to an existing active user.
+
+Use a dedicated, least-privileged {productname} account for basic authentication.
+For a multi-user HTTP deployment, use OAuth so that actions retain individual user identity and permissions.
+
+[[oauth-configuration]]
+== OAuth configuration
+
+The MCP Server expects an OpenID Connect issuer.
+It retrieves signing keys from:
+
+----
+<UYUNI_AUTH_SERVER>/protocol/openid-connect/certs
+----
+
+Tokens accepted by the MCP Server must:
+
+* Have an issuer that exactly matches `UYUNI_AUTH_SERVER`.
+* Include the `mcp-server-uyuni` audience.
+* Include the `mcp:read` scope.
+* Include the `mcp:write` scope when write tools are enabled.
+
+Configure the same identity provider on the {productname} Server in `/etc/rhn/rhn.conf`:
+
+----
+web.oidc.enabled = true
+web.oidc.idp.issuer = https://idp.example.com/realms/mcp
+----
+
+You can explicitly set the JSON Web Key Set path:
+
+----
+web.oidc.idp.jwks_path = /realms/mcp/protocol/openid-connect/certs
+----
+
+If the path is not set, {productname} discovers it from the issuer's `/.well-known/openid-configuration` document.
+
+The default {productname} audience and username claim are:
+
+----
+web.oidc.jwt.audience = uyuni-server
+web.oidc.jwt.username_claim = preferred_username
+----
+
+The token forwarded to {productname} must include:
+
+* The `uyuni-server` audience, in addition to the `mcp-server-uyuni` audience.
+* A `sub` claim.
+* A configured username claim whose value matches an existing active {productname} user.
+
+Restart the relevant {productname} services after changing `rhn.conf`.
+
+[[write-tool-controls]]
+== Write tool controls
+
+State-changing tools are not registered unless `UYUNI_MCP_WRITE_TOOLS_ENABLED=true`.
+
+When write tools are enabled, the server asks for confirmation before a change if the MCP client advertises the MCP elicitation capability.
+Clients without elicitation support do not receive this server-side confirmation.
+Such clients are responsible for their own approval user experience.
+
+[WARNING]
+====
+Do not rely on elicitation as the only authorization control.
+Use {productname} role-based access control permissions, OAuth scopes, network restrictions, and client-side tool approval policies.
+====
+
+Enable write tools only for a deployment where they are required.
+For high-risk operations:
+
+* Resolve and verify the target system ID.
+* Review the generated arguments before approval.
+* Apply changes to a small scope first.
+* Verify the resulting scheduled action in the {productname} {webui}.
+
+Using the `remove_system` tool is a destructive operation.
+When `cleanup=true`, the tool requests forced deletion and cleanup of the system.
+
+== Hardening the deployment
+
+You can harden the MCP Server deployment by applying the following controls:
+
+* Provide TLS termination for HTTP deployments.
+* Never expose unauthenticated HTTP mode to an untrusted network.
+* Keep `UYUNI_MCP_SSL_VERIFY=true`.
+* Store passwords, OAuth configuration, and SSH private keys in a secrets-management system or protected environment file.
+* Pin the MCP Server container to a reviewed release.
+* Use `INFO` or `WARNING` logging in production and protect log files from unauthorized access.
+* Restrict network access from the MCP Server to the required {productname} and identity-provider endpoints.
+
+== AI and prompt security
+
+An AI assistant can use text from prompts and external content when deciding whether and how to call a tool.
+This content might contain misleading or malicious instructions.
+Treat any tool call based on untrusted content as untrusted until you review it.
+
+Configure the MCP host to require explicit approval for state-changing tools.
+Before approval, verify the tool name, target IDs, update or action IDs, and all arguments.
+Do not provide secrets in prompts.
+Do not ask the model to reproduce environment variables, access tokens, passwords, or private keys.

--- a/en/modules/mcp-server/pages/mcp-server-tools.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-tools.adoc
@@ -1,0 +1,173 @@
+[[mcp-server-tools]]
+= Tool Reference
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter provides a reference to the tools exposed by the {productname} MCP Server, including their arguments, results, and effects.
+
+The {productname} MCP Server exposes read-only tools by default.
+Tools in the state-changing section are available only when `UYUNI_MCP_WRITE_TOOLS_ENABLED=true`.
+
+Most tools that accept `system_identifier` support a system name or system ID.
+If a name is not found or is ambiguous, call `find_systems_by_name` and use the returned ID.
+
+== Systems and events
+
+[cols="2,3,4", options="header"]
+|===
+|Tool
+|Arguments
+|Result
+
+|`list_systems`
+|`limit=50`, `offset=0`
+|Paged active systems. `limit` is capped at 500.
+
+|`get_system_details`
+|`system_identifier`
+|System ID, name, last boot time, UUID, CPU, network, and installed products.
+
+|`get_system_event_history`
+|`system_identifier`, `offset=0`, `limit=10`, optional `earliest_date`
+|Newest-first event history.
+
+|`get_system_event_details`
+|`system_identifier`, `event_id`
+|Status, timestamps, result fields, and additional information for one event.
+
+|`find_systems_by_name`
+|`name`, `limit=50`, `offset=0`
+|Paged hostname matches.
+
+|`find_systems_by_ip`
+|`ip_address`, `limit=50`, `offset=0`
+|Paged systems matching an IP address.
+
+|`list_systems_needing_reboot`
+|`limit=50`, `offset=0`
+|Paged systems requiring a reboot. `limit` is capped at 500.
+|===
+
+== Updates and CVEs
+
+The supported advisory type values are `Security Advisory`, `Product Enhancement Advisory`, and `Bug Fix Advisory`.
+
+[cols="2,3,4", options="header"]
+|===
+|Tool
+|Arguments
+|Result
+
+|`get_system_updates`
+|`system_identifier`
+|Compact pending update list and counts. CVE expansion is omitted.
+
+|`summarize_system_updates`
+|`system_identifier`, optional `advisory_types`
+|Pending and queued update counts without update details.
+
+|`query_system_updates`
+|`system_identifier`, `limit=25`, `offset=0`, `include_cves=false`, optional `advisory_types`
+|Paged pending updates. A positive `limit` is capped at 200; a non-positive value returns counts without items.
+
+|`check_all_systems_for_updates`
+|`include_updates=false`, `include_cves=false`, `system_limit=25`, `system_offset=0`, `updates_per_system=10`
+|Paged systems with pending updates. `system_limit` is capped at 200.
+
+|`summarize_fleet_updates`
+|`system_limit=25`, `system_offset=0`
+|Paged systems and update counts without update details. `system_limit` is capped at 200.
+
+|`list_systems_needing_update_for_cve`
+|`cve_identifier`, `limit=50`, `offset=0`
+|Paged systems affected by the specified CVE.
+
+|`get_unscheduled_errata`
+|`system_id`
+|Applicable patches that are not scheduled. `system_id` must be a numeric string.
+|===
+
+== Actions, activation keys, and groups
+
+[cols="2,3,4", options="header"]
+|===
+|Tool
+|Arguments
+|Result
+
+|`list_all_scheduled_actions`
+|`limit=50`, `offset=0`, optional `action_types`, optional `scheduler`
+|Paged actions after exact-match filtering. `limit` is capped at 500. The metadata lists observed action types and schedulers for subsequent filters.
+
+|`list_activation_keys`
+|None
+|Activation keys available to the current user.
+
+|`list_system_groups`
+|None
+|Group ID, name, description, and system count.
+
+|`list_group_systems`
+|`group_name`
+|System IDs and names in the specified group.
+|===
+
+== State-changing tools
+
+[WARNING]
+====
+These tools change managed infrastructure.
+Review all arguments and the intended targets before approving a call.
+====
+
+[cols="2,3,4", options="header"]
+|===
+|Tool
+|Arguments
+|Effect
+
+|`schedule_pending_updates_to_system`
+|`system_identifier`
+|Schedules all pending updates for one system.
+
+|`schedule_specific_update`
+|`system_identifier`, `errata_id`
+|Schedules one patch for one system.
+
+|`add_system`
+|`host`, optional `activation_key`, `ssh_port=22`, `ssh_user=root`, `proxy_id`, `salt_ssh=false`
+|Bootstraps and registers a system over SSH. Requires `UYUNI_SSH_PRIV_KEY`. If the client supports elicitation, a missing activation key can be requested interactively.
+
+|`remove_system`
+|`system_identifier`, `cleanup=true`
+|Removes a system. `cleanup=true` requests forced deletion and cleanup; `false` requests no cleanup.
+
+|`schedule_system_reboot`
+|`system_identifier`
+|Schedules an immediate reboot.
+
+|`cancel_action`
+|`action_id`
+|Cancels the specified scheduled action.
+
+|`create_system_group`
+|`name`, optional `description`
+|Creates a system group.
+
+|`add_systems_to_group`
+|`group_name`, `system_identifiers`
+|Adds the specified systems to a group.
+
+|`remove_systems_from_group`
+|`group_name`, `system_identifiers`
+|Removes the specified systems from a group.
+|===
+
+The `add_system` API can continue processing after the MCP Server request timeout.
+When the tool reports that the addition process has started, check the system list later rather than immediately repeating the call.
+
+== Pagination controls
+
+Tools that can return large result sets support pagination with `limit` and `offset` arguments.
+Paginated responses include a `meta` object that describes the current page and provides `next_offset` when more results are available.
+Pagination limits response size, reduces latency, and lowers AI context usage.

--- a/en/modules/mcp-server/pages/mcp-server-troubleshooting.adoc
+++ b/en/modules/mcp-server/pages/mcp-server-troubleshooting.adoc
@@ -1,0 +1,97 @@
+[[mcp-server-troubleshooting]]
+= Troubleshooting
+:revdate: 2026-07-29
+:page-revdate: {revdate}
+
+This chapter describes common problems that can occur when configuring or operating the {productname} MCP Server and provides guidance for resolving them.
+
+Start troubleshooting with a read-only tool such as `list_systems`.
+Set `UYUNI_MCP_LOG_LEVEL=DEBUG` temporarily when the default log level does not provide enough information.
+Debug logs can contain sensitive operational data; protect and remove them according to your logging policy.
+
+== Startup problems
+
+[cols="2,4", options="header"]
+|===
+|Message or symptom
+|Resolution
+
+|`Missing required environment variables: UYUNI_SERVER`
+|Set `UYUNI_SERVER` in the environment visible to the MCP Server process. For a client-managed container, verify the absolute path supplied to `--env-file`.
+
+|`UYUNI_SERVER must use http or https and include a host`
+|Use a URL such as `https://server.example.com`.
+
+|`UYUNI_SERVER must not include a path`
+|Remove paths such as `/rhn` and use only the server base URL.
+
+|`UYUNI_MCP_TRANSPORT must be either 'stdio' or 'http'`
+|Set the value to exactly `stdio` or `http`.
+
+|The stdio server disconnects immediately
+|Run the configured command in a terminal and inspect stderr. Verify the image tag, environment-file path, `-i` container option, and {productname} URL.
+
+|The HTTP client receives a connection error
+|Verify the bind address, published port, external route, and that the client URL ends in `/mcp`.
+|===
+
+== Authentication and authorization
+
+[cols="2,4", options="header"]
+|===
+|Message or symptom
+|Resolution
+
+|HTTP 401 or 403 during {productname} login
+|For basic authentication, verify `UYUNI_USER`, `UYUNI_PASS`, account status, and permissions. For OAuth, verify issuer, audiences, scopes, username claim, and the matching active {productname} user.
+
+|OAuth discovery or token validation fails
+|Ensure `UYUNI_MCP_PUBLIC_URL` is the externally reachable HTTPS base URL. Confirm that `UYUNI_AUTH_SERVER` exactly matches the token `iss` claim and that its signing-key endpoint is reachable by the MCP Server.
+
+|MCP authentication succeeds but {productname} OIDC login fails
+|Ensure the token includes both `mcp-server-uyuni` and `uyuni-server` audiences, includes `sub`, and contains the configured username claim.
+
+|A read tool is available but a write tool is missing
+|Set `UYUNI_MCP_WRITE_TOOLS_ENABLED=true` and restart the MCP Server. In OAuth mode, obtain a token with both `mcp:read` and `mcp:write`.
+
+|The user can call a tool but the operation is denied
+|Grant only the required {productname} permissions to the user. MCP availability does not override {productname} authorization.
+|===
+
+== Connectivity and certificates
+
+A network error or timeout indicates that the MCP Server could not complete a request to {productname}.
+
+. Resolve `UYUNI_SERVER` from the MCP Server host or container.
+. Verify TCP and TLS connectivity to the configured port.
+. Confirm that proxies and firewalls allow the connection.
+. Verify that the server certificate is valid for the configured hostname and that its CA is trusted.
+. Increase `UYUNI_MCP_TIMEOUT` only after checking server and network health.
+
+Do not use `UYUNI_MCP_SSL_VERIFY=false` as a permanent certificate fix.
+
+== Tool-call problems
+
+[cols="2,4", options="header"]
+|===
+|Message or symptom
+|Resolution
+
+|A system name is not found or resolves ambiguously
+|Call `find_systems_by_name` and pass the numeric `system_id` to the next tool.
+
+|`Invalid system_id ... Provide system_id as a numeric string`
+|The `get_unscheduled_errata` tool does not accept a hostname. Supply the system ID as digits.
+
+|`You need to provide an activation key`
+|The MCP client does not support elicitation. Pass `activation_key` explicitly to `add_system`.
+
+|`UYUNI_SSH_PRIV_KEY environment variable is not set`
+|Set the complete private key with literal `\n` separators in the MCP Server environment and restart the process.
+
+|System addition reports that the process started
+|The bootstrap request exceeded the request timeout but can still be running on {productname}. Check the system list and server logs before retrying.
+
+|An operation returns `Operation cancelled`
+|The elicitation request was declined, cancelled, or not explicitly approved. Review the arguments and invoke the tool again only if the change is intended.
+|===

--- a/l10n-weblate/mcp-server.cfg
+++ b/l10n-weblate/mcp-server.cfg
@@ -1,0 +1,17 @@
+[po4a_langs] cs es ja ko pt_BR zh_CN
+[po4a_paths] l10n-weblate/mcp-server/mcp-server.pot $lang:l10n-weblate/mcp-server/$lang.po
+
+[po4a_alias:adoc] adoc opt:"-M UTF-8 -L UTF-8"
+
+[options] opt:"--porefs=counter"
+
+[type: asciidoc] en/modules/mcp-server/_attributes.adoc $lang:translations/$lang/modules/mcp-server/_attributes.adoc
+[type: asciidoc] en/modules/mcp-server/nav-mcp-server-guide.adoc $lang:translations/$lang/modules/mcp-server/nav-mcp-server-guide.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-client-configuration.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-client-configuration.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-concepts.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-concepts.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-configuration.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-configuration.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-installation.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-installation.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-overview.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-overview.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-security.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-security.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-tools.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-tools.adoc
+[type: asciidoc] en/modules/mcp-server/pages/mcp-server-troubleshooting.adoc $lang:translations/$lang/modules/mcp-server/pages/mcp-server-troubleshooting.adoc


### PR DESCRIPTION
<!--

# Some hints

Adding an entry to the `CHANGELOG.md` file in the toplevel directory if necessary.
When working with the bug fix, Bugzilla eference must be added to the changelog.

Cosmetic changes such as fixing typos do not need log entries (nevertheless it is important to fix typos, etc.)!

Add description, target branches, and related links to the section below.

-->


# Description

This PR adds the Multi-Linux Manager MCP Server book. MCP server is supported for all MLM versions > 5.1.4.

See the rendered HTML draft at: https://cbbayburt.github.io/uyuni-docs/docs/mcp-server/mcp-server-overview.html

For information about the MCP server, see the [README](https://github.com/uyuni-project/mcp-server-uyuni/blob/main/README.md) on GitHub.

Port of: https://github.com/uyuni-project/uyuni-docs/pull/5169
